### PR TITLE
Fix a sample to define multiple errors

### DIFF
--- a/content/implement/error_handling.ja.md
+++ b/content/implement/error_handling.ja.md
@@ -81,12 +81,12 @@ var _ = Service("calc", func() {
 var DivByZero = Type("DivByZero", func() {
     Description("DivByZero is the error returned when using value 0 as divisor.")
     Field(1, "message", String, "division by zero leads to infinity.")
-    Field(2, "error_name", String, "Name of the error", func() {
-        // Tell Goa to use the `error_name` field to match the error definition.
+    Field(2, "name", String, "Name of the error", func() {
+        // Tell Goa to use the `name` field to match the error definition.
         Meta("struct:error:name")
     })
 
-    Required("message")
+    Required("message", "name")
 })
 ```
 

--- a/content/implement/error_handling.md
+++ b/content/implement/error_handling.md
@@ -89,12 +89,12 @@ corresponding design definition. The attribute must be identified via the
 var DivByZero = Type("DivByZero", func() {
     Description("DivByZero is the error returned when using value 0 as divisor.")
     Field(1, "message", String, "division by zero leads to infinity.")
-    Field(2, "error_name", String, "Name of the error", func() {
-        // Tell Goa to use the `error_name` field to match the error definition.
+    Field(2, "name", String, "Name of the error", func() {
+        // Tell Goa to use the `name` field to match the error definition.
         Meta("struct:error:name")
     })
 
-    Required("message")
+    Required("message", "name")
 })
 ```
 


### PR DESCRIPTION
I read the [error handling chapter of the Goa manual](https://goa.design/implement/error_handling/) and ran it. I would like to report the following two points that need to be fixed.

## 1. It seems that the tagged attribute must be a required element.

```
$ goa gen calc/design
exit status 1
attribute: attribute "error_name" with 'struct:error:name' in the meta must be required in "DivByZero" type
```

## 2. If `error_name` is specified as a field name, it conflicts with the generated method name.

```
$ go run ./cmd/calc --http-port 8000
# calc/gen/calc
gen/calc/service.go:65:6: type DivByZero has both field and method named ErrorName
```

In this case, the following code is generated:

gen/calc/service.go
```Go
// ErrorName returns "DivByZero".
func (e *DivByZero) ErrorName() string {
	return e.ErrorName
}
```
