### PR TITLE
Fix top-level links

### DIFF
--- a/layouts/section/design.html
+++ b/layouts/section/design.html
@@ -13,8 +13,8 @@
 			<div class="span12">
 				<div>
 					<p>
-						The Design section introduces the <a href="/design/overview">goa API Design language</a>.
-						It also covers how to use <a href="/design/swagger"> during design.
+						The Design section introduces the <a href="overview">goa API Design language</a>.
+						It also covers how to use <a href="swagger"> during design.
 					</p>
 					<ul id="list">
 						{{ range .Data.Pages }}

--- a/layouts/section/extend.html
+++ b/layouts/section/extend.html
@@ -15,10 +15,10 @@
 				<div>
 					<p>
 						goa is extensible with plugins both for
-						<a href="extend/generators">code generation</a> and
-						<a href="extend/dsls">new DSL</a>.
+						<a href="generators">code generation</a> and
+						<a href="dsls">new DSL</a>.
 						The section covers how to author new plugins and also covers
-						the <a href="extend/gorma">gorma</a> plugin as a good
+						the <a href="gorma">gorma</a> plugin as a good
 						reference for implementing your own.
 					</p>
 					<ul id="list">

--- a/layouts/section/implement.html
+++ b/layouts/section/implement.html
@@ -15,7 +15,7 @@
 					<p>
 						After design comes implementation. This section describes
 						what's involved in implementing a goa service. The
-						<a href="implement/overview">overview</a> page
+						<a href="overview">overview</a> page
 						presents the various pieces covered in the other pages.
 					</p>
 					<ul id="list">


### PR DESCRIPTION
These are 404ing as they use the wrong path, e.g. http://goa.design/extend/extend/gorma is shown on http://goa.design/extend/
The links on http://goa.design/learn/ are fine.

I use a modified version of golang docs' [linkcheck](https://golang.org/misc/linkcheck/linkcheck.go) to check links on all PRs for docs.rightscale.com, it's pretty quick and catches these types of issues by failing the build. It can also check external links. It's probably overkill for goa.design though...