### PR TITLE
fix links in learn pages

### DIFF
--- a/content/learn/cellar.md
+++ b/content/learn/cellar.md
@@ -9,7 +9,7 @@ framework.
 
 The service implements an API for managing wine bottles. The service is multitenant: bottles are
 created in the context of an account. At this time the database is emulated with an in-memory hash.
-An instance of this example is hosted at http://cellar.goa.design.
+An instance of this example is hosted at `http://cellar.goa.design`.
 
 Using the excellent [httpie client](https://github.com/jkbrzt/httpie):
 

--- a/content/learn/guide.md
+++ b/content/learn/guide.md
@@ -5,7 +5,7 @@ weight = 2
 +++
 
 This guide walks you through writing a complete service in goa. The simple service implements a
-small subset of the [cellar](cellar/) example found in the [github
+small subset of the [cellar](../cellar) example found in the [github
 repository](https://github.com/goadesign/goa-cellar). The service deals with wine bottles, more
 specifically it makes it possible to retrieve pre-existing wine bottle models through simple GET
 requests.


### PR DESCRIPTION
make hosted cellar url unclickable (405 Method Not Allowed)
fix link to cellar from guide