### PR TITLE
Define global GITHUB_TOKEN env var

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ name: Publish
 on:
   pull_request:
     types: [ closed ]
+env:
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
 jobs:
   deploy:


### PR DESCRIPTION
to avoid 'Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable'