### PR TITLE
Remove remaining english sentence

### DIFF
--- a/content/design/overview.ja.md
+++ b/content/design/overview.ja.md
@@ -377,7 +377,6 @@ gRPC トランスポートでは、プロトコルバッファの [map](https://
 
 * [Header](https://godoc.org/goa.design/goa/dsl#Header) 関数は HTTPヘッダからロードされる値を定義します。
 * [Body](https://godoc.org/goa.design/goa/dsl#Body) 関数はレスポンスボディからロードされる値を定義します。
-  loaded from the response body.
 
 デフォルトでは、結果のアトリビュートは HTTP レスポンスボディにマッピングされます。
 結果の型が基本型、配列、マップの場合、次のような制限が適用されます：


### PR DESCRIPTION
I removed remaining english sentence below.

> Body 関数はレスポンスボディからロードされる値を定義します。 loaded from the response body.

The page is [here](https://goa.design/ja/design/overview/#%E7%B5%90%E6%9E%9C%E3%81%8B%E3%82%89%E3%83%AC%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B9%E3%81%B8%E3%81%AE%E3%83%9E%E3%83%83%E3%83%94%E3%83%B3%E3%82%B0).
