### PR TITLE
Guide to go get recursively and minor typo

### DIFF
--- a/content/learn/guide.md
+++ b/content/learn/guide.md
@@ -10,13 +10,12 @@ repository](https://github.com/goadesign/goa-cellar). The service deals with win
 specifically it makes it possible to retrieve pre-existing wine bottle models through simple GET
 requests.
 
-# Prerequesite
+# Prerequisite
 
 Install `goa` and `goagen`:
 
 ```
-go install github.com/goadesign/goa
-go install github.com/goadesign/goa/goagen
+go get -u github.com/goadesign/goa/...
 ```
 
 # Design


### PR DESCRIPTION
The current guide fails to install goa library and goagen binary on new Go installs.

```
root@ec1fd9887c93:/go# echo $PATH
/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
root@ec1fd9887c93:/go# echo $GOPATH
/go
root@ec1fd9887c93:/go# ls -l $GOPATH/src/
total 0
root@ec1fd9887c93:/go# go install github.com/goadesign/goa
can't load package: package github.com/goadesign/goa: cannot find package "github.com/goadesign/goa" in any of:
        /usr/local/go/src/github.com/goadesign/goa (from $GOROOT)
        /go/src/github.com/goadesign/goa (from $GOPATH)
root@ec1fd9887c93:/go# go install github.com/goadesign/goa/goagen
can't load package: package github.com/goadesign/goa/goagen: cannot find package "github.com/goadesign/goa/goagen" in any of:
        /usr/local/go/src/github.com/goadesign/goa/goagen (from $GOROOT)
        /go/src/github.com/goadesign/goa/goagen (from $GOPATH)
root@ec1fd9887c93:/go# go version
go version go1.6 linux/amd64
```

For a new install, it should be a `go get` and @dlsniper further suggests the single, recursive, command `go get -u github.com/goadesign/goa/...` to fetch the library and install the binaries. Adding the `-u` to ensure all dependencies are updated.

```
root@ec1fd9887c93:/go# ls -l $GOPATH/src/
total 0
root@ec1fd9887c93:/go# which goagen
root@ec1fd9887c93:/go# go get -u github.com/goadesign/goa/...
root@ec1fd9887c93:/go# ls -l $GOPATH/src/
total 12
drwxr-xr-x. 18 root root 4096 Jun 15 23:40 github.com
drwxr-xr-x.  3 root root 4096 Jun 15 23:37 golang.org
drwxr-xr-x.  4 root root 4096 Jun 15 23:40 gopkg.in
root@ec1fd9887c93:/go# which goagen
/go/bin/goagen
```