### PR TITLE
design/reference: make it a placeholder for menu

### DIFF
--- a/content/design/reference.ja.md
+++ b/content/design/reference.ja.md
@@ -7,3 +7,5 @@ name = "DSL リファレンス"
 parent = "design"
 url = "/reference/goa/design/apidsl"
 +++
+
+<meta http-equiv="refresh" content="0; url={{< ref "reference/goa/design/apidsl.md" >}}"/>

--- a/content/design/reference.md
+++ b/content/design/reference.md
@@ -7,3 +7,5 @@ name = "DSL Reference"
 parent = "design"
 url = "/reference/goa/design/apidsl"
 +++
+
+<meta http-equiv="refresh" content="0; url={{< ref "reference/goa/design/apidsl.md" >}}"/>


### PR DESCRIPTION
The page doesn't have content, it exists to make an entry in the top
menu but the page can be accessed from other ways, like directly typing
the URL or clicking the next page link present in "design/vendoring"
content page.