### PR TITLE
Tiny fix of url typo in the latest blog post.

### DIFF
--- a/content/blog/003-v1_1_0.ja.md
+++ b/content/blog/003-v1_1_0.ja.md
@@ -64,7 +64,7 @@ Swagger generation can now also be disabled for specific endpoints using the new
 The main fixes include properly setting the collection format on parameters of
 type `Array` (fix from [@fede-bitlogic](https://github.com/fede-bitlogic)) and
 proper generation of the `Any` type (issue initially reported
-by [Peter Dulačka](https://github.com/rootp)).
+by [Peter Dulačka](https://github.com/rootpd)).
 
 ***Pull Requests:***
 
@@ -112,7 +112,7 @@ the `Access-Control-Allow-Origin` response header returned by goa when an origin
 matches the specification.
 
 CORS support was also added for file servers (issue initially reported by
-[Peter Dulačka](https://github.com/rootp)).
+[Peter Dulačka](https://github.com/rootpd)).
 
 ***Pull Requests:***
 

--- a/content/blog/003-v1_1_0.md
+++ b/content/blog/003-v1_1_0.md
@@ -64,7 +64,7 @@ Swagger generation can now also be disabled for specific endpoints using the new
 The main fixes include properly setting the collection format on parameters of
 type `Array` (fix from [@fede-bitlogic](https://github.com/fede-bitlogic)) and
 proper generation of the `Any` type (issue initially reported
-by [Peter Dulačka](https://github.com/rootp)).
+by [Peter Dulačka](https://github.com/rootpd)).
 
 ***Pull Requests:***
 
@@ -112,7 +112,7 @@ the `Access-Control-Allow-Origin` response header returned by goa when an origin
 matches the specification.
 
 CORS support was also added for file servers (issue initially reported by
-[Peter Dulačka](https://github.com/rootp)).
+[Peter Dulačka](https://github.com/rootpd)).
 
 ***Pull Requests:***
 


### PR DESCRIPTION
Found myself in the blogpost surprisingly and the link was pointing to the non-existing target :).