### PR TITLE
change Add to Multiply to avoid confusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ static/js/pindex.json
 content/reference/
 
 .hugo_build.lock
+
+# intellij IDE config
+.idea

--- a/content/design/overview.it.md
+++ b/content/design/overview.it.md
@@ -27,7 +27,7 @@ specifiche OpenAPI.
 ```go
 var _ = API("calc", func() {
     Title("Calculator Service")
-    Description("A service for adding numbers, a goa teaser")
+    Description("A service for multiplying numbers, a goa teaser")
 
     // Server descrive un singolo processo che ascolta le richieste dai client. Il DSL
     // definisce una serie di servizi che il server ospita, così come tutti i dettagli
@@ -78,7 +78,7 @@ var _ = Service("calc", func() {
     Description("The calc service performs operations on numbers")
 
     // Method descrive un service method (endpoint)
-    Method("add", func() {
+    Method("multiply", func() {
         // Payload descrive il payload del metodo.
         // In questo caso, esso consiste di due campi.
         Payload(func() {
@@ -99,7 +99,7 @@ var _ = Service("calc", func() {
             // Le richieste al servizio in questo caso consistono 
             // in richieste HTT GET. I campi del payload sono
             // codificati come path parameters.
-            GET("/add/{a}/{b}")
+            GET("/multiply/{a}/{b}")
             // Le risposte qui usano uno status HTTP "200 OK".
             // Il risultato è codificato nel body (default).
             Response(StatusOK)

--- a/content/design/overview.ja.md
+++ b/content/design/overview.ja.md
@@ -21,7 +21,7 @@ parent = "design"
 ```go
 var _ = API("calc", func() {
     Title("Calculator Service")
-    Description("A service for adding numbers, a goa teaser")
+    Description("A service for multiplying numbers, a goa teaser")
 
     // Server はクライアントのリクエストを受け付ける単一のプロセスを記述します
     // DSLは、サーバーがホストする一連のサービスとホストの詳細を定義します
@@ -69,7 +69,7 @@ var _ = Service("calc", func() {
     Description("The calc service performs operations on numbers")
 
     // Method はサービスメソッド（エンドポイント）を記述します
-    Method("add", func() {
+    Method("multiply", func() {
         // Payload はメソッドのペイロードを記述します
         // ここでは、ペイロードは2つのフィールドからなるオブジェクトです
         Payload(func() {
@@ -88,7 +88,7 @@ var _ = Service("calc", func() {
         HTTP(func() {
             // サービスへのリクエストは HTTP GET リクエストで構成されています
             // ペイロードはパスパラメータとしてエンコードされます
-            GET("/add/{a}/{b}")
+            GET("/multiply/{a}/{b}")
             // レスポンスは HTTP ステータス "200 OK" を使用します
             // 結果はレスポンスボディにエンコードされます（デフォルト）
             Response(StatusOK)

--- a/content/design/overview.md
+++ b/content/design/overview.md
@@ -25,7 +25,7 @@ used when generating command-line clients and OpenAPI specifications.
 ```go
 var _ = API("calc", func() {
     Title("Calculator Service")
-    Description("A service for adding numbers, a goa teaser")
+    Description("A service for multiplying numbers, a goa teaser")
 
     // Server describes a single process listening for client requests. The DSL
     // defines the set of services that the server hosts as well as hosts details.
@@ -76,7 +76,7 @@ var _ = Service("calc", func() {
     Description("The calc service performs operations on numbers")
 
     // Method describes a service method (endpoint)
-    Method("add", func() {
+    Method("multiply", func() {
         // Payload describes the method payload.
         // Here the payload is an object that consists of two fields.
         Payload(func() {
@@ -96,7 +96,7 @@ var _ = Service("calc", func() {
         HTTP(func() {
             // Requests to the service consist of HTTP GET requests.
             // The payload fields are encoded as path parameters.
-            GET("/add/{a}/{b}")
+            GET("/multiply/{a}/{b}")
             // Responses use a "200 OK" HTTP status.
             // The result is encoded in the response body (default).
             Response(StatusOK)

--- a/content/extend/plugins.it.md
+++ b/content/extend/plugins.it.md
@@ -76,8 +76,8 @@ var _ = Service("calc", func() {
 		cors.Credentials()
 	})
 
-	Method("add", func() {
-		Description("Add adds up the two integer parameters and returns the results.")
+	Method("multiply", func() {
+		Description("Multiply multiplies up the two integer parameters and returns the results.")
 		Payload(func() {
 			Attribute("a", Int, func() {
 				Description("Left operand")
@@ -89,7 +89,7 @@ var _ = Service("calc", func() {
 		})
 		Result(Int)
 		HTTP(func() {
-			GET("/add/{a}/{b}")
+			GET("/multiply/{a}/{b}")
 			Response(StatusOK)
 		})
 	})

--- a/content/extend/plugins.ja.md
+++ b/content/extend/plugins.ja.md
@@ -73,8 +73,8 @@ var _ = Service("calc", func() {
 		cors.Credentials()
 	})
 
-	Method("add", func() {
-		Description("Add adds up the two integer parameters and returns the results.")
+	Method("multiply", func() {
+		Description("Multiply multiplies up the two integer parameters and returns the results.")
 		Payload(func() {
 			Attribute("a", Int, func() {
 				Description("Left operand")
@@ -86,7 +86,7 @@ var _ = Service("calc", func() {
 		})
 		Result(Int)
 		HTTP(func() {
-			GET("/add/{a}/{b}")
+			GET("/multiply/{a}/{b}")
 			Response(StatusOK)
 		})
 	})

--- a/content/extend/plugins.md
+++ b/content/extend/plugins.md
@@ -78,8 +78,8 @@ var _ = Service("calc", func() {
 		cors.Credentials()
 	})
 
-	Method("add", func() {
-		Description("Add adds up the two integer parameters and returns the results.")
+	Method("multiply", func() {
+		Description("Multiply multiplies the two integer parameters and returns the results.")
 		Payload(func() {
 			Attribute("a", Int, func() {
 				Description("Left operand")
@@ -91,7 +91,7 @@ var _ = Service("calc", func() {
 		})
 		Result(Int)
 		HTTP(func() {
-			GET("/add/{a}/{b}")
+			GET("/multiply/{a}/{b}")
 			Response(StatusOK)
 		})
 	})

--- a/content/implement/implementing.ja.md
+++ b/content/implement/implementing.ja.md
@@ -120,14 +120,14 @@ package design
 import . "goa.design/goa/v3/dsl"
 
 var _ = Service("calc", func() {
-    Method("Add", func() {
+    Method("Multiply", func() {
         Payload(func() {
             Attribute("a", Int, "First operand")
             Attribute("b", Int, "Second operand")
         })
         Result(Int)
         HTTP(func() {
-            GET("/add/{a}/{b}")
+            GET("/multiply/{a}/{b}")
         })
         GRPC(func() {})
     })
@@ -148,7 +148,7 @@ Goa は次のようなインターフェースを `gen/calc/service.go` に生�
 
 ```go
 type Service interface {
-    Add(context.Context, *AddPayload) (res int, err error)
+    Multiply(context.Context, *MultiplyPayload) (res int, err error)
 }
 ```
 
@@ -157,7 +157,7 @@ type Service interface {
 ```go
 type svc struct {}
 
-func (s *svc) Add(ctx context.Context, p *calcsvc.AddPayload) (int, error) {
+func (s *svc) Multiply(ctx context.Context, p *calcsvc.MultiplyPayload) (int, error) {
 	return p.A + p.B, nil
 }
 ```
@@ -167,7 +167,7 @@ func (s *svc) Add(ctx context.Context, p *calcsvc.AddPayload) (int, error) {
 ```go
 func NewEndpoints(s Service) *Endpoints {
 	return &Endpoints{
-		Add: NewAddEndpoint(s),
+		Multiply: NewMultiplyEndpoint(s),
 	}
 }
 ```
@@ -213,7 +213,7 @@ HTTP サーバの設定に必要な最後のステップは、生成された `M
 
 ```go
 func Mount(mux goahttp.Muxer, h *Server) {
-	MountAddHandler(mux, h.Add)
+	MountMultiplyHandler(mux, h.Multiply)
 }
 ```
 
@@ -242,7 +242,7 @@ import (
 
 type svc struct{}
 
-func (s *svc) Add(ctx context.Context, p *calc.AddPayload) (int, error) {
+func (s *svc) Multiply(ctx context.Context, p *calc.MultiplyPayload) (int, error) {
 	return p.A + p.B, nil
 }
 
@@ -275,7 +275,7 @@ gRPC サーバの作成は、HTTP サーバと同様のパターンで行いま�
 ```go
 func New(e *calc.Endpoints, uh goagrpc.UnaryHandler) *Server {
 	return &Server{
-		AddH: NewAddHandler(e.Add, uh),
+		MultiplyH: NewMultiplyHandler(e.Multiply, uh),
 	}
 }
 ```
@@ -284,9 +284,9 @@ func New(e *calc.Endpoints, uh goagrpc.UnaryHandler) *Server {
 デフォルトに実装では、デフォルトの gRPC のオプションを使用しています：
 
 ```go
-func NewAddHandler(endpoint goa.Endpoint, h goagrpc.UnaryHandler) goagrpc.UnaryHandler {
+func NewMultiplyHandler(endpoint goa.Endpoint, h goagrpc.UnaryHandler) goagrpc.UnaryHandler {
 	if h == nil {
-		h = goagrpc.NewUnaryHandler(endpoint, DecodeAddRequest, EncodeAddResponse)
+		h = goagrpc.NewUnaryHandler(endpoint, DecodeMultiplyRequest, EncodeMultiplyResponse)
 	}
 	return h
 }
@@ -330,7 +330,7 @@ import (
 
 type svc struct{}
 
-func (s *svc) Add(ctx context.Context, p *calc.AddPayload) (int, error) {
+func (s *svc) Multiply(ctx context.Context, p *calc.MultiplyPayload) (int, error) {
 	return p.A + p.B, nil
 }
 
@@ -361,10 +361,10 @@ func main() {
 `gen/calc/endpoints.go`
 
 ```go
-func NewAddEndpoint(s Service) goa.Endpoint {
+func NewMultiplyEndpoint(s Service) goa.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
-		p := req.(*AddPayload)
-		return s.Add(ctx, p)
+		p := req.(*MultiplyPayload)
+		return s.Multiply(ctx, p)
 	}
 }
 ```
@@ -374,7 +374,7 @@ func NewAddEndpoint(s Service) goa.Endpoint {
 
 ```go
 type Endpoints struct {
-	Add goa.Endpoint
+	Multiply goa.Endpoint
 }
 ```
 
@@ -384,7 +384,7 @@ HTTP (`gen/http/calc/server/server.go`):
 
 ```go
 type Server struct {
-	Add http.Handler
+	Multiply http.Handler
     // ...
 }
 ```
@@ -393,7 +393,7 @@ gRPC (`gen/grpc/calc/server/server.go`):
 
 ```go
 type Server struct {
-	AddH goagrpc.UnaryHandler
+	MultiplyH goagrpc.UnaryHandler
 	// ...
 }
 ```
@@ -404,7 +404,7 @@ type Server struct {
 HTTP (`gen/http/calc/server/server.go`):
 
 ```go
-func NewAddHandler(
+func NewMultiplyHandler(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
 	decoder func(*http.Request) goahttp.Decoder,
@@ -417,7 +417,7 @@ func NewAddHandler(
 gRPC (`gen/grpc/calc/server/server.go`):
 
 ```go
-func NewAddHandler(endpoint goa.Endpoint, h goagrpc.UnaryHandler) goagrpc.UnaryHandler
+func NewMultiplyHandler(endpoint goa.Endpoint, h goagrpc.UnaryHandler) goagrpc.UnaryHandler
 ```
 
 また HTTP では、Goa の HTTP パッケージが提供するデフォルト実装ではなく、独自の実装によって、HTTP エンコーダー、デコーダー、さらには muxer をオーバーライドすることができます。

--- a/content/implement/implementing.md
+++ b/content/implement/implementing.md
@@ -132,14 +132,14 @@ package design
 import . "goa.design/goa/v3/dsl"
 
 var _ = Service("calc", func() {
-    Method("Add", func() {
+    Method("Multiply", func() {
         Payload(func() {
             Attribute("a", Int, "First operand")
             Attribute("b", Int, "Second operand")
         })
         Result(Int)
         HTTP(func() {
-            GET("/add/{a}/{b}")
+            GET("/multiply/{a}/{b}")
         })
         GRPC(func() {})
     })
@@ -160,7 +160,7 @@ Goa generates the following interface in `gen/calc/service.go`:
 
 ```go
 type Service interface {
-    Add(context.Context, *AddPayload) (res int, err error)
+    Multiply(context.Context, *MultiplyPayload) (res int, err error)
 }
 ```
 
@@ -169,7 +169,7 @@ A possible implementation could be:
 ```go
 type svc struct {}
 
-func (s *svc) Add(ctx context.Context, p *calcsvc.AddPayload) (int, error) {
+func (s *svc) Multiply(ctx context.Context, p *calcsvc.MultiplyPayload) (int, error) {
 	return p.A + p.B, nil
 }
 ```
@@ -180,7 +180,7 @@ service endpoints using the function `NewEndpoints` generated in `endpoints.go`:
 ```go
 func NewEndpoints(s Service) *Endpoints {
 	return &Endpoints{
-		Add: NewAddEndpoint(s),
+		Multiply: NewMultiplyEndpoint(s),
 	}
 }
 ```
@@ -235,7 +235,7 @@ generated `Mount` function.
 
 ```go
 func Mount(mux goahttp.Muxer, h *Server) {
-	MountAddHandler(mux, h.Add)
+	MountMultiplyHandler(mux, h.Multiply)
 }
 ```
 
@@ -265,7 +265,7 @@ import (
 
 type svc struct{}
 
-func (s *svc) Add(ctx context.Context, p *calc.AddPayload) (int, error) {
+func (s *svc) Multiply(ctx context.Context, p *calc.MultiplyPayload) (int, error) {
 	return p.A + p.B, nil
 }
 
@@ -301,7 +301,7 @@ server:
 ```go
 func New(e *calc.Endpoints, uh goagrpc.UnaryHandler) *Server {
 	return &Server{
-		AddH: NewAddHandler(e.Add, uh),
+		MultiplyH: NewMultiplyHandler(e.Multiply, uh),
 	}
 }
 ```
@@ -311,9 +311,9 @@ possible to configure gRPC. The default implementation uses the default gRPC
 options:
 
 ```go
-func NewAddHandler(endpoint goa.Endpoint, h goagrpc.UnaryHandler) goagrpc.UnaryHandler {
+func NewMultiplyHandler(endpoint goa.Endpoint, h goagrpc.UnaryHandler) goagrpc.UnaryHandler {
 	if h == nil {
-		h = goagrpc.NewUnaryHandler(endpoint, DecodeAddRequest, EncodeAddResponse)
+		h = goagrpc.NewUnaryHandler(endpoint, DecodeMultiplyRequest, EncodeMultiplyResponse)
 	}
 	return h
 }
@@ -358,7 +358,7 @@ import (
 
 type svc struct{}
 
-func (s *svc) Add(ctx context.Context, p *calc.AddPayload) (int, error) {
+func (s *svc) Multiply(ctx context.Context, p *calc.MultiplyPayload) (int, error) {
 	return p.A + p.B, nil
 }
 
@@ -391,10 +391,10 @@ functions that make it possible to create individual endpoints, for example:
 `gen/calc/endpoints.go`
 
 ```go
-func NewAddEndpoint(s Service) goa.Endpoint {
+func NewMultiplyEndpoint(s Service) goa.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
-		p := req.(*AddPayload)
-		return s.Add(ctx, p)
+		p := req.(*MultiplyPayload)
+		return s.Multiply(ctx, p)
 	}
 }
 ```
@@ -406,7 +406,7 @@ public:
 
 ```go
 type Endpoints struct {
-	Add goa.Endpoint
+	Multiply goa.Endpoint
 }
 ```
 
@@ -417,7 +417,7 @@ HTTP (`gen/http/calc/server/server.go`):
 
 ```go
 type Server struct {
-	Add http.Handler
+	Multiply http.Handler
     // ...
 }
 ```
@@ -426,7 +426,7 @@ gRPC (`gen/grpc/calc/server/server.go`):
 
 ```go
 type Server struct {
-	AddH goagrpc.UnaryHandler
+	MultiplyH goagrpc.UnaryHandler
 	// ...
 }
 ```
@@ -438,7 +438,7 @@ functions which are public and can be called individually:
 HTTP (`gen/http/calc/server/server.go`):
 
 ```go
-func NewAddHandler(
+func NewMultiplyHandler(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
 	decoder func(*http.Request) goahttp.Decoder,
@@ -451,7 +451,7 @@ func NewAddHandler(
 gRPC (`gen/grpc/calc/server/server.go`):
 
 ```go
-func NewAddHandler(endpoint goa.Endpoint, h goagrpc.UnaryHandler) goagrpc.UnaryHandler
+func NewMultiplyHandler(endpoint goa.Endpoint, h goagrpc.UnaryHandler) goagrpc.UnaryHandler
 ```
 
 Also with HTTP one can override the HTTP encoder, decoder or even the muxer by

--- a/content/learn/getting-started.it.md
+++ b/content/learn/getting-started.it.md
@@ -61,7 +61,7 @@ import (
 
 var _ = API("calc", func() {
 	Title("Calculator Service")
-	Description("Service for adding numbers, a Goa teaser")
+	Description("Service for multiplying numbers, a Goa teaser")
     Server("calc", func() {
         Host("localhost", func() {
             URI("http://localhost:8000")
@@ -73,7 +73,7 @@ var _ = API("calc", func() {
 var _ = Service("calc", func() {
 	Description("The calc service performs operations on numbers.")
 
-	Method("add", func() {
+	Method("multiply", func() {
 		Payload(func() {
 			Field(1, "a", Int, "Left operand")
 			Field(2, "b", Int, "Right operand")
@@ -83,7 +83,7 @@ var _ = Service("calc", func() {
 		Result(Int)
 
 		HTTP(func() {
-			GET("/add/{a}/{b}")
+			GET("/multiply/{a}/{b}")
 		})
 
 		GRPC(func() {
@@ -94,8 +94,8 @@ var _ = Service("calc", func() {
 })
 ```
 
-Il design descrive un servizio chiamato `calc`, il quale definisce a sua volta un metodo `add`.
-`add` prende un payload come input che consiste di 2 interi e ritorna un intero a sua volta.
+Il design descrive un servizio chiamato `calc`, il quale definisce a sua volta un metodo `multiply`.
+`multiply` prende un payload come input che consiste di 2 interi e ritorna un intero a sua volta.
 Esso descrive anche i mapping ai livelli di trasporto HTTP e gRPC. Il trasporto
 HTTP usa gli parameters per gli input mentre il gRPC usa il message (non è esplicito,
 ma è il comportamento di default). Sia HTTP che gRPC usano il codice di stato `OK` nelle
@@ -223,14 +223,14 @@ Il comando `goa example` crea i seguenti file:
 │       └── main.go
 ```
 
-`calc.go` contiene una implementazione vuota del metodo `add` descritto dal
+`calc.go` contiene una implementazione vuota del metodo `multiply` descritto dal
 design. L'unica cosa rimasta da fare è scrivere il codice che implementa, 
 compilarlo, testarlo ed eseguirlo su server e client.
 
-Apri il file `calc.go` e implementa il metodo `Add`:
+Apri il file `calc.go` e implementa il metodo `Multiply`:
 
 ```go
-func (s *calcsrvc) Add(ctx context.Context, p *calc.AddPayload) (res int, err error) {
+func (s *calcsrvc) Multiply(ctx context.Context, p *calc.MultiplyPayload) (res int, err error) {
   return p.A + p.B, nil
 }
 ```
@@ -251,21 +251,21 @@ go build ./cmd/calc && go build ./cmd/calc-cli
 # Esegui il server
 
 ./calc
-[calcapi] 21:35:36 HTTP "Add" mounted on GET /add/{a}/{b}
+[calcapi] 21:35:36 HTTP "Multiply" mounted on GET /multiply/{a}/{b}
 [calcapi] 21:35:36 HTTP "./gen/http/openapi.json" mounted on GET /openapi.json
-[calcapi] 21:35:36 serving gRPC method calc.Calc/Add
+[calcapi] 21:35:36 serving gRPC method calc.Calc/Multiply
 [calcapi] 21:35:36 HTTP server listening on "localhost:8000"
 [calcapi] 21:35:36 gRPC server listening on "localhost:8080"
 
 # Esegui il client
 
 # Contatta il server HTTP
-$ ./calc-cli --url="http://localhost:8000" calc add --a 1 --b 2
-3
+$ ./calc-cli --url="http://localhost:8000" calc multiply --a 1 --b 2
+2
 
 # Contatta il server gRPC
-$ ./calc-cli --url="grpc://localhost:8080" calc add --message '{"a": 1, "b": 2}'
-3
+$ ./calc-cli --url="grpc://localhost:8080" calc multiply --message '{"a": 1, "b": 2}'
+2
 ```
 
 ## Riassunto e Prossimi passi

--- a/content/learn/getting-started.ja.md
+++ b/content/learn/getting-started.ja.md
@@ -54,7 +54,7 @@ import (
 
 var _ = API("calc", func() {
 	Title("Calculator Service")
-	Description("Service for adding numbers, a Goa teaser")
+	Description("Service for multiplying numbers, a Goa teaser")
     Server("calc", func() {
         Host("localhost", func() {
             URI("http://localhost:8000")
@@ -66,7 +66,7 @@ var _ = API("calc", func() {
 var _ = Service("calc", func() {
 	Description("The calc service performs operations on numbers.")
 
-	Method("add", func() {
+	Method("multiply", func() {
 		Payload(func() {
 			Field(1, "a", Int, "Left operand")
 			Field(2, "b", Int, "Right operand")
@@ -76,7 +76,7 @@ var _ = Service("calc", func() {
 		Result(Int)
 
 		HTTP(func() {
-			GET("/add/{a}/{b}")
+			GET("/multiply/{a}/{b}")
 		})
 
 		GRPC(func() {
@@ -87,8 +87,8 @@ var _ = Service("calc", func() {
 })
 ```
 
-このデザインは `calc` という名前のサービスを記述していて、ひとつのメソッド `add` が定義されています。
-`add` は2つの整数からなるペイロードを入力として受け取り、ひとつの整数を返します。
+このデザインは `calc` という名前のサービスを記述していて、ひとつのメソッド `multiply` が定義されています。
+`multiply` は2つの整数からなるペイロードを入力として受け取り、ひとつの整数を返します。
 このメソッドは、HTTP と gRPC のどちらのトランスポートの対応についても記述しています。
 HTTP トランスポートは URL パラメータを使用して入力整数を伝送しますが、gRPC トランスポートはメッセージを使用します（これはデフォルトの動作であるため、デザインに明示されていません）。
 HTTP トランスポートと gRPC トランスポートのいずれも、レスポンスにステータスコード `OK` を使用します（これもデフォルトです）。
@@ -204,13 +204,13 @@ goa example calc/design
 │       └── main.go
 ```
 
-`calc.go` はデザインに記述された `add` メソッドのダミー実装を含みます。
+`calc.go` はデザインに記述された `multiply` メソッドのダミー実装を含みます。
 すべきこととして残されているのは、実際の実装を与え、ビルドし、サーバやクライアントを実行することだけです。
 
-`calc.go` ファイルを開き、`Add` メソッドを実装します：
+`calc.go` ファイルを開き、`Multiply` メソッドを実装します：
 
 ```go
-func (s *calcsrvc) Add(ctx context.Context, p *calc.AddPayload) (res int, err error) {
+func (s *calcsrvc) Multiply(ctx context.Context, p *calc.MultiplyPayload) (res int, err error) {
   return p.A + p.B, nil
 }
 ```
@@ -229,21 +229,21 @@ go build ./cmd/calc && go build ./cmd/calc-cli
 # サーバーの実行
 
 ./calc
-[calcapi] 21:35:36 HTTP "Add" mounted on GET /add/{a}/{b}
+[calcapi] 21:35:36 HTTP "Multiply" mounted on GET /multiply/{a}/{b}
 [calcapi] 21:35:36 HTTP "./gen/http/openapi.json" mounted on GET /openapi.json
-[calcapi] 21:35:36 serving gRPC method calc.Calc/Add
+[calcapi] 21:35:36 serving gRPC method calc.Calc/Multiply
 [calcapi] 21:35:36 HTTP server listening on "localhost:8000"
 [calcapi] 21:35:36 gRPC server listening on "localhost:8080"
 
 # クライアントの実行
 
 # HTTP サーバーと交信
-$ ./calc-cli --url="http://localhost:8000" calc add --a 1 --b 2
-3
+$ ./calc-cli --url="http://localhost:8000" calc multiply --a 1 --b 2
+2
 
 # gRPC サーバーと交信
-$ ./calc-cli --url="grpc://localhost:8080" calc add --message '{"a": 1, "b": 2}'
-3
+$ ./calc-cli --url="grpc://localhost:8080" calc multiply --message '{"a": 1, "b": 2}'
+2
 ```
 
 ## まとめと次のステップ

--- a/content/learn/getting-started.md
+++ b/content/learn/getting-started.md
@@ -61,7 +61,7 @@ import (
 
 var _ = API("calc", func() {
 	Title("Calculator Service")
-	Description("Service for adding numbers, a Goa teaser")
+	Description("Service for multiplying numbers, a Goa teaser")
     Server("calc", func() {
         Host("localhost", func() {
             URI("http://localhost:8000")
@@ -73,7 +73,7 @@ var _ = API("calc", func() {
 var _ = Service("calc", func() {
 	Description("The calc service performs operations on numbers.")
 
-	Method("add", func() {
+	Method("multiply", func() {
 		Payload(func() {
 			Field(1, "a", Int, "Left operand")
 			Field(2, "b", Int, "Right operand")
@@ -83,7 +83,7 @@ var _ = Service("calc", func() {
 		Result(Int)
 
 		HTTP(func() {
-			GET("/add/{a}/{b}")
+			GET("/multiply/{a}/{b}")
 		})
 
 		GRPC(func() {
@@ -94,8 +94,8 @@ var _ = Service("calc", func() {
 })
 ```
 
-The design describes a service named `calc` defining a single method `add`.
-`add` takes a payload as input that consists of two integers and returns an
+The design describes a service named `calc` defining a single method `multiply`.
+`multiply` takes a payload as input that consists of two integers and returns an
 integer. The method also describes transport mappings to both HTTP and gRPC. The
 HTTP transport uses URL parameters to carry the input integers while the gRPC
 transport uses a message (not explicitly shown in the design as it is the
@@ -225,14 +225,14 @@ The `goa example` command creates the following files
 │       └── main.go
 ```
 
-`calc.go` contains a dummy implementation of the `add` method described in the
+`calc.go` contains a dummy implementation of the `multiply` method described in the
 design. The only thing left for us to do is to provide the actual
 implementation, build, and run the server and client.
 
-Open the file `calc.go` and implement the `Add` method:
+Open the file `calc.go` and implement the `Multiply` method:
 
 ```go
-func (s *calcsrvc) Add(ctx context.Context, p *calc.AddPayload) (res int, err error) {
+func (s *calcsrvc) Multiply(ctx context.Context, p *calc.MultiplyPayload) (res int, err error) {
   return p.A + p.B, nil
 }
 ```
@@ -254,21 +254,21 @@ go build ./cmd/calc && go build ./cmd/calc-cli
 # Run the server
 
 ./calc
-[calcapi] 21:35:36 HTTP "Add" mounted on GET /add/{a}/{b}
+[calcapi] 21:35:36 HTTP "Multiply" mounted on GET /multiply/{a}/{b}
 [calcapi] 21:35:36 HTTP "./gen/http/openapi.json" mounted on GET /openapi.json
-[calcapi] 21:35:36 serving gRPC method calc.Calc/Add
+[calcapi] 21:35:36 serving gRPC method calc.Calc/Multiply
 [calcapi] 21:35:36 HTTP server listening on "localhost:8000"
 [calcapi] 21:35:36 gRPC server listening on "localhost:8080"
 
 # Run the client
 
 # Contact HTTP server
-$ ./calc-cli --url="http://localhost:8000" calc add --a 1 --b 2
-3
+$ ./calc-cli --url="http://localhost:8000" calc multiply --a 1 --b 2
+2
 
 # Contact gRPC server
-$ ./calc-cli --url="grpc://localhost:8080" calc add --message '{"a": 1, "b": 2}'
-3
+$ ./calc-cli --url="grpc://localhost:8080" calc multiply --message '{"a": 1, "b": 2}'
+2
 ```
 
 ## Summary and Next Steps


### PR DESCRIPTION
The function name `Add` can be quite confusing for someone just starting with the project as it could taken the wrong way. For example:

AddEndpoint represents the endpoint for a method that adds two numbers, but it reads as though it adds a new endpoint to the server.

Altering to do multiplication seems like a word that would cause less confusion. I updated all references to Add/add to Multiply/multiply.

I'm not sure if there is anything in the non-English files that would need additional updating based on this wording change.

Great project! 