### PR TITLE
Example update for generator and bug fix in makefile dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@
 
 DEPEND=\
 	github.com/spf13/hugo \
-	github.com/davecheney/godoc2md
+	github.com/davecheney/godoc2md \
+	github.com/goadesign/gorma
 
 all: depend install docs serve
 


### PR DESCRIPTION
Hey guys. When looking into the generator I noticed what I think were a couple of small errors in the example. I have updated it here.
I did the make command locally and served up the changes. The markdown with language definitions wasn't rendering correctly not sure why.
One other small thing I added github.com/goadesign/gorma to the makefile as it seems to be needed. The issue can be reproduced by removing the gorma line from the makefile. It results in the following error

```
could not find package github.com/goadesign/gorma in /Users/craigbrookes/servicesmake: *** [docs] Error 255
```
adding in the dependency solves this problem