### PR TITLE
Fixing relative path for openapi.json

### DIFF
--- a/content/design/overview.md
+++ b/content/design/overview.md
@@ -110,9 +110,9 @@ var _ = Service("calc", func() {
         })
     })
 
-    // Serve the file with relative path ../../gen/http/openapi.json for
+    // Serve the file with relative path ./gen/http/openapi.json for
     // requests sent to /swagger.json.
-    Files("/swagger.json", "../../gen/http/openapi.json")
+    Files("/swagger.json", "./gen/http/openapi.json")
 })
 ```
 

--- a/content/learn/getting-started.md
+++ b/content/learn/getting-started.md
@@ -90,7 +90,7 @@ var _ = Service("calc", func() {
 		})
 	})
 
-	Files("/openapi.json", "../../gen/http/openapi.json")
+	Files("/openapi.json", "./gen/http/openapi.json")
 })
 ```
 
@@ -255,7 +255,7 @@ go build ./cmd/calc && go build ./cmd/calc-cli
 
 ./calc
 [calcapi] 21:35:36 HTTP "Add" mounted on GET /add/{a}/{b}
-[calcapi] 21:35:36 HTTP "../../gen/http/openapi.json" mounted on GET /openapi.json
+[calcapi] 21:35:36 HTTP "./gen/http/openapi.json" mounted on GET /openapi.json
 [calcapi] 21:35:36 serving gRPC method calc.Calc/Add
 [calcapi] 21:35:36 HTTP server listening on "localhost:8000"
 [calcapi] 21:35:36 gRPC server listening on "localhost:8080"


### PR DESCRIPTION
Fixing a wrong relative path in the examples for v3. 

Considering the user will be in the root of source code when running `go build ./cmd/calc` and `./calc`, the relative path for serving openapi.json should be `./gen/http/openapi.json`.