### PR TITLE
chore: Change the GoDoc link to v3

### DIFF
--- a/content/blog/002-endpoints.it.md
+++ b/content/blog/002-endpoints.it.md
@@ -240,8 +240,8 @@ the `Metadata` DSL as shown above.
 JWT tokens are usually created by the service and returned to clients so they may use them to
 perform authentication.  Here we are going to use a service account JSON key file so we can create
 JWT tokens client side. The [golang.org/x/oauth2](https://github.com/golang/oauth2) package contains
-the [jws](https://godoc.org/golang.org/x/oauth2/jws) sub-package which provides helper functions for
-encoding valid JWT tokens. It also contains a [google](https://godoc.org/golang.org/x/oauth2/google)
+the [jws](https://pkg.go.dev/golang.org/x/oauth2/jws) sub-package which provides helper functions for
+encoding valid JWT tokens. It also contains a [google](https://pkg.go.dev/golang.org/x/oauth2/google)
 sub-package which contains functions for creating tokens from Google Developers service
 account JSON key file.
 

--- a/content/blog/002-endpoints.ja.md
+++ b/content/blog/002-endpoints.ja.md
@@ -240,8 +240,8 @@ the `Metadata` DSL as shown above.
 JWT tokens are usually created by the service and returned to clients so they may use them to
 perform authentication.  Here we are going to use a service account JSON key file so we can create
 JWT tokens client side. The [golang.org/x/oauth2](https://github.com/golang/oauth2) package contains
-the [jws](https://godoc.org/golang.org/x/oauth2/jws) sub-package which provides helper functions for
-encoding valid JWT tokens. It also contains a [google](https://godoc.org/golang.org/x/oauth2/google)
+the [jws](https://pkg.go.dev/golang.org/x/oauth2/jws) sub-package which provides helper functions for
+encoding valid JWT tokens. It also contains a [google](https://pkg.go.dev/golang.org/x/oauth2/google)
 sub-package which contains functions for creating tokens from Google Developers service
 account JSON key file.
 

--- a/content/blog/002-endpoints.md
+++ b/content/blog/002-endpoints.md
@@ -240,8 +240,8 @@ the `Metadata` DSL as shown above.
 JWT tokens are usually created by the service and returned to clients so they may use them to
 perform authentication.  Here we are going to use a service account JSON key file so we can create
 JWT tokens client side. The [golang.org/x/oauth2](https://github.com/golang/oauth2) package contains
-the [jws](https://godoc.org/golang.org/x/oauth2/jws) sub-package which provides helper functions for
-encoding valid JWT tokens. It also contains a [google](https://godoc.org/golang.org/x/oauth2/google)
+the [jws](https://pkg.go.dev/golang.org/x/oauth2/jws) sub-package which provides helper functions for
+encoding valid JWT tokens. It also contains a [google](https://pkg.go.dev/golang.org/x/oauth2/google)
 sub-package which contains functions for creating tokens from Google Developers service
 account JSON key file.
 

--- a/content/design/handling_errors.it.md
+++ b/content/design/handling_errors.it.md
@@ -20,7 +20,7 @@ il codice generato per ritornare errori dai service moethods.
 ## Design
 
 Il DSL di Goa rende possibile definire errori all'interno dei metodi o globalmente
-ai servizi attraverso l'espressione [Error](https://godoc.org/goa.design/goa/v3/dsl#Error):
+ai servizi attraverso l'espressione [Error](https://pkg.go.dev/goa.design/goa/v3/dsl#Error):
 
 ```go
 var _ = Service("divider", func() {
@@ -46,7 +46,7 @@ var _ = Service("divider", func() {
 ```
 
 In questo esempio sia `DivByZero` che `HasRemainder` usano il tipo di default per gli errori,
-chiamato [ErrorResult](https://godoc.org/goa.design/goa/v3/expr#pkg-variables).
+chiamato [ErrorResult](https://pkg.go.dev/goa.design/goa/v3/expr#pkg-variables).
 Questo tipo ha i seguenti campi:
 
 * `Name` è il nome dell'errore. Il codice generato si prende carico di inizializzare il campo con 
@@ -87,7 +87,7 @@ error response.
 
 ## Progettare le error response
 
-La funzione [Response](https://godoc.org/goa.design/goa/v3/dsl#Response) rende possibile
+La funzione [Response](https://pkg.go.dev/goa.design/goa/v3/dsl#Response) rende possibile
 la definizione di logiche delle risposte HTTP/gRPC associate a un determinato errore.
 
 ```go

--- a/content/design/handling_errors.it.md
+++ b/content/design/handling_errors.it.md
@@ -20,7 +20,7 @@ il codice generato per ritornare errori dai service moethods.
 ## Design
 
 Il DSL di Goa rende possibile definire errori all'interno dei metodi o globalmente
-ai servizi attraverso l'espressione [Error](https://godoc.org/goa.design/goa/dsl#Error):
+ai servizi attraverso l'espressione [Error](https://godoc.org/goa.design/goa/v3/dsl#Error):
 
 ```go
 var _ = Service("divider", func() {
@@ -46,7 +46,7 @@ var _ = Service("divider", func() {
 ```
 
 In questo esempio sia `DivByZero` che `HasRemainder` usano il tipo di default per gli errori,
-chiamato [ErrorResult](https://godoc.org/goa.design/goa/expr#pkg-variables).
+chiamato [ErrorResult](https://godoc.org/goa.design/goa/v3/expr#pkg-variables).
 Questo tipo ha i seguenti campi:
 
 * `Name` è il nome dell'errore. Il codice generato si prende carico di inizializzare il campo con 
@@ -87,7 +87,7 @@ error response.
 
 ## Progettare le error response
 
-La funzione [Response](https://godoc.org/goa.design/goa/dsl#Response) rende possibile
+La funzione [Response](https://godoc.org/goa.design/goa/v3/dsl#Response) rende possibile
 la definizione di logiche delle risposte HTTP/gRPC associate a un determinato errore.
 
 ```go

--- a/content/design/handling_errors.ja.md
+++ b/content/design/handling_errors.ja.md
@@ -15,7 +15,7 @@ Goa はこの記述からコードとドキュメントの両方を生成する�
 
 ## デザイン
 
-Goa DSL では、[Error](https://godoc.org/goa.design/goa/v3/dsl#Error) 式を使用して、メソッドおよびサービス全体でエラー結果を定義できます：
+Goa DSL では、[Error](https://pkg.go.dev/goa.design/goa/v3/dsl#Error) 式を使用して、メソッドおよびサービス全体でエラー結果を定義できます：
 
 ```go
 var _ = Service("divider", func() {
@@ -40,7 +40,7 @@ var _ = Service("divider", func() {
 })
 ```
 この例では、`DivByZero` エラーと `HasRemainder` エラーの両方で、
-デフォルトのエラー型 [ErrorResult](https://godoc.org/goa.design/goa/v3/expr#pkg-variables) が使用されます。 
+デフォルトのエラー型 [ErrorResult](https://pkg.go.dev/goa.design/goa/v3/expr#pkg-variables) が使用されます。 
 この型は、次のフィールドを定義します：
 
 * `Name` はエラーの名前です。 生成されたコードは、レスポンスエンコード中にデザインで定義された名前つきフィールドを初期化します。
@@ -75,7 +75,7 @@ Error("internal_error", func() {
 
 ## レスポンスのデザイン
 
-[Response](https://godoc.org/goa.design/goa/v3/dsl#Response) 関数を使用すると、
+[Response](https://pkg.go.dev/goa.design/goa/v3/dsl#Response) 関数を使用すると、
 特定のエラーに関連付けられた HTTP/gRPC レスポンスを定義できます。
 
 ```go

--- a/content/design/handling_errors.ja.md
+++ b/content/design/handling_errors.ja.md
@@ -15,7 +15,7 @@ Goa はこの記述からコードとドキュメントの両方を生成する�
 
 ## デザイン
 
-Goa DSL では、[Error](https://godoc.org/goa.design/goa/dsl#Error) 式を使用して、メソッドおよびサービス全体でエラー結果を定義できます：
+Goa DSL では、[Error](https://godoc.org/goa.design/goa/v3/dsl#Error) 式を使用して、メソッドおよびサービス全体でエラー結果を定義できます：
 
 ```go
 var _ = Service("divider", func() {
@@ -40,7 +40,7 @@ var _ = Service("divider", func() {
 })
 ```
 この例では、`DivByZero` エラーと `HasRemainder` エラーの両方で、
-デフォルトのエラー型 [ErrorResult](https://godoc.org/goa.design/goa/expr#pkg-variables) が使用されます。 
+デフォルトのエラー型 [ErrorResult](https://godoc.org/goa.design/goa/v3/expr#pkg-variables) が使用されます。 
 この型は、次のフィールドを定義します：
 
 * `Name` はエラーの名前です。 生成されたコードは、レスポンスエンコード中にデザインで定義された名前つきフィールドを初期化します。
@@ -75,7 +75,7 @@ Error("internal_error", func() {
 
 ## レスポンスのデザイン
 
-[Response](https://godoc.org/goa.design/goa/dsl#Response) 関数を使用すると、
+[Response](https://godoc.org/goa.design/goa/v3/dsl#Response) 関数を使用すると、
 特定のエラーに関連付けられた HTTP/gRPC レスポンスを定義できます。
 
 ```go

--- a/content/design/handling_errors.md
+++ b/content/design/handling_errors.md
@@ -19,7 +19,7 @@ the generated code to return errors from service methods.
 ## Design
 
 The Goa DSL makes it possible to define error results on methods and on entire
-services using the [Error](https://godoc.org/goa.design/goa/dsl#Error)
+services using the [Error](https://godoc.org/goa.design/goa/v3/dsl#Error)
 expression:
 
 ```go
@@ -46,7 +46,7 @@ var _ = Service("divider", func() {
 ```
 
 In this example both the `DivByZero` and `HasRemainder` errors use the default
-error type [ErrorResult](https://godoc.org/goa.design/goa/expr#pkg-variables).
+error type [ErrorResult](https://godoc.org/goa.design/goa/v3/expr#pkg-variables).
 This type defines the following fields:
 
 * `Name` is the name of the error. The generated code takes care of initializing
@@ -87,7 +87,7 @@ error response.
 
 ## Designing Responses
 
-The [Response](https://godoc.org/goa.design/goa/dsl#Response) function makes it
+The [Response](https://godoc.org/goa.design/goa/v3/dsl#Response) function makes it
 possible to define the HTTP/gRPC responses associated with a given error.
 
 ```go

--- a/content/design/handling_errors.md
+++ b/content/design/handling_errors.md
@@ -19,7 +19,7 @@ the generated code to return errors from service methods.
 ## Design
 
 The Goa DSL makes it possible to define error results on methods and on entire
-services using the [Error](https://godoc.org/goa.design/goa/v3/dsl#Error)
+services using the [Error](https://pkg.go.dev/goa.design/goa/v3/dsl#Error)
 expression:
 
 ```go
@@ -46,7 +46,7 @@ var _ = Service("divider", func() {
 ```
 
 In this example both the `DivByZero` and `HasRemainder` errors use the default
-error type [ErrorResult](https://godoc.org/goa.design/goa/v3/expr#pkg-variables).
+error type [ErrorResult](https://pkg.go.dev/goa.design/goa/v3/expr#pkg-variables).
 This type defines the following fields:
 
 * `Name` is the name of the error. The generated code takes care of initializing
@@ -87,7 +87,7 @@ error response.
 
 ## Designing Responses
 
-The [Response](https://godoc.org/goa.design/goa/v3/dsl#Response) function makes it
+The [Response](https://pkg.go.dev/goa.design/goa/v3/dsl#Response) function makes it
 possible to define the HTTP/gRPC responses associated with a given error.
 
 ```go

--- a/content/design/overview.it.md
+++ b/content/design/overview.it.md
@@ -9,14 +9,14 @@ parent = "design"
 
 La seguente sezione descrive come usare il DSL goa per descrivere servizi.
 Essi forniscono una panoramica dei concetti chiave. Revisiona le 
-[GoDocs](https://godoc.org/goa.design/goa/v3/dsl) per una reference completa.
+[GoDocs](https://pkg.go.dev/goa.design/goa/v3/dsl) per una reference completa.
 
 ## L'espressione API
 
-L'espressione [API](https://godoc.org/goa.design/goa/v3/dsl#API) è un DSL di 
+L'espressione [API](https://pkg.go.dev/goa.design/goa/v3/dsl#API) è un DSL di 
 primo livello opzionale che lista le proprietà globali di una API come nome,
 descrizione e numero di versione. `API` può definire uno o più
-[Servers](https://godoc.org/goa.design/goa/v3/dsl#Server), esponendo set differenti
+[Servers](https://pkg.go.dev/goa.design/goa/v3/dsl#Server), esponendo set differenti
 di servizi.
 Un singolo servizio può essere esposto da un qualunque numero (o nessun) server.
 Se `Server` è omesso allora un singolo server di default viene automaticamente
@@ -67,7 +67,7 @@ var _ = API("calc", func() {
 
 ## L'espressione Service
 
-La funzione [Service](https://godoc.org/goa.design/goa/v3/dsl#Service) definisce un
+La funzione [Service](https://pkg.go.dev/goa.design/goa/v3/dsl#Service) definisce un
 gruppo di methods. Questo, a sua volta, si mappa con le risorse REST o con una
 [service declaration](https://grpc.io/docs/guides/concepts.html#service-definition)
 in gRPC. Un servizio può definire risposte di errore comuni a tutti i service methods.
@@ -121,14 +121,14 @@ var _ = Service("calc", func() {
 
 ## L'espressione Method
 
-I service methods sono descritti usando la funzione [Method](https://godoc.org/goa.design/goa/v3/dsl#Method).
+I service methods sono descritti usando la funzione [Method](https://pkg.go.dev/goa.design/goa/v3/dsl#Method).
 Tale funzione definisce il payload (input) e il risultato (output). Può anche
 elencare un numero arbitrario di error values. Un error ha un nome e opzionalmente
 un tipo.
 Omettere il payload o il result ha lo stesso effetto che mapparli usando il 
 tipo built-in `Empty`, il quale mappa su un body vuoto in HTTP e al messaggio
 `Empty` in gRPC.
-Omettere un error type ha lo stesso effetto che usare quello di default [ErrorResult](https://godoc.org/goa.design/goa/v3/expr#ErrorResult).
+Omettere un error type ha lo stesso effetto che usare quello di default [ErrorResult](https://pkg.go.dev/goa.design/goa/v3/expr#ErrorResult).
 
 ```go
 Method("divide", func() {
@@ -170,7 +170,7 @@ parameters, eccetera.
 
 ### L'espressione gRPC
 
-La funzione [gRPC](https://godoc.org/goa.design/goa/v3/dsl#GRPC) definisce il
+La funzione [gRPC](https://pkg.go.dev/goa.design/goa/v3/dsl#GRPC) definisce il
 mapping fra payload e risultato a messaggio e metadata gRPC.
 
 ```go
@@ -191,7 +191,7 @@ mapping fra payload e risultato a messaggio e metadata gRPC.
 
 ### L'espressione HTTP
 
-La funzione [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) definisce il 
+La funzione [HTTP](https://pkg.go.dev/goa.design/goa/v3/dsl#HTTP) definisce il 
 mapping fra payload e risultato per tutti i tipi collegati a campi di richieste
 HTTP, ad esempio request path, query string e, ovviamente, il corpo di richiesta
 e risposta. La funzione `HTTP` definisce anche proprietà specifiche per il 
@@ -345,8 +345,8 @@ rappresentazione nei protocolli HTTP e gRPC.
 
 
 **I tipi personalizzati** possono essere definiti in goa usando 
-[Type](https://godoc.org/goa.design/goa/v3/dsl#Type) oppure
-[ResultType](https://godoc.org/goa.design/goa/v3/dsl#ResultType). Un result type è
+[Type](https://pkg.go.dev/goa.design/goa/v3/dsl#Type) oppure
+[ResultType](https://pkg.go.dev/goa.design/goa/v3/dsl#ResultType). Un result type è
 un tipo che definisce anche un set di "viste". Ogni vista elenca gli attributi
 (campi) che devono essere inclusi quando si decodifica un result type usando 
 quella vista.
@@ -359,7 +359,7 @@ Nota che dato che le viste si applicano al solo rendering dei campi usarlo in un
 payload non avrebbe senso: I tipi da mostrare in un payload possono essere usati 
 anche nel result, ma non è vero il viceversa.
 
-Le **Map** possono essere definite con [MapOf](https://godoc.org/goa.design/goa/v3/dsl#MapOf). 
+Le **Map** possono essere definite con [MapOf](https://pkg.go.dev/goa.design/goa/v3/dsl#MapOf). 
 La sintassi è `MapOf(<KeyType>, <ElemType>)` dove `<KeyType>` può essere un tipo primitivo,
 array o tipo personalizzato, mentre `<ElemType>` può anche essere una map. Le Map
 sono reppresentate come Go `map` nel protocollo HTTP e come protocol buffer
@@ -369,9 +369,9 @@ o bytes) come chiavi di una map.
 
 Gli **Array** possono essere definiti in due modi:
 
-* [ArrayOf](https://godoc.org/goa.design/goa/v3/dsl#ArrayOf) che accetta un qualunque tipo
+* [ArrayOf](https://pkg.go.dev/goa.design/goa/v3/dsl#ArrayOf) che accetta un qualunque tipo
   e ritorna un tipo.
-* [CollectionOf](https://godoc.org/goa.design/goa/v3/dsl#CollectionOf) che accetta solamente
+* [CollectionOf](https://pkg.go.dev/goa.design/goa/v3/dsl#CollectionOf) che accetta solamente
   result types e returna un result type.
 
 Il result type ritornato da `CollectionOf` contiene le stesse viste del result 
@@ -385,18 +385,18 @@ a payload e result type che sono transport-indipendent.
 
 ### Payload-to-Request Mapping
 
-La funzione [Payload](https://godoc.org/goa.design/goa/v3/dsl#Payload) descrive
+La funzione [Payload](https://pkg.go.dev/goa.design/goa/v3/dsl#Payload) descrive
 la forma dei dati presi come argomento dai service methods. Le funzioni `HTTP`
 e `GRPC` definiscono come il payload viene costruito a partire da richieste
 in arrivo (server-side) e come costruisce la richiesta nel payload (client-side).
 
 Per quanto riguarda **HTTP**,
 
-* La funzione [Param](https://godoc.org/goa.design/goa/v3/dsl#Param) definisce
+* La funzione [Param](https://pkg.go.dev/goa.design/goa/v3/dsl#Param) definisce
   i valori caricati da paramtetri all'interno di path o query string.
-* La funzione [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) definisce
+* La funzione [Header](https://pkg.go.dev/goa.design/goa/v3/dsl#Header) definisce
   valori caricati dagli header HTTP.
-* La funzione [Body](https://godoc.org/goa.design/goa/v3/dsl#Body) definisce i valori
+* La funzione [Body](https://pkg.go.dev/goa.design/goa/v3/dsl#Body) definisce i valori
   caricati dal corpo della richiesta.
 
 Di default, gli attributi del payload sono mappati al corpo della richiesta HTTP.
@@ -411,9 +411,9 @@ vengono applicate:
 
 Pe rquanto riguarda **gRPC**,
 
-* La funzione [Message](https://godoc.org/goa.design/goa/v3/dsl#Message) definisce
+* La funzione [Message](https://pkg.go.dev/goa.design/goa/v3/dsl#Message) definisce
   i valori caricati dal messaggio gRPC.
-* La funzione [Metadata](https://godoc.org/goa.design/goa/v3/dsl#Metadata) definisce
+* La funzione [Metadata](https://pkg.go.dev/goa.design/goa/v3/dsl#Metadata) definisce
   i valori caricati dai [metadata](https://grpc.io/docs/guides/concepts.html#metadata)
   del messaggio gRPC.
 
@@ -425,16 +425,16 @@ viene applicata:
 
 ### Result-To-Response Mapping
 
-La funzione [Result](https://godoc.org/goa.design/goa/v3/dsl#Result) descrive la forma
+La funzione [Result](https://pkg.go.dev/goa.design/goa/v3/dsl#Result) descrive la forma
 del dato di ritorno di un service method. le funzioni `HTTP` e `GRPC` definiscono
 come la risposta viene costruita (server-side) e come il risultato viene creato
 dalla risposta ricevuta (client-side).
 
 Per quanto riguarda **HTTP**,
 
-* La funzione [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) definisce i valori caricati
+* La funzione [Header](https://pkg.go.dev/goa.design/goa/v3/dsl#Header) definisce i valori caricati
   dagli header HTTP.
-* La funzione [Body](https://godoc.org/goa.design/goa/v3/dsl#Body) definisce i valori caricati
+* La funzione [Body](https://pkg.go.dev/goa.design/goa/v3/dsl#Body) definisce i valori caricati
   dal corpo della risposta.
 
 Di default, gli attributi del result sono mappati al corpo della risposta HTTP.
@@ -446,11 +446,11 @@ vengono applicate:
 
 Per quanto riguarda **gRPC**,
 
-* La funzione [Message](https://godoc.org/goa.design/goa/v3/dsl#Message) definisce i valori caricati
+* La funzione [Message](https://pkg.go.dev/goa.design/goa/v3/dsl#Message) definisce i valori caricati
   nel messaggio gRPC.
-* La funzione [Headers](https://godoc.org/goa.design/goa/v3/dsl#Headers) definisce i valori caricati
+* La funzione [Headers](https://pkg.go.dev/goa.design/goa/v3/dsl#Headers) definisce i valori caricati
   negli header metadata del messaggio gRPC.
-* La funzione [Trailers](https://godoc.org/goa.design/goa/v3/dsl#Trailers) definisce i valori caricati
+* La funzione [Trailers](https://pkg.go.dev/goa.design/goa/v3/dsl#Trailers) definisce i valori caricati
   negli trailer metadata del messaggio gRPC.
 
 Di default, gli attributi del result sono mappati nel messaggio gRPC. Qualora

--- a/content/design/overview.it.md
+++ b/content/design/overview.it.md
@@ -9,14 +9,14 @@ parent = "design"
 
 La seguente sezione descrive come usare il DSL goa per descrivere servizi.
 Essi forniscono una panoramica dei concetti chiave. Revisiona le 
-[GoDocs](https://godoc.org/goa.design/goa/dsl) per una reference completa.
+[GoDocs](https://godoc.org/goa.design/goa/v3/dsl) per una reference completa.
 
 ## L'espressione API
 
-L'espressione [API](https://godoc.org/goa.design/goa/dsl#API) è un DSL di 
+L'espressione [API](https://godoc.org/goa.design/goa/v3/dsl#API) è un DSL di 
 primo livello opzionale che lista le proprietà globali di una API come nome,
 descrizione e numero di versione. `API` può definire uno o più
-[Servers](https://godoc.org/goa.design/goa/dsl#Server), esponendo set differenti
+[Servers](https://godoc.org/goa.design/goa/v3/dsl#Server), esponendo set differenti
 di servizi.
 Un singolo servizio può essere esposto da un qualunque numero (o nessun) server.
 Se `Server` è omesso allora un singolo server di default viene automaticamente
@@ -67,7 +67,7 @@ var _ = API("calc", func() {
 
 ## L'espressione Service
 
-La funzione [Service](https://godoc.org/goa.design/goa/dsl#Service) definisce un
+La funzione [Service](https://godoc.org/goa.design/goa/v3/dsl#Service) definisce un
 gruppo di methods. Questo, a sua volta, si mappa con le risorse REST o con una
 [service declaration](https://grpc.io/docs/guides/concepts.html#service-definition)
 in gRPC. Un servizio può definire risposte di errore comuni a tutti i service methods.
@@ -121,14 +121,14 @@ var _ = Service("calc", func() {
 
 ## L'espressione Method
 
-I service methods sono descritti usando la funzione [Method](https://godoc.org/goa.design/goa/dsl#Method).
+I service methods sono descritti usando la funzione [Method](https://godoc.org/goa.design/goa/v3/dsl#Method).
 Tale funzione definisce il payload (input) e il risultato (output). Può anche
 elencare un numero arbitrario di error values. Un error ha un nome e opzionalmente
 un tipo.
 Omettere il payload o il result ha lo stesso effetto che mapparli usando il 
 tipo built-in `Empty`, il quale mappa su un body vuoto in HTTP e al messaggio
 `Empty` in gRPC.
-Omettere un error type ha lo stesso effetto che usare quello di default [ErrorResult](https://godoc.org/goa.design/goa/expr#ErrorResult).
+Omettere un error type ha lo stesso effetto che usare quello di default [ErrorResult](https://godoc.org/goa.design/goa/v3/expr#ErrorResult).
 
 ```go
 Method("divide", func() {
@@ -170,7 +170,7 @@ parameters, eccetera.
 
 ### L'espressione gRPC
 
-La funzione [gRPC](https://godoc.org/goa.design/goa/dsl#GRPC) definisce il
+La funzione [gRPC](https://godoc.org/goa.design/goa/v3/dsl#GRPC) definisce il
 mapping fra payload e risultato a messaggio e metadata gRPC.
 
 ```go
@@ -191,7 +191,7 @@ mapping fra payload e risultato a messaggio e metadata gRPC.
 
 ### L'espressione HTTP
 
-La funzione [HTTP](https://godoc.org/goa.design/goa/dsl#HTTP) definisce il 
+La funzione [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) definisce il 
 mapping fra payload e risultato per tutti i tipi collegati a campi di richieste
 HTTP, ad esempio request path, query string e, ovviamente, il corpo di richiesta
 e risposta. La funzione `HTTP` definisce anche proprietà specifiche per il 
@@ -345,8 +345,8 @@ rappresentazione nei protocolli HTTP e gRPC.
 
 
 **I tipi personalizzati** possono essere definiti in goa usando 
-[Type](https://godoc.org/goa.design/goa/dsl#Type) oppure
-[ResultType](https://godoc.org/goa.design/goa/dsl#ResultType). Un result type è
+[Type](https://godoc.org/goa.design/goa/v3/dsl#Type) oppure
+[ResultType](https://godoc.org/goa.design/goa/v3/dsl#ResultType). Un result type è
 un tipo che definisce anche un set di "viste". Ogni vista elenca gli attributi
 (campi) che devono essere inclusi quando si decodifica un result type usando 
 quella vista.
@@ -359,7 +359,7 @@ Nota che dato che le viste si applicano al solo rendering dei campi usarlo in un
 payload non avrebbe senso: I tipi da mostrare in un payload possono essere usati 
 anche nel result, ma non è vero il viceversa.
 
-Le **Map** possono essere definite con [MapOf](https://godoc.org/goa.design/goa/dsl#MapOf). 
+Le **Map** possono essere definite con [MapOf](https://godoc.org/goa.design/goa/v3/dsl#MapOf). 
 La sintassi è `MapOf(<KeyType>, <ElemType>)` dove `<KeyType>` può essere un tipo primitivo,
 array o tipo personalizzato, mentre `<ElemType>` può anche essere una map. Le Map
 sono reppresentate come Go `map` nel protocollo HTTP e come protocol buffer
@@ -369,9 +369,9 @@ o bytes) come chiavi di una map.
 
 Gli **Array** possono essere definiti in due modi:
 
-* [ArrayOf](https://godoc.org/goa.design/goa/dsl#ArrayOf) che accetta un qualunque tipo
+* [ArrayOf](https://godoc.org/goa.design/goa/v3/dsl#ArrayOf) che accetta un qualunque tipo
   e ritorna un tipo.
-* [CollectionOf](https://godoc.org/goa/design/goa/dsl#CollectionOf) che accetta solamente
+* [CollectionOf](https://godoc.org/goa.design/goa/v3/dsl#CollectionOf) che accetta solamente
   result types e returna un result type.
 
 Il result type ritornato da `CollectionOf` contiene le stesse viste del result 
@@ -385,18 +385,18 @@ a payload e result type che sono transport-indipendent.
 
 ### Payload-to-Request Mapping
 
-La funzione [Payload](https://godoc.org/goa.design/goa/dsl#Payload) descrive
+La funzione [Payload](https://godoc.org/goa.design/goa/v3/dsl#Payload) descrive
 la forma dei dati presi come argomento dai service methods. Le funzioni `HTTP`
 e `GRPC` definiscono come il payload viene costruito a partire da richieste
 in arrivo (server-side) e come costruisce la richiesta nel payload (client-side).
 
 Per quanto riguarda **HTTP**,
 
-* La funzione [Param](https://godoc.org/goa.design/goa/dsl#Param) definisce
+* La funzione [Param](https://godoc.org/goa.design/goa/v3/dsl#Param) definisce
   i valori caricati da paramtetri all'interno di path o query string.
-* La funzione [Header](https://godoc.org/goa.design/goa/dsl#Header) definisce
+* La funzione [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) definisce
   valori caricati dagli header HTTP.
-* La funzione [Body](https://godoc.org/goa.design/goa/dsl#Body) definisce i valori
+* La funzione [Body](https://godoc.org/goa.design/goa/v3/dsl#Body) definisce i valori
   caricati dal corpo della richiesta.
 
 Di default, gli attributi del payload sono mappati al corpo della richiesta HTTP.
@@ -411,9 +411,9 @@ vengono applicate:
 
 Pe rquanto riguarda **gRPC**,
 
-* La funzione [Message](https://godoc.org/goa.design/goa/dsl#Message) definisce
+* La funzione [Message](https://godoc.org/goa.design/goa/v3/dsl#Message) definisce
   i valori caricati dal messaggio gRPC.
-* La funzione [Metadata](https://godoc.org/goa.design/goa/dsl#Metadata) definisce
+* La funzione [Metadata](https://godoc.org/goa.design/goa/v3/dsl#Metadata) definisce
   i valori caricati dai [metadata](https://grpc.io/docs/guides/concepts.html#metadata)
   del messaggio gRPC.
 
@@ -425,16 +425,16 @@ viene applicata:
 
 ### Result-To-Response Mapping
 
-La funzione [Result](https://godoc.org/goa.design/goa/dsl#Result) descrive la forma
+La funzione [Result](https://godoc.org/goa.design/goa/v3/dsl#Result) descrive la forma
 del dato di ritorno di un service method. le funzioni `HTTP` e `GRPC` definiscono
 come la risposta viene costruita (server-side) e come il risultato viene creato
 dalla risposta ricevuta (client-side).
 
 Per quanto riguarda **HTTP**,
 
-* La funzione [Header](https://godoc.org/goa.design/goa/dsl#Header) definisce i valori caricati
+* La funzione [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) definisce i valori caricati
   dagli header HTTP.
-* La funzione [Body](https://godoc.org/goa.design/goa/dsl#Body) definisce i valori caricati
+* La funzione [Body](https://godoc.org/goa.design/goa/v3/dsl#Body) definisce i valori caricati
   dal corpo della risposta.
 
 Di default, gli attributi del result sono mappati al corpo della risposta HTTP.
@@ -446,11 +446,11 @@ vengono applicate:
 
 Per quanto riguarda **gRPC**,
 
-* La funzione [Message](https://godoc.org/goa.design/goa/dsl#Message) definisce i valori caricati
+* La funzione [Message](https://godoc.org/goa.design/goa/v3/dsl#Message) definisce i valori caricati
   nel messaggio gRPC.
-* La funzione [Headers](https://godoc.org/goa.design/goa/dsl#Headers) definisce i valori caricati
+* La funzione [Headers](https://godoc.org/goa.design/goa/v3/dsl#Headers) definisce i valori caricati
   negli header metadata del messaggio gRPC.
-* La funzione [Trailers](https://godoc.org/goa.design/goa/dsl#Trailers) definisce i valori caricati
+* La funzione [Trailers](https://godoc.org/goa.design/goa/v3/dsl#Trailers) definisce i valori caricati
   negli trailer metadata del messaggio gRPC.
 
 Di default, gli attributi del result sono mappati nel messaggio gRPC. Qualora

--- a/content/design/overview.ja.md
+++ b/content/design/overview.ja.md
@@ -8,12 +8,12 @@ parent = "design"
 +++
 
 以下のセクションでは、goa DSL を使用してサービスを記述する方法について説明し、キーコンセプトの概要を説明します。
-完全なリファレンスは [GoDocs](https://godoc.org/goa.design/goa/dsl) を参照してください。
+完全なリファレンスは [GoDocs](https://godoc.org/goa.design/goa/v3/dsl) を参照してください。
 
 ## API の表現
 
-[API](https://godoc.org/goa.design/goa/dsl#API) 関数は、省略可能なトップレベルの DSL で、名前や説明、バージョン番号のような API の大域のプロパティを列挙します。
-`API` は、異なるサービスセットを公開する可能性がある1つ以上の[サーバー](https://godoc.org/goa.design/goa/dsl#Server)を定義できます。
+[API](https://godoc.org/goa.design/goa/v3/dsl#API) 関数は、省略可能なトップレベルの DSL で、名前や説明、バージョン番号のような API の大域のプロパティを列挙します。
+`API` は、異なるサービスセットを公開する可能性がある1つ以上の[サーバー](https://godoc.org/goa.design/goa/v3/dsl#Server)を定義できます。
 単一のサービスは、任意の番号（または番号なし）のサーバーによって公開されるでしょう。
 もし `Server` が省略されていれば、デザインで定義される全てのサービスを公開する単一のサーバーが自動的に定義されます。
 `Server` の表現は、コマンドライン クライアントや OpenAPI の仕様を生成するときに使用されます。
@@ -59,7 +59,7 @@ var _ = API("calc", func() {
 
 ## Service の表現
 
-[Service](https://godoc.org/goa.design/goa/dsl#Service) 関数はメソッドのグループを定義します。
+[Service](https://godoc.org/goa.design/goa/v3/dsl#Service) 関数はメソッドのグループを定義します。
 これは、REST のリソースか、gRPC の [サービス宣言](https://grpc.io/docs/guides/concepts.html#service-definition) に対応します。 
 サービスはすべてのサービスメソッドに共通のエラーレスポンスを定義することができます。
 エラー定義に関する追加情報については、[エラー処理](/design/handling_errors/) を参照してください。
@@ -109,13 +109,13 @@ var _ = Service("calc", func() {
 
 ## Method の表現
 
-サービスメソッドは [Method](https://godoc.org/goa.design/goa/dsl#Method) を用いて記述されます。
+サービスメソッドは [Method](https://godoc.org/goa.design/goa/v3/dsl#Method) を用いて記述されます。
 この関数はメソッドペイロード（入力）と結果（出力）の型を定義します。
 任意の数のエラーレスポンスを列挙することもあります。
 エラーレスポンスは名前と型があります。型はオプションです。
 ペイロードまたは結果の型を省略すると、組み込み型 `Empty` を使用した場合と同じ効果があります。
 `Empty` は HTTP では空のボディ、gRPC では `Empty` メッセージに対応します。
-エラータイプを省略すると、デフォルトのエラータイプ [ErrorResult](https://godoc.org/goa.design/goa/expr#ErrorResult) を使用した場合と同じ効果があります。
+エラータイプを省略すると、デフォルトのエラータイプ [ErrorResult](https://godoc.org/goa.design/goa/v3/expr#ErrorResult) を使用した場合と同じ効果があります。
 
 ```go
 Method("divide", func() {
@@ -151,7 +151,7 @@ Method("divide", func() {
 ### gRPC の表現
 
 
-[gRPC](https://godoc.org/goa.design/goa/dsl#GRPC) 関数は、ペイロードや結果型のアトリビュートから gRPC メッセージとメタデータへのマッピングを定義します。 
+[gRPC](https://godoc.org/goa.design/goa/v3/dsl#GRPC) 関数は、ペイロードや結果型のアトリビュートから gRPC メッセージとメタデータへのマッピングを定義します。 
 
 ```go
     Method("update", func() {
@@ -171,7 +171,7 @@ Method("divide", func() {
 
 ### HTTP の表現
 
-[HTTP](https://godoc.org/goa.design/goa/dsl#HTTP) 関数は、
+[HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) 関数は、
 ペイロードや結果型のアトリビュートから HTTP リクエストパスとクエリー文字列の値、
 および HTTP リクエストやレスポンスボディへのマッピングを定義します。
 `HTTP` 関数は、リクエストパスやレスポンス HTTP ステータスコードなど、他の HTTP 固有のプロパティも定義します。
@@ -304,8 +304,8 @@ Goaは、プリミティブ型、配列、マップ、およびオブジェク�
  \* - 非対応
 
 
-**ユーザー定義型**は [Type](https://godoc.org/goa.design/goa/dsl#Type) または
-[ResultType](https://godoc.org/goa.design/goa/dsl#ResultType) を使用して Goa で定義できます。
+**ユーザー定義型**は [Type](https://godoc.org/goa.design/goa/v3/dsl#Type) または
+[ResultType](https://godoc.org/goa.design/goa/v3/dsl#ResultType) を使用して Goa で定義できます。
 ResultType は （Typeとは違って）ビューのセットも定義する型です。
 各ビューは、結果型のインスタンスを Marshal するときにレンダリングされるアトリビュート（フィールド）を列挙します。
 たとえば、HTTP API は、エンティティのコレクションを列挙するエンドポイントと、特定のエンティティを取得するエンドポイントを定義できます。
@@ -314,7 +314,7 @@ ResultType は （Typeとは違って）ビューのセットも定義する型�
 ビューは結果型のレンダリングにのみ適用されるため、メソッドペイロードでは意味がないことに注意してください。
 型はペイロードと結果の両方で使用できますが、ResultType は結果でのみ使用する必要があります。
 
-**マップ** は [MapOf](https://godoc.org/goa.design/goa/dsl#MapOf) で定義できます. 
+**マップ** は [MapOf](https://godoc.org/goa.design/goa/v3/dsl#MapOf) で定義できます. 
 構文は `MapOf(<KeyType>, <ElemType>)` の形式です。ここで、 `<KeyType>` は
 基本型、配列、ユーザー型で、`<ElemType>` は基本型、配列、ユーザー型もしくはマップが利用できます。
 マップ型は HTTP トランスポートでは、Go の `map` として、
@@ -324,8 +324,8 @@ gRPC トランスポートでは、プロトコルバッファの [map](https://
 
 
 **配列** は2つの方法で定義できます：
-* 任意の型を受け付け、型を返す [ArrayOf](https://godoc.org/goa.design/goa/dsl#ArrayOf)
-* 結果型のみを受け付け、結果型を返す [CollectionOf](https://godoc.org/goa/design/goa/dsl#CollectionOf)
+* 任意の型を受け付け、型を返す [ArrayOf](https://godoc.org/goa.design/goa/v3/dsl#ArrayOf)
+* 結果型のみを受け付け、結果型を返す [CollectionOf](https://godoc.org/goa.design/goa/v3/dsl#CollectionOf)
 
 `CollectionOf` によって返される結果型には、引数として指定された結果型とおなじビューが含まれます。
 各ビューは、各要素が対応する要素のビューによって投影された配列を単純にレンダリングします。
@@ -338,15 +338,15 @@ gRPC トランスポートでは、プロトコルバッファの [map](https://
 ### ペイロードからリクエストへのマッピング
 
 
-[Payload](https://godoc.org/goa.design/goa/dsl#Payload) 関数は、
+[Payload](https://godoc.org/goa.design/goa/v3/dsl#Payload) 関数は、
 サービスメソッドの引数として指定されたデータの形状を記述します。
 `HTTP` および `GRPC` 関数は、受信リクエストからペイロードを構築する方法（サーバー側）と、ペイロードからリクエストを構築する方法（クライアント側）を定義します。
 
 **HTTP** の場合：
 
-* [Param](https://godoc.org/goa.design/goa/dsl#Param) 関数はパスまたはクエリ文字列パラメータからロードされる値を定義します。
-* [Header](https://godoc.org/goa.design/goa/dsl#Header) 関数は HTTP ヘッダからロードされる値を定義します。
-* [Body](https://godoc.org/goa.design/goa/dsl#Body) 関数はリクエストボディからロードされる値を定義します。
+* [Param](https://godoc.org/goa.design/goa/v3/dsl#Param) 関数はパスまたはクエリ文字列パラメータからロードされる値を定義します。
+* [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) 関数は HTTP ヘッダからロードされる値を定義します。
+* [Body](https://godoc.org/goa.design/goa/v3/dsl#Body) 関数はリクエストボディからロードされる値を定義します。
 
 デフォルトでは、ペイロードアトリビュートは HTTP リクエストボディにマップされます。
 ペイロードの型が基本型、配列型、マップ型のとき、次のような制限が適用されます：
@@ -358,8 +358,8 @@ gRPC トランスポートでは、プロトコルバッファの [map](https://
 
 **gRPC** の場合：
 
-* [Message](https://godoc.org/goa.design/goa/dsl#Message) 関数は gRPC メッセージからロードされた値を定義します。
-* [Metadata](https://godoc.org/goa.design/goa/dsl#Metadata) 関数は gRPC リクエスト[メタデータ](https://grpc.io/docs/guides/concepts.html#metadata)からロードされた値を定義します。
+* [Message](https://godoc.org/goa.design/goa/v3/dsl#Message) 関数は gRPC メッセージからロードされた値を定義します。
+* [Metadata](https://godoc.org/goa.design/goa/v3/dsl#Metadata) 関数は gRPC リクエスト[メタデータ](https://grpc.io/docs/guides/concepts.html#metadata)からロードされた値を定義します。
 
 デフォルトでは、ペイロードアトリビュートは gRPC メッセージにマッピングされます。 
 ペイロードの型が基本型、配列、マップの場合、次のような制限が適用されます：
@@ -368,15 +368,15 @@ gRPC トランスポートでは、プロトコルバッファの [map](https://
 
 ### 結果からレスポンスへのマッピング
 
-[Result](https://godoc.org/goa.design/goa/dsl#Result) 関数は
+[Result](https://godoc.org/goa.design/goa/v3/dsl#Result) 関数は
 サービスメソッドの返値となるデータの形状を記述します。
  `HTTP` および `GRPC` 関数は、結果型からのレスポンスの構築方法（サーバー側）と、
  レスポンスからから結果の構築方法（クライアント側）を定義します。
 
 **HTTP** の場合：
 
-* [Header](https://godoc.org/goa.design/goa/dsl#Header) 関数は HTTPヘッダからロードされる値を定義します。
-* [Body](https://godoc.org/goa.design/goa/dsl#Body) 関数はレスポンスボディからロードされる値を定義します。
+* [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) 関数は HTTPヘッダからロードされる値を定義します。
+* [Body](https://godoc.org/goa.design/goa/v3/dsl#Body) 関数はレスポンスボディからロードされる値を定義します。
 
 デフォルトでは、結果のアトリビュートは HTTP レスポンスボディにマッピングされます。
 結果の型が基本型、配列、マップの場合、次のような制限が適用されます：
@@ -386,9 +386,9 @@ gRPC トランスポートでは、プロトコルバッファの [map](https://
 
 **gRPC** の場合：
 
-* [Message](https://godoc.org/goa.design/goa/dsl#Message) 関数は gRPC メッセージからロードされる値を定義します。
-* [Headers](https://godoc.org/goa.design/goa/dsl#Headers) 関数は gRPC ヘッダーメタデータからロードされる値を定義します。
-* [Trailers](https://godoc.org/goa.design/goa/dsl#Trailers) 関数は gRPC トレーラーメタデータからロードされる値を定義します。
+* [Message](https://godoc.org/goa.design/goa/v3/dsl#Message) 関数は gRPC メッセージからロードされる値を定義します。
+* [Headers](https://godoc.org/goa.design/goa/v3/dsl#Headers) 関数は gRPC ヘッダーメタデータからロードされる値を定義します。
+* [Trailers](https://godoc.org/goa.design/goa/v3/dsl#Trailers) 関数は gRPC トレーラーメタデータからロードされる値を定義します。
 
 デフォルトでは、結果のアトリビュートは gRPC メッセージにマッピングされます。 
 結果の型が基本型、配列、マップの場合、次のような制限が適用されます：

--- a/content/design/overview.ja.md
+++ b/content/design/overview.ja.md
@@ -8,12 +8,12 @@ parent = "design"
 +++
 
 以下のセクションでは、goa DSL を使用してサービスを記述する方法について説明し、キーコンセプトの概要を説明します。
-完全なリファレンスは [GoDocs](https://godoc.org/goa.design/goa/v3/dsl) を参照してください。
+完全なリファレンスは [GoDocs](https://pkg.go.dev/goa.design/goa/v3/dsl) を参照してください。
 
 ## API の表現
 
-[API](https://godoc.org/goa.design/goa/v3/dsl#API) 関数は、省略可能なトップレベルの DSL で、名前や説明、バージョン番号のような API の大域のプロパティを列挙します。
-`API` は、異なるサービスセットを公開する可能性がある1つ以上の[サーバー](https://godoc.org/goa.design/goa/v3/dsl#Server)を定義できます。
+[API](https://pkg.go.dev/goa.design/goa/v3/dsl#API) 関数は、省略可能なトップレベルの DSL で、名前や説明、バージョン番号のような API の大域のプロパティを列挙します。
+`API` は、異なるサービスセットを公開する可能性がある1つ以上の[サーバー](https://pkg.go.dev/goa.design/goa/v3/dsl#Server)を定義できます。
 単一のサービスは、任意の番号（または番号なし）のサーバーによって公開されるでしょう。
 もし `Server` が省略されていれば、デザインで定義される全てのサービスを公開する単一のサーバーが自動的に定義されます。
 `Server` の表現は、コマンドライン クライアントや OpenAPI の仕様を生成するときに使用されます。
@@ -59,7 +59,7 @@ var _ = API("calc", func() {
 
 ## Service の表現
 
-[Service](https://godoc.org/goa.design/goa/v3/dsl#Service) 関数はメソッドのグループを定義します。
+[Service](https://pkg.go.dev/goa.design/goa/v3/dsl#Service) 関数はメソッドのグループを定義します。
 これは、REST のリソースか、gRPC の [サービス宣言](https://grpc.io/docs/guides/concepts.html#service-definition) に対応します。 
 サービスはすべてのサービスメソッドに共通のエラーレスポンスを定義することができます。
 エラー定義に関する追加情報については、[エラー処理](/design/handling_errors/) を参照してください。
@@ -109,13 +109,13 @@ var _ = Service("calc", func() {
 
 ## Method の表現
 
-サービスメソッドは [Method](https://godoc.org/goa.design/goa/v3/dsl#Method) を用いて記述されます。
+サービスメソッドは [Method](https://pkg.go.dev/goa.design/goa/v3/dsl#Method) を用いて記述されます。
 この関数はメソッドペイロード（入力）と結果（出力）の型を定義します。
 任意の数のエラーレスポンスを列挙することもあります。
 エラーレスポンスは名前と型があります。型はオプションです。
 ペイロードまたは結果の型を省略すると、組み込み型 `Empty` を使用した場合と同じ効果があります。
 `Empty` は HTTP では空のボディ、gRPC では `Empty` メッセージに対応します。
-エラータイプを省略すると、デフォルトのエラータイプ [ErrorResult](https://godoc.org/goa.design/goa/v3/expr#ErrorResult) を使用した場合と同じ効果があります。
+エラータイプを省略すると、デフォルトのエラータイプ [ErrorResult](https://pkg.go.dev/goa.design/goa/v3/expr#ErrorResult) を使用した場合と同じ効果があります。
 
 ```go
 Method("divide", func() {
@@ -151,7 +151,7 @@ Method("divide", func() {
 ### gRPC の表現
 
 
-[gRPC](https://godoc.org/goa.design/goa/v3/dsl#GRPC) 関数は、ペイロードや結果型のアトリビュートから gRPC メッセージとメタデータへのマッピングを定義します。 
+[gRPC](https://pkg.go.dev/goa.design/goa/v3/dsl#GRPC) 関数は、ペイロードや結果型のアトリビュートから gRPC メッセージとメタデータへのマッピングを定義します。 
 
 ```go
     Method("update", func() {
@@ -171,7 +171,7 @@ Method("divide", func() {
 
 ### HTTP の表現
 
-[HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) 関数は、
+[HTTP](https://pkg.go.dev/goa.design/goa/v3/dsl#HTTP) 関数は、
 ペイロードや結果型のアトリビュートから HTTP リクエストパスとクエリー文字列の値、
 および HTTP リクエストやレスポンスボディへのマッピングを定義します。
 `HTTP` 関数は、リクエストパスやレスポンス HTTP ステータスコードなど、他の HTTP 固有のプロパティも定義します。
@@ -304,8 +304,8 @@ Goaは、プリミティブ型、配列、マップ、およびオブジェク�
  \* - 非対応
 
 
-**ユーザー定義型**は [Type](https://godoc.org/goa.design/goa/v3/dsl#Type) または
-[ResultType](https://godoc.org/goa.design/goa/v3/dsl#ResultType) を使用して Goa で定義できます。
+**ユーザー定義型**は [Type](https://pkg.go.dev/goa.design/goa/v3/dsl#Type) または
+[ResultType](https://pkg.go.dev/goa.design/goa/v3/dsl#ResultType) を使用して Goa で定義できます。
 ResultType は （Typeとは違って）ビューのセットも定義する型です。
 各ビューは、結果型のインスタンスを Marshal するときにレンダリングされるアトリビュート（フィールド）を列挙します。
 たとえば、HTTP API は、エンティティのコレクションを列挙するエンドポイントと、特定のエンティティを取得するエンドポイントを定義できます。
@@ -314,7 +314,7 @@ ResultType は （Typeとは違って）ビューのセットも定義する型�
 ビューは結果型のレンダリングにのみ適用されるため、メソッドペイロードでは意味がないことに注意してください。
 型はペイロードと結果の両方で使用できますが、ResultType は結果でのみ使用する必要があります。
 
-**マップ** は [MapOf](https://godoc.org/goa.design/goa/v3/dsl#MapOf) で定義できます. 
+**マップ** は [MapOf](https://pkg.go.dev/goa.design/goa/v3/dsl#MapOf) で定義できます. 
 構文は `MapOf(<KeyType>, <ElemType>)` の形式です。ここで、 `<KeyType>` は
 基本型、配列、ユーザー型で、`<ElemType>` は基本型、配列、ユーザー型もしくはマップが利用できます。
 マップ型は HTTP トランスポートでは、Go の `map` として、
@@ -324,8 +324,8 @@ gRPC トランスポートでは、プロトコルバッファの [map](https://
 
 
 **配列** は2つの方法で定義できます：
-* 任意の型を受け付け、型を返す [ArrayOf](https://godoc.org/goa.design/goa/v3/dsl#ArrayOf)
-* 結果型のみを受け付け、結果型を返す [CollectionOf](https://godoc.org/goa.design/goa/v3/dsl#CollectionOf)
+* 任意の型を受け付け、型を返す [ArrayOf](https://pkg.go.dev/goa.design/goa/v3/dsl#ArrayOf)
+* 結果型のみを受け付け、結果型を返す [CollectionOf](https://pkg.go.dev/goa.design/goa/v3/dsl#CollectionOf)
 
 `CollectionOf` によって返される結果型には、引数として指定された結果型とおなじビューが含まれます。
 各ビューは、各要素が対応する要素のビューによって投影された配列を単純にレンダリングします。
@@ -338,15 +338,15 @@ gRPC トランスポートでは、プロトコルバッファの [map](https://
 ### ペイロードからリクエストへのマッピング
 
 
-[Payload](https://godoc.org/goa.design/goa/v3/dsl#Payload) 関数は、
+[Payload](https://pkg.go.dev/goa.design/goa/v3/dsl#Payload) 関数は、
 サービスメソッドの引数として指定されたデータの形状を記述します。
 `HTTP` および `GRPC` 関数は、受信リクエストからペイロードを構築する方法（サーバー側）と、ペイロードからリクエストを構築する方法（クライアント側）を定義します。
 
 **HTTP** の場合：
 
-* [Param](https://godoc.org/goa.design/goa/v3/dsl#Param) 関数はパスまたはクエリ文字列パラメータからロードされる値を定義します。
-* [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) 関数は HTTP ヘッダからロードされる値を定義します。
-* [Body](https://godoc.org/goa.design/goa/v3/dsl#Body) 関数はリクエストボディからロードされる値を定義します。
+* [Param](https://pkg.go.dev/goa.design/goa/v3/dsl#Param) 関数はパスまたはクエリ文字列パラメータからロードされる値を定義します。
+* [Header](https://pkg.go.dev/goa.design/goa/v3/dsl#Header) 関数は HTTP ヘッダからロードされる値を定義します。
+* [Body](https://pkg.go.dev/goa.design/goa/v3/dsl#Body) 関数はリクエストボディからロードされる値を定義します。
 
 デフォルトでは、ペイロードアトリビュートは HTTP リクエストボディにマップされます。
 ペイロードの型が基本型、配列型、マップ型のとき、次のような制限が適用されます：
@@ -358,8 +358,8 @@ gRPC トランスポートでは、プロトコルバッファの [map](https://
 
 **gRPC** の場合：
 
-* [Message](https://godoc.org/goa.design/goa/v3/dsl#Message) 関数は gRPC メッセージからロードされた値を定義します。
-* [Metadata](https://godoc.org/goa.design/goa/v3/dsl#Metadata) 関数は gRPC リクエスト[メタデータ](https://grpc.io/docs/guides/concepts.html#metadata)からロードされた値を定義します。
+* [Message](https://pkg.go.dev/goa.design/goa/v3/dsl#Message) 関数は gRPC メッセージからロードされた値を定義します。
+* [Metadata](https://pkg.go.dev/goa.design/goa/v3/dsl#Metadata) 関数は gRPC リクエスト[メタデータ](https://grpc.io/docs/guides/concepts.html#metadata)からロードされた値を定義します。
 
 デフォルトでは、ペイロードアトリビュートは gRPC メッセージにマッピングされます。 
 ペイロードの型が基本型、配列、マップの場合、次のような制限が適用されます：
@@ -368,15 +368,15 @@ gRPC トランスポートでは、プロトコルバッファの [map](https://
 
 ### 結果からレスポンスへのマッピング
 
-[Result](https://godoc.org/goa.design/goa/v3/dsl#Result) 関数は
+[Result](https://pkg.go.dev/goa.design/goa/v3/dsl#Result) 関数は
 サービスメソッドの返値となるデータの形状を記述します。
  `HTTP` および `GRPC` 関数は、結果型からのレスポンスの構築方法（サーバー側）と、
  レスポンスからから結果の構築方法（クライアント側）を定義します。
 
 **HTTP** の場合：
 
-* [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) 関数は HTTPヘッダからロードされる値を定義します。
-* [Body](https://godoc.org/goa.design/goa/v3/dsl#Body) 関数はレスポンスボディからロードされる値を定義します。
+* [Header](https://pkg.go.dev/goa.design/goa/v3/dsl#Header) 関数は HTTPヘッダからロードされる値を定義します。
+* [Body](https://pkg.go.dev/goa.design/goa/v3/dsl#Body) 関数はレスポンスボディからロードされる値を定義します。
 
 デフォルトでは、結果のアトリビュートは HTTP レスポンスボディにマッピングされます。
 結果の型が基本型、配列、マップの場合、次のような制限が適用されます：
@@ -386,9 +386,9 @@ gRPC トランスポートでは、プロトコルバッファの [map](https://
 
 **gRPC** の場合：
 
-* [Message](https://godoc.org/goa.design/goa/v3/dsl#Message) 関数は gRPC メッセージからロードされる値を定義します。
-* [Headers](https://godoc.org/goa.design/goa/v3/dsl#Headers) 関数は gRPC ヘッダーメタデータからロードされる値を定義します。
-* [Trailers](https://godoc.org/goa.design/goa/v3/dsl#Trailers) 関数は gRPC トレーラーメタデータからロードされる値を定義します。
+* [Message](https://pkg.go.dev/goa.design/goa/v3/dsl#Message) 関数は gRPC メッセージからロードされる値を定義します。
+* [Headers](https://pkg.go.dev/goa.design/goa/v3/dsl#Headers) 関数は gRPC ヘッダーメタデータからロードされる値を定義します。
+* [Trailers](https://pkg.go.dev/goa.design/goa/v3/dsl#Trailers) 関数は gRPC トレーラーメタデータからロードされる値を定義します。
 
 デフォルトでは、結果のアトリビュートは gRPC メッセージにマッピングされます。 
 結果の型が基本型、配列、マップの場合、次のような制限が適用されます：

--- a/content/design/overview.md
+++ b/content/design/overview.md
@@ -9,14 +9,14 @@ parent = "design"
 
 The following sections describe how to use the goa DSL to describe services.
 They provide an overview of the key concepts. Review the
-[GoDocs](https://godoc.org/goa.design/goa/v3/dsl) for a complete reference.
+[GoDocs](https://pkg.go.dev/goa.design/goa/v3/dsl) for a complete reference.
 
 ## API Expression
 
-The [API](https://godoc.org/goa.design/goa/v3/dsl#API) function is an optional
+The [API](https://pkg.go.dev/goa.design/goa/v3/dsl#API) function is an optional
 top-level DSL which lists the global properties of the API such as a name, a
 description and a version number. `API` may define one or more
-[Servers](https://godoc.org/goa.design/goa/v3/dsl#Server) potentially exposing
+[Servers](https://pkg.go.dev/goa.design/goa/v3/dsl#Server) potentially exposing
 different sets of services. A single service may be exposed by any number (or
 no) server. If `Server` is omitted then a single server is automatically defined
 that exposes all the services defined in the design. The `Server` expression is
@@ -64,7 +64,7 @@ var _ = API("calc", func() {
 
 ## Service Expression
 
-The [Service](https://godoc.org/goa.design/goa/v3/dsl#Service) function defines a
+The [Service](https://pkg.go.dev/goa.design/goa/v3/dsl#Service) function defines a
 group of methods. This maps to a resource in REST or a
 [service declaration](https://grpc.io/docs/guides/concepts.html#service-definition)
 in gRPC. A service may define common error responses to all the service methods.
@@ -118,14 +118,14 @@ var _ = Service("calc", func() {
 
 ## Method Expression
 
-The service methods are described using [Method](https://godoc.org/goa.design/goa/v3/dsl#Method).
+The service methods are described using [Method](https://pkg.go.dev/goa.design/goa/v3/dsl#Method).
 This function defines the method payload (input) and result (output) types. It
 may also list an arbitrary number of error return values. An error return value
 has a name and optionally a type. Omitting the payload or result type has the
 same effect as using the built-in type `Empty` which maps to an empty body in
 HTTP and to the `Empty` message in gRPC. Omitting an error type has the same
 effect as using the default error type
-[ErrorResult](https://godoc.org/goa.design/goa/v3/expr#ErrorResult).
+[ErrorResult](https://pkg.go.dev/goa.design/goa/v3/expr#ErrorResult).
 
 ```go
 Method("divide", func() {
@@ -166,7 +166,7 @@ fields that are mapped to HTTP headers, URL parameters etc.
 
 ### gRPC Expression
 
-The [gRPC](https://godoc.org/goa.design/goa/v3/dsl#GRPC) function defines the
+The [gRPC](https://pkg.go.dev/goa.design/goa/v3/dsl#GRPC) function defines the
 mapping of the payload and result type attributes to the gRPC message and
 metadata.
 
@@ -188,7 +188,7 @@ metadata.
 
 ### HTTP Expression
 
-The [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) function defines the
+The [HTTP](https://pkg.go.dev/goa.design/goa/v3/dsl#HTTP) function defines the
 mapping of the payload and result type attributes to the HTTP request path and
 query string values as well as the HTTP request and response bodies. The `HTTP`
 function also defines other HTTP-specific properties such as the request path
@@ -341,8 +341,8 @@ representation in the generated HTTP and gRPC transport code.
 
 
 **User-defined types** can be defined in Goa using
-[Type](https://godoc.org/goa.design/goa/v3/dsl#Type) or
-[ResultType](https://godoc.org/goa.design/goa/v3/dsl#ResultType). A result type is
+[Type](https://pkg.go.dev/goa.design/goa/v3/dsl#Type) or
+[ResultType](https://pkg.go.dev/goa.design/goa/v3/dsl#ResultType). A result type is
 a type that also defines a set of "views". Each view lists the attributes
 (fields) that should be rendered when marshaling a result type instance using
 the view. For example a HTTP API may define a endpoint that lists a collection
@@ -355,7 +355,7 @@ can be used both in payloads and results while result types should only be used
 in results.
 
 **Maps** can be defined with
-[MapOf](https://godoc.org/goa.design/goa/v3/dsl#MapOf). The syntax is
+[MapOf](https://pkg.go.dev/goa.design/goa/v3/dsl#MapOf). The syntax is
 `MapOf(<KeyType>, <ElemType>)` where `<KeyType>` can be a primitive, array, or
 user type and `<ElemType>` can be a primitive, array, user type, or map. Map
 types are represented as Go `map` in the HTTP transport and protocol buffer
@@ -365,7 +365,7 @@ gRPC transport. Note that the protocol buffer language only supports primitives
 
 **Arrays** can be defined in two ways:
 
-* [ArrayOf](https://godoc.org/goa.design/goa/v3/dsl#ArrayOf) which accepts any type
+* [ArrayOf](https://pkg.go.dev/goa.design/goa/v3/dsl#ArrayOf) which accepts any type
   and returns a type.
 * [CollectionOf](https://pkg.go.dev/goa.design/goa/v3/dsl#CollectionOf) which
   only accepts result types and returns a result type.
@@ -381,18 +381,18 @@ are mapped to the transport-independent payload and result types.
 
 ### Payload-to-Request Mapping
 
-The [Payload](https://godoc.org/goa.design/goa/v3/dsl#Payload) function describes
+The [Payload](https://pkg.go.dev/goa.design/goa/v3/dsl#Payload) function describes
 the shape of the data given as an argument to the service methods. The `HTTP`
 and `GRPC` functions define how the payload is built from the incoming request
 (server-side) and how the request is built from the payload (client-side).
 
 For **HTTP**,
 
-* The [Param](https://godoc.org/goa.design/goa/v3/dsl#Param) function defines
+* The [Param](https://pkg.go.dev/goa.design/goa/v3/dsl#Param) function defines
   values loaded from path or query string parameters.
-* The [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) function defines
+* The [Header](https://pkg.go.dev/goa.design/goa/v3/dsl#Header) function defines
   values loaded from HTTP headers.
-* The [Body](https://godoc.org/goa.design/goa/v3/dsl#Body) function defines values
+* The [Body](https://pkg.go.dev/goa.design/goa/v3/dsl#Body) function defines values
   loaded from the request body.
 
 By default, the payload attributes are mapped to HTTP request body. When the
@@ -407,9 +407,9 @@ apply:
 
 For **gRPC**,
 
-* The [Message](https://godoc.org/goa.design/goa/v3/dsl#Message) function defines
+* The [Message](https://pkg.go.dev/goa.design/goa/v3/dsl#Message) function defines
   values loaded from a gRPC message.
-* The [Metadata](https://godoc.org/goa.design/goa/v3/dsl#Metadata) function defines
+* The [Metadata](https://pkg.go.dev/goa.design/goa/v3/dsl#Metadata) function defines
   values loaded from a gRPC request
   [metadata](https://grpc.io/docs/guides/concepts.html#metadata).
 
@@ -421,16 +421,16 @@ apply:
 
 ### Result-To-Response Mapping
 
-The [Result](https://godoc.org/goa.design/goa/v3/dsl#Result) function describes the
+The [Result](https://pkg.go.dev/goa.design/goa/v3/dsl#Result) function describes the
 shape of the return data of the service methods. The `HTTP` and `GRPC` functions
 define how the response is built from the result type (server-side) and how the
 result is built from the response (client-side).
 
 For **HTTP**,
 
-* The [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) function defines
+* The [Header](https://pkg.go.dev/goa.design/goa/v3/dsl#Header) function defines
   values loaded from HTTP headers.
-* The [Body](https://godoc.org/goa.design/goa/v3/dsl#Body) function defines values
+* The [Body](https://pkg.go.dev/goa.design/goa/v3/dsl#Body) function defines values
   loaded from the response body.
 
 By default, the result attributes are mapped to HTTP response body. When the
@@ -442,11 +442,11 @@ apply:
 
 For **gRPC**,
 
-* The [Message](https://godoc.org/goa.design/goa/v3/dsl#Message) function defines
+* The [Message](https://pkg.go.dev/goa.design/goa/v3/dsl#Message) function defines
   values loaded into a gRPC message.
-* The [Headers](https://godoc.org/goa.design/goa/v3/dsl#Headers) function defines
+* The [Headers](https://pkg.go.dev/goa.design/goa/v3/dsl#Headers) function defines
   values loaded into a gRPC header metadata.
-* The [Trailers](https://godoc.org/goa.design/goa/v3/dsl#Trailers) function defines
+* The [Trailers](https://pkg.go.dev/goa.design/goa/v3/dsl#Trailers) function defines
   values loaded into a gRPC trailer metadata.
 
 By default, the result attributes are mapped to gRPC message. When the

--- a/content/design/overview.md
+++ b/content/design/overview.md
@@ -9,14 +9,14 @@ parent = "design"
 
 The following sections describe how to use the goa DSL to describe services.
 They provide an overview of the key concepts. Review the
-[GoDocs](https://godoc.org/goa.design/goa/dsl) for a complete reference.
+[GoDocs](https://godoc.org/goa.design/goa/v3/dsl) for a complete reference.
 
 ## API Expression
 
-The [API](https://godoc.org/goa.design/goa/dsl#API) function is an optional
+The [API](https://godoc.org/goa.design/goa/v3/dsl#API) function is an optional
 top-level DSL which lists the global properties of the API such as a name, a
 description and a version number. `API` may define one or more
-[Servers](https://godoc.org/goa.design/goa/dsl#Server) potentially exposing
+[Servers](https://godoc.org/goa.design/goa/v3/dsl#Server) potentially exposing
 different sets of services. A single service may be exposed by any number (or
 no) server. If `Server` is omitted then a single server is automatically defined
 that exposes all the services defined in the design. The `Server` expression is
@@ -64,7 +64,7 @@ var _ = API("calc", func() {
 
 ## Service Expression
 
-The [Service](https://godoc.org/goa.design/goa/dsl#Service) function defines a
+The [Service](https://godoc.org/goa.design/goa/v3/dsl#Service) function defines a
 group of methods. This maps to a resource in REST or a
 [service declaration](https://grpc.io/docs/guides/concepts.html#service-definition)
 in gRPC. A service may define common error responses to all the service methods.
@@ -118,14 +118,14 @@ var _ = Service("calc", func() {
 
 ## Method Expression
 
-The service methods are described using [Method](https://godoc.org/goa.design/goa/dsl#Method).
+The service methods are described using [Method](https://godoc.org/goa.design/goa/v3/dsl#Method).
 This function defines the method payload (input) and result (output) types. It
 may also list an arbitrary number of error return values. An error return value
 has a name and optionally a type. Omitting the payload or result type has the
 same effect as using the built-in type `Empty` which maps to an empty body in
 HTTP and to the `Empty` message in gRPC. Omitting an error type has the same
 effect as using the default error type
-[ErrorResult](https://godoc.org/goa.design/goa/expr#ErrorResult).
+[ErrorResult](https://godoc.org/goa.design/goa/v3/expr#ErrorResult).
 
 ```go
 Method("divide", func() {
@@ -166,7 +166,7 @@ fields that are mapped to HTTP headers, URL parameters etc.
 
 ### gRPC Expression
 
-The [gRPC](https://godoc.org/goa.design/goa/dsl#GRPC) function defines the
+The [gRPC](https://godoc.org/goa.design/goa/v3/dsl#GRPC) function defines the
 mapping of the payload and result type attributes to the gRPC message and
 metadata.
 
@@ -188,7 +188,7 @@ metadata.
 
 ### HTTP Expression
 
-The [HTTP](https://godoc.org/goa.design/goa/dsl#HTTP) function defines the
+The [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) function defines the
 mapping of the payload and result type attributes to the HTTP request path and
 query string values as well as the HTTP request and response bodies. The `HTTP`
 function also defines other HTTP-specific properties such as the request path
@@ -341,8 +341,8 @@ representation in the generated HTTP and gRPC transport code.
 
 
 **User-defined types** can be defined in Goa using
-[Type](https://godoc.org/goa.design/goa/dsl#Type) or
-[ResultType](https://godoc.org/goa.design/goa/dsl#ResultType). A result type is
+[Type](https://godoc.org/goa.design/goa/v3/dsl#Type) or
+[ResultType](https://godoc.org/goa.design/goa/v3/dsl#ResultType). A result type is
 a type that also defines a set of "views". Each view lists the attributes
 (fields) that should be rendered when marshaling a result type instance using
 the view. For example a HTTP API may define a endpoint that lists a collection
@@ -355,7 +355,7 @@ can be used both in payloads and results while result types should only be used
 in results.
 
 **Maps** can be defined with
-[MapOf](https://godoc.org/goa.design/goa/dsl#MapOf). The syntax is
+[MapOf](https://godoc.org/goa.design/goa/v3/dsl#MapOf). The syntax is
 `MapOf(<KeyType>, <ElemType>)` where `<KeyType>` can be a primitive, array, or
 user type and `<ElemType>` can be a primitive, array, user type, or map. Map
 types are represented as Go `map` in the HTTP transport and protocol buffer
@@ -365,9 +365,9 @@ gRPC transport. Note that the protocol buffer language only supports primitives
 
 **Arrays** can be defined in two ways:
 
-* [ArrayOf](https://godoc.org/goa.design/goa/dsl#ArrayOf) which accepts any type
+* [ArrayOf](https://godoc.org/goa.design/goa/v3/dsl#ArrayOf) which accepts any type
   and returns a type.
-* [CollectionOf](https://godoc.org/goa/design/goa/dsl#CollectionOf) which
+* [CollectionOf](https://pkg.go.dev/goa.design/goa/v3/dsl#CollectionOf) which
   only accepts result types and returns a result type.
 
 The result type returned by `CollectionOf` contains the same views as the result
@@ -381,18 +381,18 @@ are mapped to the transport-independent payload and result types.
 
 ### Payload-to-Request Mapping
 
-The [Payload](https://godoc.org/goa.design/goa/dsl#Payload) function describes
+The [Payload](https://godoc.org/goa.design/goa/v3/dsl#Payload) function describes
 the shape of the data given as an argument to the service methods. The `HTTP`
 and `GRPC` functions define how the payload is built from the incoming request
 (server-side) and how the request is built from the payload (client-side).
 
 For **HTTP**,
 
-* The [Param](https://godoc.org/goa.design/goa/dsl#Param) function defines
+* The [Param](https://godoc.org/goa.design/goa/v3/dsl#Param) function defines
   values loaded from path or query string parameters.
-* The [Header](https://godoc.org/goa.design/goa/dsl#Header) function defines
+* The [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) function defines
   values loaded from HTTP headers.
-* The [Body](https://godoc.org/goa.design/goa/dsl#Body) function defines values
+* The [Body](https://godoc.org/goa.design/goa/v3/dsl#Body) function defines values
   loaded from the request body.
 
 By default, the payload attributes are mapped to HTTP request body. When the
@@ -407,9 +407,9 @@ apply:
 
 For **gRPC**,
 
-* The [Message](https://godoc.org/goa.design/goa/dsl#Message) function defines
+* The [Message](https://godoc.org/goa.design/goa/v3/dsl#Message) function defines
   values loaded from a gRPC message.
-* The [Metadata](https://godoc.org/goa.design/goa/dsl#Metadata) function defines
+* The [Metadata](https://godoc.org/goa.design/goa/v3/dsl#Metadata) function defines
   values loaded from a gRPC request
   [metadata](https://grpc.io/docs/guides/concepts.html#metadata).
 
@@ -421,16 +421,16 @@ apply:
 
 ### Result-To-Response Mapping
 
-The [Result](https://godoc.org/goa.design/goa/dsl#Result) function describes the
+The [Result](https://godoc.org/goa.design/goa/v3/dsl#Result) function describes the
 shape of the return data of the service methods. The `HTTP` and `GRPC` functions
 define how the response is built from the result type (server-side) and how the
 result is built from the response (client-side).
 
 For **HTTP**,
 
-* The [Header](https://godoc.org/goa.design/goa/dsl#Header) function defines
+* The [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) function defines
   values loaded from HTTP headers.
-* The [Body](https://godoc.org/goa.design/goa/dsl#Body) function defines values
+* The [Body](https://godoc.org/goa.design/goa/v3/dsl#Body) function defines values
   loaded from the response body.
 
 By default, the result attributes are mapped to HTTP response body. When the
@@ -442,11 +442,11 @@ apply:
 
 For **gRPC**,
 
-* The [Message](https://godoc.org/goa.design/goa/dsl#Message) function defines
+* The [Message](https://godoc.org/goa.design/goa/v3/dsl#Message) function defines
   values loaded into a gRPC message.
-* The [Headers](https://godoc.org/goa.design/goa/dsl#Headers) function defines
+* The [Headers](https://godoc.org/goa.design/goa/v3/dsl#Headers) function defines
   values loaded into a gRPC header metadata.
-* The [Trailers](https://godoc.org/goa.design/goa/dsl#Trailers) function defines
+* The [Trailers](https://godoc.org/goa.design/goa/v3/dsl#Trailers) function defines
   values loaded into a gRPC trailer metadata.
 
 By default, the result attributes are mapped to gRPC message. When the

--- a/content/extend/plugins.it.md
+++ b/content/extend/plugins.it.md
@@ -7,7 +7,7 @@ name = "Plugins"
 parent = "extend"
 +++
 
-I [plugin di Goa](https://godoc.org/github.com/goadesign/plugins) permettono di
+I [plugin di Goa](https://pkg.go.dev/github.com/goadesign/plugins) permettono di
 creare nuovi DSL e i relativi generatori di codice. Vengono eseguiti prima del
 rendering degli artefatti finali e rendono possibile l'alterazione dei template
 esposti dai generatori di default di Goa e , di conseguenza, di produrre nuovi
@@ -26,7 +26,7 @@ I plugin possono essere utilizzati per fare le cose più disparate:
   dai generatori di Goa.
 
 * Ogni plugin può avere una
-  [GenerateFunc](https://godoc.org/goa.design/goa/v3/codegen#GenerateFunc) per modificare
+  [GenerateFunc](https://pkg.go.dev/goa.design/goa/v3/codegen#GenerateFunc) per modificare
   i file generati da Goa o generare nuovi file da aggiungere agli artefatti finali.
 
 ```go
@@ -34,7 +34,7 @@ type GenerateFunc func(genpkg string, roots []eval.Root, files []*File) ([]*File
 ```
 
 * Ogni plugin può avere una
-  [PrepareFunc](https://godoc.org/goa.design/goa/v3/codegen#PrepareFunc), per alterare
+  [PrepareFunc](https://pkg.go.dev/goa.design/goa/v3/codegen#PrepareFunc), per alterare
   il design prima della generazione del codice.
 
 ```go
@@ -42,10 +42,10 @@ type PrepareFunc func(genpkg string, roots []eval.Root) error
 ```
 
 I plugin si auto-registrano usando una fra le funzioni
-[RegisterPlugin](https://godoc.org/goa.design/goa/v3/codegen#RegisterPlugin),
-[RegisterPluginFirst](https://godoc.org/goa.design/goa/v3/codegen#RegisterPluginFirst),
+[RegisterPlugin](https://pkg.go.dev/goa.design/goa/v3/codegen#RegisterPlugin),
+[RegisterPluginFirst](https://pkg.go.dev/goa.design/goa/v3/codegen#RegisterPluginFirst),
 oppure
-[RegisterPluginLast](https://godoc.org/goa.design/goa/v3/codegen#RegisterPlugin).
+[RegisterPluginLast](https://pkg.go.dev/goa.design/goa/v3/codegen#RegisterPlugin).
 
 ## CORS Plugin
 
@@ -54,7 +54,7 @@ che aggiunge la possibilità di definire CORS properties sugli endpoint HTTP e u
 le corrispondenti espressioni per implementare i controlli CORS sulla API.
 
 Il plugin CORS aggiunge il suo 
-[DSL](https://godoc.org/github.com/goadesign/plugins/cors/dsl)
+[DSL](https://pkg.go.dev/github.com/goadesign/plugins/cors/dsl)
 personale, il quale può essere integrato come segue:
 
 ```go
@@ -101,7 +101,7 @@ servizio `calc`.
 
 Il plugin CORS si auto-registra chiamando `RegisterPlugin` nel package `codegen` di Goa
 e aggiunge il proprio
-[generatore di codice](https://godoc.org/github.com/goadesign/plugins/cors#Generate) che
+[generatore di codice](https://pkg.go.dev/github.com/goadesign/plugins/cors#Generate) che
 implementa la funzione `GenerateFunc`.
 
 ```go

--- a/content/extend/plugins.it.md
+++ b/content/extend/plugins.it.md
@@ -26,7 +26,7 @@ I plugin possono essere utilizzati per fare le cose più disparate:
   dai generatori di Goa.
 
 * Ogni plugin può avere una
-  [GenerateFunc](https://godoc.org/goa.design/goa/codegen#GenerateFunc) per modificare
+  [GenerateFunc](https://godoc.org/goa.design/goa/v3/codegen#GenerateFunc) per modificare
   i file generati da Goa o generare nuovi file da aggiungere agli artefatti finali.
 
 ```go
@@ -34,7 +34,7 @@ type GenerateFunc func(genpkg string, roots []eval.Root, files []*File) ([]*File
 ```
 
 * Ogni plugin può avere una
-  [PrepareFunc](https://godoc.org/goa.design/goa/codegen#PrepareFunc), per alterare
+  [PrepareFunc](https://godoc.org/goa.design/goa/v3/codegen#PrepareFunc), per alterare
   il design prima della generazione del codice.
 
 ```go
@@ -42,10 +42,10 @@ type PrepareFunc func(genpkg string, roots []eval.Root) error
 ```
 
 I plugin si auto-registrano usando una fra le funzioni
-[RegisterPlugin](https://godoc.org/goa.design/goa/codegen#RegisterPlugin),
-[RegisterPluginFirst](https://godoc.org/goa.design/goa/codegen#RegisterPluginFirst),
+[RegisterPlugin](https://godoc.org/goa.design/goa/v3/codegen#RegisterPlugin),
+[RegisterPluginFirst](https://godoc.org/goa.design/goa/v3/codegen#RegisterPluginFirst),
 oppure
-[RegisterPluginLast](https://godoc.org/goa.design/goa/codegen#RegisterPlugin).
+[RegisterPluginLast](https://godoc.org/goa.design/goa/v3/codegen#RegisterPlugin).
 
 ## CORS Plugin
 

--- a/content/extend/plugins.ja.md
+++ b/content/extend/plugins.ja.md
@@ -7,7 +7,7 @@ name = "プラグイン"
 parent = "extend"
 +++
 
-[Goa プラグイン](https://godoc.org/github.com/goadesign/plugins) を使用すると、
+[Goa プラグイン](https://pkg.go.dev/github.com/goadesign/plugins) を使用すると、
 新しい DSL と付随するジェネレーターを作成できます。
 これらは最終的な生成物をレンダリングする前に実行されるため、
 Goa コードジェネレーターによって公開されるテンプレートを変更でき、
@@ -24,7 +24,7 @@ Goa プラグインのパブリックセットが含まれています。
 * プラグインは、既存の Goa DSL とともに使用される独自の DSL を追加できます。
   プラグイン DSL は、まったく異なるコードを生成したり、Goa コードジェネレーターによって生成された既存のコードを変更したりできます。
 
-* プラグインは、[GenerateFunc](https://godoc.org/goa.design/goa/v3/codegen#GenerateFunc) を提供して、
+* プラグインは、[GenerateFunc](https://pkg.go.dev/goa.design/goa/v3/codegen#GenerateFunc) を提供して、
   Goa が生成したファイルを変更したり、新しいファイルを生成して最終的な生成物として返したりできます。
 
 ```go
@@ -32,17 +32,17 @@ type GenerateFunc func(genpkg string, roots []eval.Root, files []*File) ([]*File
 ```
 
 * プラグインは、コードが生成される前にデザインを変更するために、
-  [PrepareFunc](https://godoc.org/goa.design/goa/v3/codegen#PrepareFunc) を提供する場合があります。
+  [PrepareFunc](https://pkg.go.dev/goa.design/goa/v3/codegen#PrepareFunc) を提供する場合があります。
 
 ```go
 type PrepareFunc func(genpkg string, roots []eval.Root) error
 ```
 
 プラグインは、
-[RegisterPlugin](https://godoc.org/goa.design/goa/v3/codegen#RegisterPlugin) 関数、
-[RegisterPluginFirst](https://godoc.org/goa.design/goa/v3/codegen#RegisterPluginFirst) 関数、
+[RegisterPlugin](https://pkg.go.dev/goa.design/goa/v3/codegen#RegisterPlugin) 関数、
+[RegisterPluginFirst](https://pkg.go.dev/goa.design/goa/v3/codegen#RegisterPluginFirst) 関数、
 もしくは
-[RegisterPluginLast](https://godoc.org/goa.design/goa/v3/codegen#RegisterPlugin) 関数
+[RegisterPluginLast](https://pkg.go.dev/goa.design/goa/v3/codegen#RegisterPlugin) 関数
 を使用してプラグイン自身を登録します。
 
 ## CORS プラグイン
@@ -52,7 +52,7 @@ type PrepareFunc func(genpkg string, roots []eval.Root) error
 対応する式を使用して API に対して CORS を実装するコードを生成します。
 
 CORS プラグインは、以下に示すようにデザインで
-使用できる独自の [DSL](https://godoc.org/github.com/goadesign/plugins/cors/dsl) を追加します：
+使用できる独自の [DSL](https://pkg.go.dev/github.com/goadesign/plugins/cors/dsl) を追加します：
 
 ```go
 package design
@@ -96,7 +96,7 @@ var _ = Service("calc", func() {
 上記のデザインでは、`calc` サービスで定義されたすべてのエンドポイントに CORS ポリシーを設定します。
 
 CORS プラグインは、Goa `codegen` パッケージの `RegisterPlugin` 関数を呼び出すことで自身を登録し、
-`GenerateFunc` 型を実装する独自のコード[ジェネレーター](https://godoc.org/github.com/goadesign/plugins/cors#Generate)を追加します。
+`GenerateFunc` 型を実装する独自のコード[ジェネレーター](https://pkg.go.dev/github.com/goadesign/plugins/cors#Generate)を追加します。
 
 ```go
 package cors

--- a/content/extend/plugins.ja.md
+++ b/content/extend/plugins.ja.md
@@ -24,7 +24,7 @@ Goa プラグインのパブリックセットが含まれています。
 * プラグインは、既存の Goa DSL とともに使用される独自の DSL を追加できます。
   プラグイン DSL は、まったく異なるコードを生成したり、Goa コードジェネレーターによって生成された既存のコードを変更したりできます。
 
-* プラグインは、[GenerateFunc](https://godoc.org/goa.design/goa/codegen#GenerateFunc) を提供して、
+* プラグインは、[GenerateFunc](https://godoc.org/goa.design/goa/v3/codegen#GenerateFunc) を提供して、
   Goa が生成したファイルを変更したり、新しいファイルを生成して最終的な生成物として返したりできます。
 
 ```go
@@ -32,17 +32,17 @@ type GenerateFunc func(genpkg string, roots []eval.Root, files []*File) ([]*File
 ```
 
 * プラグインは、コードが生成される前にデザインを変更するために、
-  [PrepareFunc](https://godoc.org/goa.design/goa/codegen#PrepareFunc) を提供する場合があります。
+  [PrepareFunc](https://godoc.org/goa.design/goa/v3/codegen#PrepareFunc) を提供する場合があります。
 
 ```go
 type PrepareFunc func(genpkg string, roots []eval.Root) error
 ```
 
 プラグインは、
-[RegisterPlugin](https://godoc.org/goa.design/goa/codegen#RegisterPlugin) 関数、
-[RegisterPluginFirst](https://godoc.org/goa.design/goa/codegen#RegisterPluginFirst) 関数、
+[RegisterPlugin](https://godoc.org/goa.design/goa/v3/codegen#RegisterPlugin) 関数、
+[RegisterPluginFirst](https://godoc.org/goa.design/goa/v3/codegen#RegisterPluginFirst) 関数、
 もしくは
-[RegisterPluginLast](https://godoc.org/goa.design/goa/codegen#RegisterPlugin) 関数
+[RegisterPluginLast](https://godoc.org/goa.design/goa/v3/codegen#RegisterPlugin) 関数
 を使用してプラグイン自身を登録します。
 
 ## CORS プラグイン

--- a/content/extend/plugins.md
+++ b/content/extend/plugins.md
@@ -25,7 +25,7 @@ Plugins can be used to do a few different things:
   existing code produced by Goa code generators.
 
 * A plugin may provide a
-  [GenerateFunc](https://godoc.org/goa.design/goa/codegen#GenerateFunc) to
+  [GenerateFunc](https://godoc.org/goa.design/goa/v3/codegen#GenerateFunc) to
   modify the Goa generated files or to generate new files and return them to the
   final artifact generation.
 
@@ -34,7 +34,7 @@ type GenerateFunc func(genpkg string, roots []eval.Root, files []*File) ([]*File
 ```
 
 * A plugin may provide a
-  [PrepareFunc](https://godoc.org/goa.design/goa/codegen#PrepareFunc), to modify
+  [PrepareFunc](https://godoc.org/goa.design/goa/v3/codegen#PrepareFunc), to modify
   the design prior to the code being generated.
 
 ```go
@@ -42,10 +42,10 @@ type PrepareFunc func(genpkg string, roots []eval.Root) error
 ```
 
 Plugins register themselves using one of the
-[RegisterPlugin](https://godoc.org/goa.design/goa/codegen#RegisterPlugin),
-[RegisterPluginFirst](https://godoc.org/goa.design/goa/codegen#RegisterPluginFirst),
+[RegisterPlugin](https://godoc.org/goa.design/goa/v3/codegen#RegisterPlugin),
+[RegisterPluginFirst](https://godoc.org/goa.design/goa/v3/codegen#RegisterPluginFirst),
 or
-[RegisterPluginLast](https://godoc.org/goa.design/goa/codegen#RegisterPlugin)
+[RegisterPluginLast](https://godoc.org/goa.design/goa/v3/codegen#RegisterPlugin)
 functions.
 
 ## CORS Plugin

--- a/content/extend/plugins.md
+++ b/content/extend/plugins.md
@@ -7,7 +7,7 @@ name = "Plugins"
 parent = "extend"
 +++
 
-[Goa plugins](https://godoc.org/github.com/goadesign/plugins) make it possible
+[Goa plugins](https://pkg.go.dev/github.com/goadesign/plugins) make it possible
 to create new DSLs and accompanying generators. They run before rendering the
 final artifacts which makes it possible to alter the templates exposed by the
 Goa code generators, thereby, producing new kinds of outputs from any DSL.
@@ -25,7 +25,7 @@ Plugins can be used to do a few different things:
   existing code produced by Goa code generators.
 
 * A plugin may provide a
-  [GenerateFunc](https://godoc.org/goa.design/goa/v3/codegen#GenerateFunc) to
+  [GenerateFunc](https://pkg.go.dev/goa.design/goa/v3/codegen#GenerateFunc) to
   modify the Goa generated files or to generate new files and return them to the
   final artifact generation.
 
@@ -34,7 +34,7 @@ type GenerateFunc func(genpkg string, roots []eval.Root, files []*File) ([]*File
 ```
 
 * A plugin may provide a
-  [PrepareFunc](https://godoc.org/goa.design/goa/v3/codegen#PrepareFunc), to modify
+  [PrepareFunc](https://pkg.go.dev/goa.design/goa/v3/codegen#PrepareFunc), to modify
   the design prior to the code being generated.
 
 ```go
@@ -42,10 +42,10 @@ type PrepareFunc func(genpkg string, roots []eval.Root) error
 ```
 
 Plugins register themselves using one of the
-[RegisterPlugin](https://godoc.org/goa.design/goa/v3/codegen#RegisterPlugin),
-[RegisterPluginFirst](https://godoc.org/goa.design/goa/v3/codegen#RegisterPluginFirst),
+[RegisterPlugin](https://pkg.go.dev/goa.design/goa/v3/codegen#RegisterPlugin),
+[RegisterPluginFirst](https://pkg.go.dev/goa.design/goa/v3/codegen#RegisterPluginFirst),
 or
-[RegisterPluginLast](https://godoc.org/goa.design/goa/v3/codegen#RegisterPlugin)
+[RegisterPluginLast](https://pkg.go.dev/goa.design/goa/v3/codegen#RegisterPlugin)
 functions.
 
 ## CORS Plugin
@@ -56,7 +56,7 @@ the ability to define CORS properties on HTTP endpoints and uses the
 corresponding expressions to generate code that implements CORS for the API.
 
 The CORS plugin adds its own
-[DSL](https://godoc.org/github.com/goadesign/plugins/cors/dsl)
+[DSL](https://pkg.go.dev/github.com/goadesign/plugins/cors/dsl)
 which can be used in the design as shown below:
 
 ```go
@@ -103,7 +103,7 @@ The design above sets up a CORS policy on all the endpoints defined in the
 
 The CORS plugin registers itself by calling the `RegisterPlugin` function in the
 Goa `codegen` package and adds its own code
-[generator](https://godoc.org/github.com/goadesign/plugins/cors#Generate) which
+[generator](https://pkg.go.dev/github.com/goadesign/plugins/cors#Generate) which
 implements the `GenerateFunc` type.
 
 ```go

--- a/content/implement/encoding.it.md
+++ b/content/implement/encoding.it.md
@@ -13,8 +13,8 @@ parent = "implement"
 Goa supporta una strategia di encoding e decoding estremamente flessibile, che rende possibile
 l'associazione di encoder e decoder arbitrari con le richieste e risposte HTTP date attraverso
 diversi content types. Un encoder è una struct che implementa l'interfaccia 
-[Encoder](https://godoc.org/goa.design/goa/http#Encoder) mentre un decoder implementa
-[Decoder](https://godoc.org/goa.design/goa/http#Decoder).
+[Encoder](https://godoc.org/goa.design/goa/v3/http#Encoder) mentre un decoder implementa
+[Decoder](https://godoc.org/goa.design/goa/v3/http#Decoder).
 
 I costruttori del server generati accettano dei costruttori di encoder e decoder come argomento,
 rendendo possibile implementazioni libere. Goa ha anche degli encoder e decoder di default, che
@@ -41,8 +41,8 @@ ritorna un encoder.
 ### Costruttori di Default per Encoder e Decoder
 
 Il package fornito da Goa fornisce dei costruttori di default per HTTP
-[encoder](https://godoc.org/goa.design/goa/http#RequestEncoder) e
-[decoder](https://godoc.org/goa.design/goa/http#ResponseEncoder) che possono codificare e 
+[encoder](https://godoc.org/goa.design/goa/v3/http#RequestEncoder) e
+[decoder](https://godoc.org/goa.design/goa/v3/http#ResponseEncoder) che possono codificare e 
 decodificare JSON, XML e gob. 
 Ecco un esempio di come il generatore usa questi costruttori:
 
@@ -109,15 +109,15 @@ func(ctx context.Context, w http.ResponseWriter) (goahttp.Encoder, error)
 ```
 
 Il context dato quando Goa richiama il costruttore contiene sia l'header `Content-Type` che
-`Accept` rispettivamente sotto le chiavi[ContentTypeKey](https://godoc.org/goa.design/goa/http#pkg-constants)
+`Accept` rispettivamente sotto le chiavi[ContentTypeKey](https://godoc.org/goa.design/goa/v3/http#pkg-constants)
 e `AcceptTypeKey`. 
 Questo rende possibile al costruttore dell'encoder di implementare forme differenti di negoziazione che 
 controllano questi 2 valori e restituiscono il miglior encoder possibile.
 
 ## Impostare un Content Type di default
 
-Il DSL [Response](https://godoc.org/goa.design/goa/dsl#Response) permette di specificare un
-content type usando [ContentType](https://godoc.org/goa.design/goa/dsl#ContentType). Quando
+Il DSL [Response](https://godoc.org/goa.design/goa/v3/dsl#Response) permette di specificare un
+content type usando [ContentType](https://godoc.org/goa.design/goa/v3/dsl#ContentType). Quando
 viene impostato, il valore sovrascrive ogni content type specificato nei request headers. 
 Nota che questo NON sovrascrive alcun valore specificato nell'header `Accept`.
 Questo permette di controllare il content type anche quando tale header è assente.

--- a/content/implement/encoding.it.md
+++ b/content/implement/encoding.it.md
@@ -13,8 +13,8 @@ parent = "implement"
 Goa supporta una strategia di encoding e decoding estremamente flessibile, che rende possibile
 l'associazione di encoder e decoder arbitrari con le richieste e risposte HTTP date attraverso
 diversi content types. Un encoder è una struct che implementa l'interfaccia 
-[Encoder](https://godoc.org/goa.design/goa/v3/http#Encoder) mentre un decoder implementa
-[Decoder](https://godoc.org/goa.design/goa/v3/http#Decoder).
+[Encoder](https://pkg.go.dev/goa.design/goa/v3/http#Encoder) mentre un decoder implementa
+[Decoder](https://pkg.go.dev/goa.design/goa/v3/http#Decoder).
 
 I costruttori del server generati accettano dei costruttori di encoder e decoder come argomento,
 rendendo possibile implementazioni libere. Goa ha anche degli encoder e decoder di default, che
@@ -41,8 +41,8 @@ ritorna un encoder.
 ### Costruttori di Default per Encoder e Decoder
 
 Il package fornito da Goa fornisce dei costruttori di default per HTTP
-[encoder](https://godoc.org/goa.design/goa/v3/http#RequestEncoder) e
-[decoder](https://godoc.org/goa.design/goa/v3/http#ResponseEncoder) che possono codificare e 
+[encoder](https://pkg.go.dev/goa.design/goa/v3/http#RequestEncoder) e
+[decoder](https://pkg.go.dev/goa.design/goa/v3/http#ResponseEncoder) che possono codificare e 
 decodificare JSON, XML e gob. 
 Ecco un esempio di come il generatore usa questi costruttori:
 
@@ -109,15 +109,15 @@ func(ctx context.Context, w http.ResponseWriter) (goahttp.Encoder, error)
 ```
 
 Il context dato quando Goa richiama il costruttore contiene sia l'header `Content-Type` che
-`Accept` rispettivamente sotto le chiavi[ContentTypeKey](https://godoc.org/goa.design/goa/v3/http#pkg-constants)
+`Accept` rispettivamente sotto le chiavi[ContentTypeKey](https://pkg.go.dev/goa.design/goa/v3/http#pkg-constants)
 e `AcceptTypeKey`. 
 Questo rende possibile al costruttore dell'encoder di implementare forme differenti di negoziazione che 
 controllano questi 2 valori e restituiscono il miglior encoder possibile.
 
 ## Impostare un Content Type di default
 
-Il DSL [Response](https://godoc.org/goa.design/goa/v3/dsl#Response) permette di specificare un
-content type usando [ContentType](https://godoc.org/goa.design/goa/v3/dsl#ContentType). Quando
+Il DSL [Response](https://pkg.go.dev/goa.design/goa/v3/dsl#Response) permette di specificare un
+content type usando [ContentType](https://pkg.go.dev/goa.design/goa/v3/dsl#ContentType). Quando
 viene impostato, il valore sovrascrive ogni content type specificato nei request headers. 
 Nota che questo NON sovrascrive alcun valore specificato nell'header `Accept`.
 Questo permette di controllare il content type anche quando tale header è assente.

--- a/content/implement/encoding.ja.md
+++ b/content/implement/encoding.ja.md
@@ -11,8 +11,8 @@ parent = "implement"
 ## 概要
 
 Goa は、柔軟なエンコード/デコードをサポートしていて、任意のエンコーダーおよびデコーダーを特定の HTTP レスポンスおよびリクエスト・コンテンツタイプに関連付けることができます。
-エンコーダーは [Encoder](https://godoc.org/goa.design/goa/http#Encoder) インターフェイスを実装する構造体であり、
-デコーダーは [Decoder](https://godoc.org/goa.design/goa/http#Decoder) インターフェイスを実装する構造体です。
+エンコーダーは [Encoder](https://godoc.org/goa.design/goa/v3/http#Encoder) インターフェイスを実装する構造体であり、
+デコーダーは [Decoder](https://godoc.org/goa.design/goa/v3/http#Decoder) インターフェイスを実装する構造体です。
 
 生成されたサーバーコンストラクターは、引数としてエンコーダーおよびデコーダーのコンストラクター関数を受理し、任意の実装を提供できるようにします。
 Goa には、JSON、XML、および [gob](https://golang.org/pkg/encoding/gob/) をサポートするデフォルトのエンコーダーとデコーダーが付属しています。
@@ -37,8 +37,8 @@ Goa はリクエストごとにこの関数を呼び出し、異なる HTTP リ�
 ### デフォルトのエンコーダー/デコーダーのコンストラクター
 
 Goa パッケージは、JSON、XML、および gob をエンコード/デコードできるデフォルトの HTTP 
-[エンコーダー](https://godoc.org/goa.design/goa/http#RequestEncoder) / 
-[デコーダー](https://godoc.org/goa.design/goa/http#ResponseEncoder)
+[エンコーダー](https://godoc.org/goa.design/goa/v3/http#RequestEncoder) / 
+[デコーダー](https://godoc.org/goa.design/goa/v3/http#ResponseEncoder)
 のコンストラクターを提供します。 
 ここに、デフォルトの example ジェネレーターが `calc` の例でこれらのコンストラクタをどのように活用しているかを示します：
 
@@ -100,15 +100,15 @@ func(ctx context.Context, w http.ResponseWriter) (goahttp.Encoder, error)
 ```
 
 Goa がコンストラクター関数を呼び出すときに指定されるコンテキストには、
-`Content-Type` リクエストと `Accept` ヘッダーの値が [ContentTypeKey](https://godoc.org/goa.design/goa/http#pkg-constants) と `AcceptTypeKey` が
+`Content-Type` リクエストと `Accept` ヘッダーの値が [ContentTypeKey](https://godoc.org/goa.design/goa/v3/http#pkg-constants) と `AcceptTypeKey` が
 のそれぞれに含まれています。
 これにより、エンコーダー・コンストラクターは、これらのヘッダーの値を調べて、
 クライアントにとって最適なエンコーダーを返すコンテンツタイプ・ネゴシエーションを実装できます。
 
 ## デフォルト・コンテンツタイプの設定
 
-[レスポンス](https://godoc.org/goa.design/goa/dsl#Response) デザイン DSL では、
-[ContentType](https://godoc.org/goa.design/goa/dsl#ContentType) を使用してコンテンツタイプを指定できます。
+[レスポンス](https://godoc.org/goa.design/goa/v3/dsl#Response) デザイン DSL では、
+[ContentType](https://godoc.org/goa.design/goa/v3/dsl#ContentType) を使用してコンテンツタイプを指定できます。
 設定すると、値はリクエストヘッダーで指定されたコンテンツタイプをオーバーライドします。
 これは `Accept` ヘッダーで指定された値をオーバーライドしないことに注意してください。
 これにより、`Accept` ヘッダーがない場合に、レスポンス・エンコーダー コンストラクターが使用するコンテンツタイプを制御できます。

--- a/content/implement/encoding.ja.md
+++ b/content/implement/encoding.ja.md
@@ -11,8 +11,8 @@ parent = "implement"
 ## 概要
 
 Goa は、柔軟なエンコード/デコードをサポートしていて、任意のエンコーダーおよびデコーダーを特定の HTTP レスポンスおよびリクエスト・コンテンツタイプに関連付けることができます。
-エンコーダーは [Encoder](https://godoc.org/goa.design/goa/v3/http#Encoder) インターフェイスを実装する構造体であり、
-デコーダーは [Decoder](https://godoc.org/goa.design/goa/v3/http#Decoder) インターフェイスを実装する構造体です。
+エンコーダーは [Encoder](https://pkg.go.dev/goa.design/goa/v3/http#Encoder) インターフェイスを実装する構造体であり、
+デコーダーは [Decoder](https://pkg.go.dev/goa.design/goa/v3/http#Decoder) インターフェイスを実装する構造体です。
 
 生成されたサーバーコンストラクターは、引数としてエンコーダーおよびデコーダーのコンストラクター関数を受理し、任意の実装を提供できるようにします。
 Goa には、JSON、XML、および [gob](https://golang.org/pkg/encoding/gob/) をサポートするデフォルトのエンコーダーとデコーダーが付属しています。
@@ -37,8 +37,8 @@ Goa はリクエストごとにこの関数を呼び出し、異なる HTTP リ�
 ### デフォルトのエンコーダー/デコーダーのコンストラクター
 
 Goa パッケージは、JSON、XML、および gob をエンコード/デコードできるデフォルトの HTTP 
-[エンコーダー](https://godoc.org/goa.design/goa/v3/http#RequestEncoder) / 
-[デコーダー](https://godoc.org/goa.design/goa/v3/http#ResponseEncoder)
+[エンコーダー](https://pkg.go.dev/goa.design/goa/v3/http#RequestEncoder) / 
+[デコーダー](https://pkg.go.dev/goa.design/goa/v3/http#ResponseEncoder)
 のコンストラクターを提供します。 
 ここに、デフォルトの example ジェネレーターが `calc` の例でこれらのコンストラクタをどのように活用しているかを示します：
 
@@ -100,15 +100,15 @@ func(ctx context.Context, w http.ResponseWriter) (goahttp.Encoder, error)
 ```
 
 Goa がコンストラクター関数を呼び出すときに指定されるコンテキストには、
-`Content-Type` リクエストと `Accept` ヘッダーの値が [ContentTypeKey](https://godoc.org/goa.design/goa/v3/http#pkg-constants) と `AcceptTypeKey` が
+`Content-Type` リクエストと `Accept` ヘッダーの値が [ContentTypeKey](https://pkg.go.dev/goa.design/goa/v3/http#pkg-constants) と `AcceptTypeKey` が
 のそれぞれに含まれています。
 これにより、エンコーダー・コンストラクターは、これらのヘッダーの値を調べて、
 クライアントにとって最適なエンコーダーを返すコンテンツタイプ・ネゴシエーションを実装できます。
 
 ## デフォルト・コンテンツタイプの設定
 
-[レスポンス](https://godoc.org/goa.design/goa/v3/dsl#Response) デザイン DSL では、
-[ContentType](https://godoc.org/goa.design/goa/v3/dsl#ContentType) を使用してコンテンツタイプを指定できます。
+[レスポンス](https://pkg.go.dev/goa.design/goa/v3/dsl#Response) デザイン DSL では、
+[ContentType](https://pkg.go.dev/goa.design/goa/v3/dsl#ContentType) を使用してコンテンツタイプを指定できます。
 設定すると、値はリクエストヘッダーで指定されたコンテンツタイプをオーバーライドします。
 これは `Accept` ヘッダーで指定された値をオーバーライドしないことに注意してください。
 これにより、`Accept` ヘッダーがない場合に、レスポンス・エンコーダー コンストラクターが使用するコンテンツタイプを制御できます。

--- a/content/implement/encoding.md
+++ b/content/implement/encoding.md
@@ -12,8 +12,8 @@ parent = "implement"
 
 Goa supports a flexible encoding and decoding strategy that makes it possible to associate arbitrary
 encoders and decoders with given HTTP response and request content types. An encoder is a struct
-that implements the [Encoder](https://godoc.org/goa.design/goa/v3/http#Encoder) interface while a
-decoder implements the [Decoder](https://godoc.org/goa.design/goa/v3/http#Decoder) interface.
+that implements the [Encoder](https://pkg.go.dev/goa.design/goa/v3/http#Encoder) interface while a
+decoder implements the [Decoder](https://pkg.go.dev/goa.design/goa/v3/http#Decoder) interface.
 
 The generated server constructors accept an encoder and a decoder constructor functions as argument
 making it possible to provide arbitrary implementations. Goa comes with default encoders and
@@ -41,8 +41,8 @@ returns an encoder.
 ### Default Encoder and Decoder Constructors
 
 The Goa package provides constructors for a default HTTP
-[encoder](https://godoc.org/goa.design/goa/v3/http#RequestEncoder) and
-[decoder](https://godoc.org/goa.design/goa/v3/http#ResponseEncoder) that can encode and decode JSON,
+[encoder](https://pkg.go.dev/goa.design/goa/v3/http#RequestEncoder) and
+[decoder](https://pkg.go.dev/goa.design/goa/v3/http#ResponseEncoder) that can encode and decode JSON,
 XML and gob. Here is how the default example generator leverages these constructors in the calc
 example:
 
@@ -107,15 +107,15 @@ func(ctx context.Context, w http.ResponseWriter) (goahttp.Encoder, error)
 
 The context given when Goa invokes the constructor function contains both the request `Content-Type`
 and `Accept` header values under the
-[ContentTypeKey](https://godoc.org/goa.design/goa/v3/http#pkg-constants) and `AcceptTypeKey`
+[ContentTypeKey](https://pkg.go.dev/goa.design/goa/v3/http#pkg-constants) and `AcceptTypeKey`
 respectively. This makes it possible for the encoder constructor to implement a form of content type
 negotiation that looks at the values of these headers and return an encoder that is best suited for
 the client.
 
 ## Setting a Default Content Type
 
-The [Response](https://godoc.org/goa.design/goa/v3/dsl#Response) design DSL makes it possible to
-specify a content type using [ContentType](https://godoc.org/goa.design/goa/v3/dsl#ContentType). When
+The [Response](https://pkg.go.dev/goa.design/goa/v3/dsl#Response) design DSL makes it possible to
+specify a content type using [ContentType](https://pkg.go.dev/goa.design/goa/v3/dsl#ContentType). When
 set the value overrides any content type specified in the request headers. Note that this does NOT
 override any value specified in the `Accept` header. This provides a way to control the content type
 used by the response encoder constructor when the `Accept` header is missing.

--- a/content/implement/encoding.md
+++ b/content/implement/encoding.md
@@ -12,8 +12,8 @@ parent = "implement"
 
 Goa supports a flexible encoding and decoding strategy that makes it possible to associate arbitrary
 encoders and decoders with given HTTP response and request content types. An encoder is a struct
-that implements the [Encoder](https://godoc.org/goa.design/goa/http#Encoder) interface while a
-decoder implements the [Decoder](https://godoc.org/goa.design/goa/http#Decoder) interface.
+that implements the [Encoder](https://godoc.org/goa.design/goa/v3/http#Encoder) interface while a
+decoder implements the [Decoder](https://godoc.org/goa.design/goa/v3/http#Decoder) interface.
 
 The generated server constructors accept an encoder and a decoder constructor functions as argument
 making it possible to provide arbitrary implementations. Goa comes with default encoders and
@@ -41,8 +41,8 @@ returns an encoder.
 ### Default Encoder and Decoder Constructors
 
 The Goa package provides constructors for a default HTTP
-[encoder](https://godoc.org/goa.design/goa/http#RequestEncoder) and
-[decoder](https://godoc.org/goa.design/goa/http#ResponseEncoder) that can encode and decode JSON,
+[encoder](https://godoc.org/goa.design/goa/v3/http#RequestEncoder) and
+[decoder](https://godoc.org/goa.design/goa/v3/http#ResponseEncoder) that can encode and decode JSON,
 XML and gob. Here is how the default example generator leverages these constructors in the calc
 example:
 
@@ -107,15 +107,15 @@ func(ctx context.Context, w http.ResponseWriter) (goahttp.Encoder, error)
 
 The context given when Goa invokes the constructor function contains both the request `Content-Type`
 and `Accept` header values under the
-[ContentTypeKey](https://godoc.org/goa.design/goa/http#pkg-constants) and `AcceptTypeKey`
+[ContentTypeKey](https://godoc.org/goa.design/goa/v3/http#pkg-constants) and `AcceptTypeKey`
 respectively. This makes it possible for the encoder constructor to implement a form of content type
 negotiation that looks at the values of these headers and return an encoder that is best suited for
 the client.
 
 ## Setting a Default Content Type
 
-The [Response](https://godoc.org/goa.design/goa/dsl#Response) design DSL makes it possible to
-specify a content type using [ContentType](https://godoc.org/goa.design/goa/dsl#ContentType). When
+The [Response](https://godoc.org/goa.design/goa/v3/dsl#Response) design DSL makes it possible to
+specify a content type using [ContentType](https://godoc.org/goa.design/goa/v3/dsl#ContentType). When
 set the value overrides any content type specified in the request headers. Note that this does NOT
 override any value specified in the `Accept` header. This provides a way to control the content type
 used by the response encoder constructor when the `Accept` header is missing.

--- a/content/implement/middleware.it.md
+++ b/content/implement/middleware.it.md
@@ -7,7 +7,7 @@ name = "Middleware"
 parent = "implement"
 +++
 
-Un [middleware](https://godoc.org/goa.design/goa/v3/middleware) è una funzione che accetta
+Un [middleware](https://pkg.go.dev/goa.design/goa/v3/middleware) è una funzione che accetta
 e ritorna un endpoint o un handler per un transport specifico.
 
 ## Endpoint Middleware
@@ -106,7 +106,7 @@ Questo metodo applica il middleware a tutti i server handler.
 In alternativa il middleware si può applicare a specifici server handler
 allo stesso modo dei middleware endpoint.
 I middleware HTTP possono anche essere montati direttamente sul
-[goa Muxer](https://godoc.org/goa.design/goa/v3/http#Muxer) per eseguirlo su
+[goa Muxer](https://pkg.go.dev/goa.design/goa/v3/http#Muxer) per eseguirlo su
 tutte le richieste a prescindere da qualunque handler.
 
 ```go
@@ -133,40 +133,40 @@ func main() {
 
 Goa ha delle implementazioni di alcuni middleware HTTP:
 
-* [**Logging**](https://godoc.org/goa.design/goa/v3/http/middleware#Log) server
+* [**Logging**](https://pkg.go.dev/goa.design/goa/v3/http/middleware#Log) server
   middleware.
-* [**Request ID**](https://godoc.org/goa.design/goa/v3/http/middleware#RequestID)
+* [**Request ID**](https://pkg.go.dev/goa.design/goa/v3/http/middleware#RequestID)
   server middleware.
-* **Tracing** middleware per [server](https://godoc.org/goa.design/goa/v3/http/middleware#Trace)
-  e [client](https://godoc.org/goa.design/goa/v3/http/middleware#WrapDoer)
-* [**AWS X-Ray**](https://godoc.org/goa.design/goa/v3/http/middleware/xray)
+* **Tracing** middleware per [server](https://pkg.go.dev/goa.design/goa/v3/http/middleware#Trace)
+  e [client](https://pkg.go.dev/goa.design/goa/v3/http/middleware#WrapDoer)
+* [**AWS X-Ray**](https://pkg.go.dev/goa.design/goa/v3/http/middleware/xray)
   middleware per server e client.
 
 ### gRPC Middleware
 
 I middleware gRPC sono specifici per gRPC e consistono di interceptors per server e client.
 
-* [UnaryServerInterceptor](https://godoc.org/google.golang.org/grpc#UnaryServerInterceptor)
-e [UnaryClientInterceptor](https://godoc.org/google.golang.org/grpc#UnaryClientInterceptor)
+* [UnaryServerInterceptor](https://pkg.go.dev/google.golang.org/grpc#UnaryServerInterceptor)
+e [UnaryClientInterceptor](https://pkg.go.dev/google.golang.org/grpc#UnaryClientInterceptor)
 per gli unary endpoint.
-* [StreamServerInterceptor](https://godoc.org/google.golang.org/grpc#StreamServerInterceptor)
-e [StreamClientInterceptor](https://godoc.org/google.golang.org/grpc#StreamClientInterceptor)
+* [StreamServerInterceptor](https://pkg.go.dev/google.golang.org/grpc#StreamServerInterceptor)
+e [StreamClientInterceptor](https://pkg.go.dev/google.golang.org/grpc#StreamClientInterceptor)
 per gli streaming endpoint.
 
 Goa implementa i seguenti middleware gRPC:
 
-* **Logging** server middleware per gli [unary](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryServerLog)
-  e per gli [streaming](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamServerLog)
+* **Logging** server middleware per gli [unary](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#UnaryServerLog)
+  e per gli [streaming](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamServerLog)
   endpoint.
-* **Request ID** server middleware for [unary](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryRequestID)
-  and [streaming](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamRequestID)
+* **Request ID** server middleware for [unary](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#UnaryRequestID)
+  and [streaming](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamRequestID)
   endpoints.
-* [**Stream Canceler**](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamCanceler)
+* [**Stream Canceler**](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamCanceler)
   server middleware.
-* **Tracing** middleware per gli [unary server](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryServerTrace)
-  e [client](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryClientTrace), ma anche
-  [streaming server](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamServerTrace) e [client](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamClientTrace).
-* [**AWS X-Ray**](https://godoc.org/goa.design/goa/v3/grpc/middleware/xray)
+* **Tracing** middleware per gli [unary server](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#UnaryServerTrace)
+  e [client](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#UnaryClientTrace), ma anche
+  [streaming server](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamServerTrace) e [client](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamClientTrace).
+* [**AWS X-Ray**](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware/xray)
   middleware per gli unary e streaming sia client che server.
 
 Usa come riferimento l'[esempio tracing](https://github.com/goadesign/examples/blob/master/tracing)

--- a/content/implement/middleware.it.md
+++ b/content/implement/middleware.it.md
@@ -7,7 +7,7 @@ name = "Middleware"
 parent = "implement"
 +++
 
-Un [middleware](https://godoc.org/goa.design/goa/middleware) è una funzione che accetta
+Un [middleware](https://godoc.org/goa.design/goa/v3/middleware) è una funzione che accetta
 e ritorna un endpoint o un handler per un transport specifico.
 
 ## Endpoint Middleware
@@ -106,7 +106,7 @@ Questo metodo applica il middleware a tutti i server handler.
 In alternativa il middleware si può applicare a specifici server handler
 allo stesso modo dei middleware endpoint.
 I middleware HTTP possono anche essere montati direttamente sul
-[goa Muxer](https://godoc.org/goa.design/goa/http#Muxer) per eseguirlo su
+[goa Muxer](https://godoc.org/goa.design/goa/v3/http#Muxer) per eseguirlo su
 tutte le richieste a prescindere da qualunque handler.
 
 ```go
@@ -133,13 +133,13 @@ func main() {
 
 Goa ha delle implementazioni di alcuni middleware HTTP:
 
-* [**Logging**](https://godoc.org/goa.design/goa/http/middleware#Log) server
+* [**Logging**](https://godoc.org/goa.design/goa/v3/http/middleware#Log) server
   middleware.
-* [**Request ID**](https://godoc.org/goa.design/goa/http/middleware#RequestID)
+* [**Request ID**](https://godoc.org/goa.design/goa/v3/http/middleware#RequestID)
   server middleware.
-* **Tracing** middleware per [server](https://godoc.org/goa.design/goa/http/middleware#Trace)
-  e [client](https://godoc.org/goa.design/goa/http/middleware#WrapDoer)
-* [**AWS X-Ray**](https://godoc.org/goa.design/goa/http/middleware/xray)
+* **Tracing** middleware per [server](https://godoc.org/goa.design/goa/v3/http/middleware#Trace)
+  e [client](https://godoc.org/goa.design/goa/v3/http/middleware#WrapDoer)
+* [**AWS X-Ray**](https://godoc.org/goa.design/goa/v3/http/middleware/xray)
   middleware per server e client.
 
 ### gRPC Middleware
@@ -155,18 +155,18 @@ per gli streaming endpoint.
 
 Goa implementa i seguenti middleware gRPC:
 
-* **Logging** server middleware per gli [unary](https://godoc.org/goa.design/goa/grpc/middleware#UnaryServerLog)
-  e per gli [streaming](https://godoc.org/goa.design/goa/grpc/middleware#StreamServerLog)
+* **Logging** server middleware per gli [unary](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryServerLog)
+  e per gli [streaming](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamServerLog)
   endpoint.
-* **Request ID** server middleware for [unary](https://godoc.org/goa.design/goa/grpc/middleware#UnaryRequestID)
-  and [streaming](https://godoc.org/goa.design/goa/grpc/middleware#StreamRequestID)
+* **Request ID** server middleware for [unary](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryRequestID)
+  and [streaming](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamRequestID)
   endpoints.
-* [**Stream Canceler**](https://godoc.org/goa.design/goa/grpc/middleware#StreamCanceler)
+* [**Stream Canceler**](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamCanceler)
   server middleware.
-* **Tracing** middleware per gli [unary server](https://godoc.org/goa.design/goa/grpc/middleware#UnaryServerTrace)
-  e [client](https://godoc.org/goa.design/goa/grpc/middleware#UnaryClientTrace), ma anche
-  [streaming server](https://godoc.org/goa.design/goa/grpc/middleware#StreamServerTrace) e [client](https://godoc.org/goa.design/goa/grpc/middleware#StreamClientTrace).
-* [**AWS X-Ray**](https://godoc.org/goa.design/goa/grpc/middleware/xray)
+* **Tracing** middleware per gli [unary server](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryServerTrace)
+  e [client](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryClientTrace), ma anche
+  [streaming server](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamServerTrace) e [client](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamClientTrace).
+* [**AWS X-Ray**](https://godoc.org/goa.design/goa/v3/grpc/middleware/xray)
   middleware per gli unary e streaming sia client che server.
 
 Usa come riferimento l'[esempio tracing](https://github.com/goadesign/examples/blob/master/tracing)

--- a/content/implement/middleware.ja.md
+++ b/content/implement/middleware.ja.md
@@ -8,7 +8,7 @@ parent = "implement"
 +++
 
 
-[ミドルウェア](https://godoc.org/goa.design/goa/v3/middleware) は、エンドポイントまたはトランスポート固有のハンドラを受け付けて返す関数で構成されます。
+[ミドルウェア](https://pkg.go.dev/goa.design/goa/v3/middleware) は、エンドポイントまたはトランスポート固有のハンドラを受け付けて返す関数で構成されます。
 
 ## ミドルウェアのエンドポイント
 
@@ -102,7 +102,7 @@ HTTP ミドルウェアは、HTTPサーバー上に生成された `Use` メソ�
 このメソッドは、ミドルウェアをすべてのサーバーハンドラに適用します。
 エンドポイント・ミドルウェアを特定のエンドポイントに適用する方法と同様に、
 ミドルウェアを特定のサーバーハンドラに適用することもできます。
-HTTP ミドルウェアを [goa Muxer](https://godoc.org/goa.design/goa/v3/http#Muxer) に直接マウントして、
+HTTP ミドルウェアを [goa Muxer](https://pkg.go.dev/goa.design/goa/v3/http#Muxer) に直接マウントして、
 ハンドラとは無関係にすべてのリクエストでミドルウェアを実行することもできます。
 
 ```go
@@ -128,31 +128,31 @@ func main() {
 ```
 Goaには、次のような HTTP ミドルウェアの実装があります。
 
-* [**ロギング**](https://godoc.org/goa.design/goa/v3/http/middleware#Log) サーバー ミドルウエア。
-* [**リクエスト ID**](https://godoc.org/goa.design/goa/v3/http/middleware#RequestID) サーバー ミドルウェア。
-* [サーバー](https://godoc.org/goa.design/goa/v3/http/middleware#Trace)および[クライアント](https://godoc.org/goa.design/goa/v3/http/middleware#WrapDoer)用の **トラッキング** ミドルウエア。
-* サーバーおよびクライアント用の [**AWS X-Ray**](https://godoc.org/goa.design/goa/v3/http/middleware/xray) ミドルウェア。
+* [**ロギング**](https://pkg.go.dev/goa.design/goa/v3/http/middleware#Log) サーバー ミドルウエア。
+* [**リクエスト ID**](https://pkg.go.dev/goa.design/goa/v3/http/middleware#RequestID) サーバー ミドルウェア。
+* [サーバー](https://pkg.go.dev/goa.design/goa/v3/http/middleware#Trace)および[クライアント](https://pkg.go.dev/goa.design/goa/v3/http/middleware#WrapDoer)用の **トラッキング** ミドルウエア。
+* サーバーおよびクライアント用の [**AWS X-Ray**](https://pkg.go.dev/goa.design/goa/v3/http/middleware/xray) ミドルウェア。
 
 ### gRPC ミドルウェア
 
 gRPC ミドルウェアは gRPC トランスポート固有であり、サーバーとクライアントの gRPC インターセプターで構成されます。
 
-* 単項エンドポイントに対して、[UnaryServerInterceptor](https://godoc.org/google.golang.org/grpc#UnaryServerInterceptor)
-と [UnaryClientInterceptor](https://godoc.org/google.golang.org/grpc#UnaryClientInterceptor)
-* ストリーミング エンドポイントに対して、[StreamServerInterceptor](https://godoc.org/google.golang.org/grpc#StreamServerInterceptor)
-と [StreamClientInterceptor](https://godoc.org/google.golang.org/grpc#StreamClientInterceptor)
+* 単項エンドポイントに対して、[UnaryServerInterceptor](https://pkg.go.dev/google.golang.org/grpc#UnaryServerInterceptor)
+と [UnaryClientInterceptor](https://pkg.go.dev/google.golang.org/grpc#UnaryClientInterceptor)
+* ストリーミング エンドポイントに対して、[StreamServerInterceptor](https://pkg.go.dev/google.golang.org/grpc#StreamServerInterceptor)
+と [StreamClientInterceptor](https://pkg.go.dev/google.golang.org/grpc#StreamClientInterceptor)
 
 Goa は次の gRPC ミドルウェアを実装しています：
 
-* [単項](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryServerLog)および[ストリーミング](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamServerLog)エンドポイント用の **ロギング** サーバー ミドルウエア。
+* [単項](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#UnaryServerLog)および[ストリーミング](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamServerLog)エンドポイント用の **ロギング** サーバー ミドルウエア。
 
-* [単項](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryRequestID)および[ストリーミング](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamRequestID)エンドポイント用の **リクエスト ID** サーバー ミドルウェア
+* [単項](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#UnaryRequestID)および[ストリーミング](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamRequestID)エンドポイント用の **リクエスト ID** サーバー ミドルウェア
 
-* [**ストリーム キャンセラー**](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamCanceler)サーバー ミドルウェア。
-* [単項サーバー](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryServerTrace)および
-  [クライアント](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryClientTrace)、および
-  [ストリーミング サーバー](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamServerTrace)および
-  [クライアント](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamClientTrace)用の **トレーシング**ミドルウエア。  
-* 単項およびストリーミングのクライアント・サーバー用の [**AWS X-Ray**](https://godoc.org/goa.design/goa/v3/grpc/middleware/xray) ミドルウエア。
+* [**ストリーム キャンセラー**](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamCanceler)サーバー ミドルウェア。
+* [単項サーバー](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#UnaryServerTrace)および
+  [クライアント](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#UnaryClientTrace)、および
+  [ストリーミング サーバー](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamServerTrace)および
+  [クライアント](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamClientTrace)用の **トレーシング**ミドルウエア。  
+* 単項およびストリーミングのクライアント・サーバー用の [**AWS X-Ray**](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware/xray) ミドルウエア。
 
 gRPC ミドルウェアを gRPC エンドポイントに適用する方法については、[トレースの例](https://github.com/goadesign/examples/blob/master/tracing)を参照してください。

--- a/content/implement/middleware.ja.md
+++ b/content/implement/middleware.ja.md
@@ -8,7 +8,7 @@ parent = "implement"
 +++
 
 
-[ミドルウェア](https://godoc.org/goa.design/goa/middleware) は、エンドポイントまたはトランスポート固有のハンドラを受け付けて返す関数で構成されます。
+[ミドルウェア](https://godoc.org/goa.design/goa/v3/middleware) は、エンドポイントまたはトランスポート固有のハンドラを受け付けて返す関数で構成されます。
 
 ## ミドルウェアのエンドポイント
 
@@ -102,7 +102,7 @@ HTTP ミドルウェアは、HTTPサーバー上に生成された `Use` メソ�
 このメソッドは、ミドルウェアをすべてのサーバーハンドラに適用します。
 エンドポイント・ミドルウェアを特定のエンドポイントに適用する方法と同様に、
 ミドルウェアを特定のサーバーハンドラに適用することもできます。
-HTTP ミドルウェアを [goa Muxer](https://godoc.org/goa.design/goa/http#Muxer) に直接マウントして、
+HTTP ミドルウェアを [goa Muxer](https://godoc.org/goa.design/goa/v3/http#Muxer) に直接マウントして、
 ハンドラとは無関係にすべてのリクエストでミドルウェアを実行することもできます。
 
 ```go
@@ -128,10 +128,10 @@ func main() {
 ```
 Goaには、次のような HTTP ミドルウェアの実装があります。
 
-* [**ロギング**](https://godoc.org/goa.design/goa/http/middleware#Log) サーバー ミドルウエア。
-* [**リクエスト ID**](https://godoc.org/goa.design/goa/http/middleware#RequestID) サーバー ミドルウェア。
-* [サーバー](https://godoc.org/goa.design/goa/http/middleware#Trace)および[クライアント](https://godoc.org/goa.design/goa/http/middleware#WrapDoer)用の **トラッキング** ミドルウエア。
-* サーバーおよびクライアント用の [**AWS X-Ray**](https://godoc.org/goa.design/goa/http/middleware/xray) ミドルウェア。
+* [**ロギング**](https://godoc.org/goa.design/goa/v3/http/middleware#Log) サーバー ミドルウエア。
+* [**リクエスト ID**](https://godoc.org/goa.design/goa/v3/http/middleware#RequestID) サーバー ミドルウェア。
+* [サーバー](https://godoc.org/goa.design/goa/v3/http/middleware#Trace)および[クライアント](https://godoc.org/goa.design/goa/v3/http/middleware#WrapDoer)用の **トラッキング** ミドルウエア。
+* サーバーおよびクライアント用の [**AWS X-Ray**](https://godoc.org/goa.design/goa/v3/http/middleware/xray) ミドルウェア。
 
 ### gRPC ミドルウェア
 
@@ -144,15 +144,15 @@ gRPC ミドルウェアは gRPC トランスポート固有であり、サーバ
 
 Goa は次の gRPC ミドルウェアを実装しています：
 
-* [単項](https://godoc.org/goa.design/goa/grpc/middleware#UnaryServerLog)および[ストリーミング](https://godoc.org/goa.design/goa/grpc/middleware#StreamServerLog)エンドポイント用の **ロギング** サーバー ミドルウエア。
+* [単項](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryServerLog)および[ストリーミング](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamServerLog)エンドポイント用の **ロギング** サーバー ミドルウエア。
 
-* [単項](https://godoc.org/goa.design/goa/grpc/middleware#UnaryRequestID)および[ストリーミング](https://godoc.org/goa.design/goa/grpc/middleware#StreamRequestID)エンドポイント用の **リクエスト ID** サーバー ミドルウェア
+* [単項](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryRequestID)および[ストリーミング](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamRequestID)エンドポイント用の **リクエスト ID** サーバー ミドルウェア
 
-* [**ストリーム キャンセラー**](https://godoc.org/goa.design/goa/grpc/middleware#StreamCanceler)サーバー ミドルウェア。
-* [単項サーバー](https://godoc.org/goa.design/goa/grpc/middleware#UnaryServerTrace)および
-  [クライアント](https://godoc.org/goa.design/goa/grpc/middleware#UnaryClientTrace)、および
-  [ストリーミング サーバー](https://godoc.org/goa.design/goa/grpc/middleware#StreamServerTrace)および
-  [クライアント](https://godoc.org/goa.design/goa/grpc/middleware#StreamClientTrace)用の **トレーシング**ミドルウエア。  
-* 単項およびストリーミングのクライアント・サーバー用の [**AWS X-Ray**](https://godoc.org/goa.design/goa/grpc/middleware/xray) ミドルウエア。
+* [**ストリーム キャンセラー**](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamCanceler)サーバー ミドルウェア。
+* [単項サーバー](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryServerTrace)および
+  [クライアント](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryClientTrace)、および
+  [ストリーミング サーバー](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamServerTrace)および
+  [クライアント](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamClientTrace)用の **トレーシング**ミドルウエア。  
+* 単項およびストリーミングのクライアント・サーバー用の [**AWS X-Ray**](https://godoc.org/goa.design/goa/v3/grpc/middleware/xray) ミドルウエア。
 
 gRPC ミドルウェアを gRPC エンドポイントに適用する方法については、[トレースの例](https://github.com/goadesign/examples/blob/master/tracing)を参照してください。

--- a/content/implement/middleware.md
+++ b/content/implement/middleware.md
@@ -7,7 +7,7 @@ name = "Middleware"
 parent = "implement"
 +++
 
-A [middleware](https://godoc.org/goa.design/goa/middleware) consists of a function
+A [middleware](https://godoc.org/goa.design/goa/v3/middleware) consists of a function
 that accepts and returns a endpoint or a transport specific handler.
 
 ## Endpoint Middlewares
@@ -107,7 +107,7 @@ server. This method applies the middleware to all the server handlers.
 Alternatively the middleware may be applied to a specific server handler
 similarly to how endpoint middlewares may be applied to a specific endpoint.
 HTTP middlewares may also be mounted directly on the
-[goa Muxer](https://godoc.org/goa.design/goa/http#Muxer) to execute the
+[goa Muxer](https://godoc.org/goa.design/goa/v3/http#Muxer) to execute the
 middleware on all requests independently of any handler.
 
 ```go
@@ -134,13 +134,13 @@ func main() {
 
 Goa has implementations for the following HTTP middlewares:
 
-* [**Logging**](https://godoc.org/goa.design/goa/http/middleware#Log) server
+* [**Logging**](https://godoc.org/goa.design/goa/v3/http/middleware#Log) server
   middleware.
-* [**Request ID**](https://godoc.org/goa.design/goa/http/middleware#RequestID)
+* [**Request ID**](https://godoc.org/goa.design/goa/v3/http/middleware#RequestID)
   server middleware.
-* **Tracing** middleware for [server](https://godoc.org/goa.design/goa/http/middleware#Trace)
-  and [client](https://godoc.org/goa.design/goa/http/middleware#WrapDoer)
-* [**AWS X-Ray**](https://godoc.org/goa.design/goa/http/middleware/xray)
+* **Tracing** middleware for [server](https://godoc.org/goa.design/goa/v3/http/middleware#Trace)
+  and [client](https://godoc.org/goa.design/goa/v3/http/middleware#WrapDoer)
+* [**AWS X-Ray**](https://godoc.org/goa.design/goa/v3/http/middleware/xray)
   middleware for server and client.
 
 ### gRPC Middleware
@@ -157,18 +157,18 @@ for streaming endpoints.
 
 Goa implements the following gRPC middlewares:
 
-* **Logging** server middleware for [unary](https://godoc.org/goa.design/goa/grpc/middleware#UnaryServerLog)
-  and [streaming](https://godoc.org/goa.design/goa/grpc/middleware#StreamServerLog)
+* **Logging** server middleware for [unary](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryServerLog)
+  and [streaming](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamServerLog)
   endpoints.
-* **Request ID** server middleware for [unary](https://godoc.org/goa.design/goa/grpc/middleware#UnaryRequestID)
-  and [streaming](https://godoc.org/goa.design/goa/grpc/middleware#StreamRequestID)
+* **Request ID** server middleware for [unary](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryRequestID)
+  and [streaming](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamRequestID)
   endpoints.
-* [**Stream Canceler**](https://godoc.org/goa.design/goa/grpc/middleware#StreamCanceler)
+* [**Stream Canceler**](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamCanceler)
   server middleware.
-* **Tracing** middleware for [unary server](https://godoc.org/goa.design/goa/grpc/middleware#UnaryServerTrace)
-  and [client](https://godoc.org/goa.design/goa/grpc/middleware#UnaryClientTrace)
-  and [streaming server](https://godoc.org/goa.design/goa/grpc/middleware#StreamServerTrace) and [client](https://godoc.org/goa.design/goa/grpc/middleware#StreamClientTrace).
-* [**AWS X-Ray**](https://godoc.org/goa.design/goa/grpc/middleware/xray)
+* **Tracing** middleware for [unary server](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryServerTrace)
+  and [client](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryClientTrace)
+  and [streaming server](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamServerTrace) and [client](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamClientTrace).
+* [**AWS X-Ray**](https://godoc.org/goa.design/goa/v3/grpc/middleware/xray)
   middleware for unary and streaming client and server.
 
 Refer to the [tracing example](https://github.com/goadesign/examples/blob/master/tracing)

--- a/content/implement/middleware.md
+++ b/content/implement/middleware.md
@@ -7,7 +7,7 @@ name = "Middleware"
 parent = "implement"
 +++
 
-A [middleware](https://godoc.org/goa.design/goa/v3/middleware) consists of a function
+A [middleware](https://pkg.go.dev/goa.design/goa/v3/middleware) consists of a function
 that accepts and returns a endpoint or a transport specific handler.
 
 ## Endpoint Middlewares
@@ -107,7 +107,7 @@ server. This method applies the middleware to all the server handlers.
 Alternatively the middleware may be applied to a specific server handler
 similarly to how endpoint middlewares may be applied to a specific endpoint.
 HTTP middlewares may also be mounted directly on the
-[goa Muxer](https://godoc.org/goa.design/goa/v3/http#Muxer) to execute the
+[goa Muxer](https://pkg.go.dev/goa.design/goa/v3/http#Muxer) to execute the
 middleware on all requests independently of any handler.
 
 ```go
@@ -134,13 +134,13 @@ func main() {
 
 Goa has implementations for the following HTTP middlewares:
 
-* [**Logging**](https://godoc.org/goa.design/goa/v3/http/middleware#Log) server
+* [**Logging**](https://pkg.go.dev/goa.design/goa/v3/http/middleware#Log) server
   middleware.
-* [**Request ID**](https://godoc.org/goa.design/goa/v3/http/middleware#RequestID)
+* [**Request ID**](https://pkg.go.dev/goa.design/goa/v3/http/middleware#RequestID)
   server middleware.
-* **Tracing** middleware for [server](https://godoc.org/goa.design/goa/v3/http/middleware#Trace)
-  and [client](https://godoc.org/goa.design/goa/v3/http/middleware#WrapDoer)
-* [**AWS X-Ray**](https://godoc.org/goa.design/goa/v3/http/middleware/xray)
+* **Tracing** middleware for [server](https://pkg.go.dev/goa.design/goa/v3/http/middleware#Trace)
+  and [client](https://pkg.go.dev/goa.design/goa/v3/http/middleware#WrapDoer)
+* [**AWS X-Ray**](https://pkg.go.dev/goa.design/goa/v3/http/middleware/xray)
   middleware for server and client.
 
 ### gRPC Middleware
@@ -148,27 +148,27 @@ Goa has implementations for the following HTTP middlewares:
 gRPC middlewares are gRPC transport specific and consist of server and client
 gRPC interceptors.
 
-* [UnaryServerInterceptor](https://godoc.org/google.golang.org/grpc#UnaryServerInterceptor)
-and [UnaryClientInterceptor](https://godoc.org/google.golang.org/grpc#UnaryClientInterceptor)
+* [UnaryServerInterceptor](https://pkg.go.dev/google.golang.org/grpc#UnaryServerInterceptor)
+and [UnaryClientInterceptor](https://pkg.go.dev/google.golang.org/grpc#UnaryClientInterceptor)
 for unary endpoints.
-* [StreamServerInterceptor](https://godoc.org/google.golang.org/grpc#StreamServerInterceptor)
-and [StreamClientInterceptor](https://godoc.org/google.golang.org/grpc#StreamClientInterceptor)
+* [StreamServerInterceptor](https://pkg.go.dev/google.golang.org/grpc#StreamServerInterceptor)
+and [StreamClientInterceptor](https://pkg.go.dev/google.golang.org/grpc#StreamClientInterceptor)
 for streaming endpoints.
 
 Goa implements the following gRPC middlewares:
 
-* **Logging** server middleware for [unary](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryServerLog)
-  and [streaming](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamServerLog)
+* **Logging** server middleware for [unary](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#UnaryServerLog)
+  and [streaming](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamServerLog)
   endpoints.
-* **Request ID** server middleware for [unary](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryRequestID)
-  and [streaming](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamRequestID)
+* **Request ID** server middleware for [unary](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#UnaryRequestID)
+  and [streaming](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamRequestID)
   endpoints.
-* [**Stream Canceler**](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamCanceler)
+* [**Stream Canceler**](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamCanceler)
   server middleware.
-* **Tracing** middleware for [unary server](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryServerTrace)
-  and [client](https://godoc.org/goa.design/goa/v3/grpc/middleware#UnaryClientTrace)
-  and [streaming server](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamServerTrace) and [client](https://godoc.org/goa.design/goa/v3/grpc/middleware#StreamClientTrace).
-* [**AWS X-Ray**](https://godoc.org/goa.design/goa/v3/grpc/middleware/xray)
+* **Tracing** middleware for [unary server](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#UnaryServerTrace)
+  and [client](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#UnaryClientTrace)
+  and [streaming server](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamServerTrace) and [client](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware#StreamClientTrace).
+* [**AWS X-Ray**](https://pkg.go.dev/goa.design/goa/v3/grpc/middleware/xray)
   middleware for unary and streaming client and server.
 
 Refer to the [tracing example](https://github.com/goadesign/examples/blob/master/tracing)

--- a/content/implement/streaming.it.md
+++ b/content/implement/streaming.it.md
@@ -18,7 +18,7 @@ cosa procuce il generatore, sia di transport-indipendent che di transport-specif
 
 ## Progettazione
 
-Il DSL [StreamingResult](https://godoc.org/goa.design/goa/v3/dsl#StreamingResult)
+Il DSL [StreamingResult](https://pkg.go.dev/goa.design/goa/v3/dsl#StreamingResult)
 può essere definito su un metodo per impostare un endpoint che produce sequenze di 
 risultati. Il DSL `StreamingResult` ha una sintassi simile a quella del DSL `Result`.
 `StreamingResult` e `Result` sono mutualmente esclusivi: solo uno dei due può essere 
@@ -87,7 +87,7 @@ func (s *cellarSvc) List(ctx context.Context, stream cellarsvc.ListServerStream)
 ### Streaming via HTTP
 
 Streaming in HTTP sfrutta i websockets. goa usa i
-[gorilla websocket](https://godoc.org/github.com/gorilla/websocket) per
+[gorilla websocket](https://pkg.go.dev/github.com/gorilla/websocket) per
 implementare le interfacce di streaming sia di server che di client.
 
 Il package `goa http` fornisce due interfacce Upgrader e Dialer e un configuratore

--- a/content/implement/streaming.it.md
+++ b/content/implement/streaming.it.md
@@ -18,7 +18,7 @@ cosa procuce il generatore, sia di transport-indipendent che di transport-specif
 
 ## Progettazione
 
-Il DSL [StreamingResult](https://godoc.org/goa.design/goa/dsl#StreamingResult)
+Il DSL [StreamingResult](https://godoc.org/goa.design/goa/v3/dsl#StreamingResult)
 può essere definito su un metodo per impostare un endpoint che produce sequenze di 
 risultati. Il DSL `StreamingResult` ha una sintassi simile a quella del DSL `Result`.
 `StreamingResult` e `Result` sono mutualmente esclusivi: solo uno dei due può essere 

--- a/content/implement/streaming.ja.md
+++ b/content/implement/streaming.ja.md
@@ -15,7 +15,7 @@ Goa を使用すると、エンドポイントがペイロードを受信して�
 
 ## デザイン
 
-[StreamingResult DSL](https://godoc.org/goa.design/goa/v3/dsl#StreamingResult) は、結果のシーケンスをストリーミングするエンドポイントを設定するメソッドで定義できます。
+[StreamingResult DSL](https://pkg.go.dev/goa.design/goa/v3/dsl#StreamingResult) は、結果のシーケンスをストリーミングするエンドポイントを設定するメソッドで定義できます。
 `StreamingResult` DSL は `Result` DSL と似た構文を持ちます。
 `StreamingResult` と `Result` は相互に排他的です：指定された `Method` 式で使えるのはそのうちの1つだけです。
 
@@ -77,7 +77,7 @@ func (s *cellarSvc) List(ctx context.Context, stream cellarsvc.ListServerStream)
 ### HTTP 経由のストリーミング
 
 HTTP でのストリーミングは Web ソケットを利用します。
-Goa は [gorilla websocket](https://godoc.org/github.com/gorilla/websocket)
+Goa は [gorilla websocket](https://pkg.go.dev/github.com/gorilla/websocket)
 を使用して、サーバーとクライアントのストリーミングインターフェイスを実装します。
 
 `Goa http` パッケージは、Web ソケットの Upgrader および Dialer インターフェースと、

--- a/content/implement/streaming.ja.md
+++ b/content/implement/streaming.ja.md
@@ -15,7 +15,7 @@ Goa を使用すると、エンドポイントがペイロードを受信して�
 
 ## デザイン
 
-[StreamingResult DSL](https://godoc.org/goa.design/goa/dsl#StreamingResult) は、結果のシーケンスをストリーミングするエンドポイントを設定するメソッドで定義できます。
+[StreamingResult DSL](https://godoc.org/goa.design/goa/v3/dsl#StreamingResult) は、結果のシーケンスをストリーミングするエンドポイントを設定するメソッドで定義できます。
 `StreamingResult` DSL は `Result` DSL と似た構文を持ちます。
 `StreamingResult` と `Result` は相互に排他的です：指定された `Method` 式で使えるのはそのうちの1つだけです。
 

--- a/content/implement/streaming.md
+++ b/content/implement/streaming.md
@@ -18,7 +18,7 @@ generator produces for the transport-independent and transport-dependent code.
 
 ## Design
 
-The [StreamingResult DSL](https://godoc.org/goa.design/goa/dsl#StreamingResult)
+The [StreamingResult DSL](https://godoc.org/goa.design/goa/v3/dsl#StreamingResult)
 can be defined on a method to setup an endpoint that streams a sequence of
 results. `StreamingResult` DSL has a similar syntax to the `Result` DSL.
 `StreamingResult` and `Result` are mutually exclusive: only one of then may be

--- a/content/implement/streaming.md
+++ b/content/implement/streaming.md
@@ -18,7 +18,7 @@ generator produces for the transport-independent and transport-dependent code.
 
 ## Design
 
-The [StreamingResult DSL](https://godoc.org/goa.design/goa/v3/dsl#StreamingResult)
+The [StreamingResult DSL](https://pkg.go.dev/goa.design/goa/v3/dsl#StreamingResult)
 can be defined on a method to setup an endpoint that streams a sequence of
 results. `StreamingResult` DSL has a similar syntax to the `Result` DSL.
 `StreamingResult` and `Result` are mutually exclusive: only one of then may be
@@ -86,7 +86,7 @@ func (s *cellarSvc) List(ctx context.Context, stream cellarsvc.ListServerStream)
 ### Streaming via HTTP
 
 Streaming in HTTP leverages websockets. goa uses
-[gorilla websocket](https://godoc.org/github.com/gorilla/websocket) to
+[gorilla websocket](https://pkg.go.dev/github.com/gorilla/websocket) to
 implement the server and client streaming interfaces.
 
 The `goa http` package provides a websocket Upgrader and Dialer interface

--- a/content/learn/getting-started.it.md
+++ b/content/learn/getting-started.it.md
@@ -106,7 +106,7 @@ Infine, il design espone un file server HTTP che fornisce le specifiche
 
 >Questo esempio copre solo una frazione di cosa Goa può fare. Puoi trovare più esempi
 >nella [repository apposita](https://github.com/goadesign/examples). La
->[documentazione del DSL Goa](https://godoc.org/goa.design/goa/dsl) elenca tutti i DSL
+>[documentazione del DSL Goa](https://godoc.org/goa.design/goa/v3/dsl) elenca tutti i DSL
 >insieme a una loro descrizione e uno o più esempi di utilizzo.
 
 ## Generazione di codice
@@ -235,7 +235,7 @@ func (s *calcsrvc) Multiply(ctx context.Context, p *calc.MultiplyPayload) (res i
 }
 ```
 
-Il comando `goa example` usa la [DSL Server](https://godoc.org/goa.design/goa/dsl#Server)
+Il comando `goa example` usa la [DSL Server](https://godoc.org/goa.design/goa/v3/dsl#Server)
 opzionalmente definita nel design per generare codice compilabile per server e client.
 Lo costruisce nella cartella `cmd` per ogni `Server` specificato nel 
 design. Qui abbiamo definito un unico server `calc` che ascolta richieste HTTP sulla porta
@@ -282,5 +282,5 @@ Questo esempio copre solo le basi di Goa, la
 <a href="../../design/overview">Panoramica</a> copre molti altri aspetti. Magari vuoi anche
 dare un'occhiata agli altri [esempi](https://github.com/goadesign/examples). 
 Infine, la
-[GoDoc](https://godoc.org/goa.design/goa/dsl) del package DSL include molti snippet di codice
+[GoDoc](https://godoc.org/goa.design/goa/v3/dsl) del package DSL include molti snippet di codice
 e fornisce un grande riferimento nella progettazione.

--- a/content/learn/getting-started.it.md
+++ b/content/learn/getting-started.it.md
@@ -106,7 +106,7 @@ Infine, il design espone un file server HTTP che fornisce le specifiche
 
 >Questo esempio copre solo una frazione di cosa Goa può fare. Puoi trovare più esempi
 >nella [repository apposita](https://github.com/goadesign/examples). La
->[documentazione del DSL Goa](https://godoc.org/goa.design/goa/v3/dsl) elenca tutti i DSL
+>[documentazione del DSL Goa](https://pkg.go.dev/goa.design/goa/v3/dsl) elenca tutti i DSL
 >insieme a una loro descrizione e uno o più esempi di utilizzo.
 
 ## Generazione di codice
@@ -172,7 +172,7 @@ gen
 
 La cartella `gen` contiene la sotto-cartella `calc` dovesi trova il codice
 transport-independent del servizio. Il file `endpoints.go` crea un
-[Goa endpoint](https://godoc.org/goa.design/goa#Endpoint) che espone
+[Goa endpoint](https://pkg.go.dev/goa.design/goa#Endpoint) che espone
 il codice transport-agnostic ai livelli di trasporto.
 
 La cartella `grpc` contiene il protocol buffer file (`pb/calc.proto`) che
@@ -235,7 +235,7 @@ func (s *calcsrvc) Multiply(ctx context.Context, p *calc.MultiplyPayload) (res i
 }
 ```
 
-Il comando `goa example` usa la [DSL Server](https://godoc.org/goa.design/goa/v3/dsl#Server)
+Il comando `goa example` usa la [DSL Server](https://pkg.go.dev/goa.design/goa/v3/dsl#Server)
 opzionalmente definita nel design per generare codice compilabile per server e client.
 Lo costruisce nella cartella `cmd` per ogni `Server` specificato nel 
 design. Qui abbiamo definito un unico server `calc` che ascolta richieste HTTP sulla porta
@@ -282,5 +282,5 @@ Questo esempio copre solo le basi di Goa, la
 <a href="../../design/overview">Panoramica</a> copre molti altri aspetti. Magari vuoi anche
 dare un'occhiata agli altri [esempi](https://github.com/goadesign/examples). 
 Infine, la
-[GoDoc](https://godoc.org/goa.design/goa/v3/dsl) del package DSL include molti snippet di codice
+[GoDoc](https://pkg.go.dev/goa.design/goa/v3/dsl) del package DSL include molti snippet di codice
 e fornisce un grande riferimento nella progettazione.

--- a/content/learn/getting-started.ja.md
+++ b/content/learn/getting-started.ja.md
@@ -102,7 +102,7 @@ HTTP トランスポートと gRPC トランスポートのいずれも、レス
 
 >上記の例は、Goa ができることのほんの一部です。
 >もっと多くの例を [examples リポジトリ](https://github.com/goadesign/examples)で見つけることが出来るでしょう。
->[Goa DSL パッケージの GoDoc](https://godoc.org/goa.design/goa/v3/dsl) では、すべての DSL キーワードをそれぞれの説明と使用例付きで一覧できます。
+>[Goa DSL パッケージの GoDoc](https://pkg.go.dev/goa.design/goa/v3/dsl) では、すべての DSL キーワードをそれぞれの説明と使用例付きで一覧できます。
 
 ## コード生成
 
@@ -166,7 +166,7 @@ gen
 ```
 
 `gen` ディレクトリはトランスポートに依存しないサービスコードを格納する `calc` サブディレクトリを含みます。
-`endpoints.go` ファイルはトランスポートに依存しないサービスコードをトランスポート層に公開する [Goa エンドポイント](https://godoc.org/goa.design/goa#Endpoint) を作成します。
+`endpoints.go` ファイルはトランスポートに依存しないサービスコードをトランスポート層に公開する [Goa エンドポイント](https://pkg.go.dev/goa.design/goa#Endpoint) を作成します。
 
 `grpc` ディレクトリには、 `protoc` [ツール](https://developers.google.com/protocol-buffers/docs/proto3#generating)の出力(pb/calc.pb.go) はもちろん、 `calc` gRPC サービスを記述するプロトコルバッファファイル (pb/calc.proto) も含まれています。
 このディレクトリには、リクエストとレスポンスをエンコード・デコードするためのロジックとともに、protoc で生成された gRPC サーバーとクライアントのコードを接続するサーバーとクライアントのコードも含まれています。
@@ -220,7 +220,7 @@ func (s *calcsrvc) Multiply(ctx context.Context, p *calc.MultiplyPayload) (res i
 }
 ```
 
-`goa example` コマンドは、デザインに記述されている任意の [Server DSL](https://godoc.org/goa.design/goa/v3/dsl#Server) を使用して、ビルド可能なサーバーファイルとクライアントファイルを生成します。
+`goa example` コマンドは、デザインに記述されている任意の [Server DSL](https://pkg.go.dev/goa.design/goa/v3/dsl#Server) を使用して、ビルド可能なサーバーファイルとクライアントファイルを生成します。
 デザインで指定されたそれぞれの `Server` DSL に対して `cmd` に一つのディレクトリを構築します。
 ここではポート 8000 で HTTP リクエストを待ち受けるサーバー `calc` をひとつ定義しました。
 
@@ -259,4 +259,4 @@ API デザインに焦点を当てることができるため、実装を開始�
 
 この例は Goa の基本にのみ触れています。デザインの<a href="../design/overview">デザイン概要</a> では他の多くの側面もカバーしています。
 ぜひ他の[例](https://github.com/goadesign/examples)も見てみてください。
-最後に、DSL パッケージ [GoDoc](https://godoc.org/goa.design/goa/v3/dsl) には多くのコードスニペットが含まれており、デザインを作成する際の参考資料として役立ちます。
+最後に、DSL パッケージ [GoDoc](https://pkg.go.dev/goa.design/goa/v3/dsl) には多くのコードスニペットが含まれており、デザインを作成する際の参考資料として役立ちます。

--- a/content/learn/getting-started.ja.md
+++ b/content/learn/getting-started.ja.md
@@ -102,7 +102,7 @@ HTTP トランスポートと gRPC トランスポートのいずれも、レス
 
 >上記の例は、Goa ができることのほんの一部です。
 >もっと多くの例を [examples リポジトリ](https://github.com/goadesign/examples)で見つけることが出来るでしょう。
->[Goa DSL パッケージの GoDoc](https://godoc.org/goa.design/goa/dsl) では、すべての DSL キーワードをそれぞれの説明と使用例付きで一覧できます。
+>[Goa DSL パッケージの GoDoc](https://godoc.org/goa.design/goa/v3/dsl) では、すべての DSL キーワードをそれぞれの説明と使用例付きで一覧できます。
 
 ## コード生成
 
@@ -220,7 +220,7 @@ func (s *calcsrvc) Multiply(ctx context.Context, p *calc.MultiplyPayload) (res i
 }
 ```
 
-`goa example` コマンドは、デザインに記述されている任意の [Server DSL](https://godoc.org/goa.design/goa/dsl#Server) を使用して、ビルド可能なサーバーファイルとクライアントファイルを生成します。
+`goa example` コマンドは、デザインに記述されている任意の [Server DSL](https://godoc.org/goa.design/goa/v3/dsl#Server) を使用して、ビルド可能なサーバーファイルとクライアントファイルを生成します。
 デザインで指定されたそれぞれの `Server` DSL に対して `cmd` に一つのディレクトリを構築します。
 ここではポート 8000 で HTTP リクエストを待ち受けるサーバー `calc` をひとつ定義しました。
 
@@ -259,4 +259,4 @@ API デザインに焦点を当てることができるため、実装を開始�
 
 この例は Goa の基本にのみ触れています。デザインの<a href="../design/overview">デザイン概要</a> では他の多くの側面もカバーしています。
 ぜひ他の[例](https://github.com/goadesign/examples)も見てみてください。
-最後に、DSL パッケージ [GoDoc](https://godoc.org/goa.design/goa/dsl) には多くのコードスニペットが含まれており、デザインを作成する際の参考資料として役立ちます。
+最後に、DSL パッケージ [GoDoc](https://godoc.org/goa.design/goa/v3/dsl) には多くのコードスニペットが含まれており、デザインを作成する際の参考資料として役立ちます。

--- a/content/learn/getting-started.md
+++ b/content/learn/getting-started.md
@@ -110,7 +110,7 @@ generated [OpenAPI](https://www.openapis.org/) specification.
 
 >The example above covers a fraction of what Goa can do. More examples can be
 >found in the [examples repo](https://github.com/goadesign/examples). The
->[Goa DSL package GoDoc](https://godoc.org/goa.design/goa/v3/dsl) lists all the DSL
+>[Goa DSL package GoDoc](https://pkg.go.dev/goa.design/goa/v3/dsl) lists all the DSL
 >keywords together with a description and example usage for each.
 
 ## Code Generation
@@ -176,7 +176,7 @@ gen
 
 The `gen` directory contains the `calc` sub-directory which houses the
 transport-independent service code. The `endpoints.go` file creates a
-[Goa endpoint](https://godoc.org/goa.design/goa#Endpoint) which exposes
+[Goa endpoint](https://pkg.go.dev/goa.design/goa#Endpoint) which exposes
 the transport-agnostic service code to the transport layers.
 
 The `grpc` directory contains the protocol buffer file (`pb/calc.proto`) that
@@ -240,7 +240,7 @@ func (s *calcsrvc) Multiply(ctx context.Context, p *calc.MultiplyPayload) (res i
 ```
 
 The `goa example` command uses the optional
-[Server DSL](https://godoc.org/goa.design/goa/v3/dsl#Server)
+[Server DSL](https://pkg.go.dev/goa.design/goa/v3/dsl#Server)
 described in the design to generate buildable server and client files.
 It builds one directory in `cmd` for each `Server` DSL specified in the
 design. Here we defined a single server `calc` which listens for HTTP
@@ -348,7 +348,7 @@ calc service using a non-integer value for example).
 
 This example only touches on the basics of Goa, the <a href="../../design/overview">design overview</a> covers many other aspects.
 
-You may also want to take a look at the other [examples](https://github.com/goadesign/examples). The DSL package [GoDoc](https://godoc.org/goa.design/goa/v3/dsl) includes many code snippets and provides a great reference when writing designs.
+You may also want to take a look at the other [examples](https://github.com/goadesign/examples). The DSL package [GoDoc](https://pkg.go.dev/goa.design/goa/v3/dsl) includes many code snippets and provides a great reference when writing designs.
 
 If you need help, use the Go Slack group:
 - Register for the group at https://invite.slack.golangbridge.org.

--- a/content/learn/getting-started.md
+++ b/content/learn/getting-started.md
@@ -110,7 +110,7 @@ generated [OpenAPI](https://www.openapis.org/) specification.
 
 >The example above covers a fraction of what Goa can do. More examples can be
 >found in the [examples repo](https://github.com/goadesign/examples). The
->[Goa DSL package GoDoc](https://godoc.org/goa.design/goa/dsl) lists all the DSL
+>[Goa DSL package GoDoc](https://godoc.org/goa.design/goa/v3/dsl) lists all the DSL
 >keywords together with a description and example usage for each.
 
 ## Code Generation
@@ -240,7 +240,7 @@ func (s *calcsrvc) Multiply(ctx context.Context, p *calc.MultiplyPayload) (res i
 ```
 
 The `goa example` command uses the optional
-[Server DSL](https://godoc.org/goa.design/goa/dsl#Server)
+[Server DSL](https://godoc.org/goa.design/goa/v3/dsl#Server)
 described in the design to generate buildable server and client files.
 It builds one directory in `cmd` for each `Server` DSL specified in the
 design. Here we defined a single server `calc` which listens for HTTP
@@ -348,7 +348,7 @@ calc service using a non-integer value for example).
 
 This example only touches on the basics of Goa, the <a href="../../design/overview">design overview</a> covers many other aspects.
 
-You may also want to take a look at the other [examples](https://github.com/goadesign/examples). The DSL package [GoDoc](https://godoc.org/goa.design/goa/dsl) includes many code snippets and provides a great reference when writing designs.
+You may also want to take a look at the other [examples](https://github.com/goadesign/examples). The DSL package [GoDoc](https://godoc.org/goa.design/goa/v3/dsl) includes many code snippets and provides a great reference when writing designs.
 
 If you need help, use the Go Slack group:
 - Register for the group at https://invite.slack.golangbridge.org.

--- a/content/learn/upgrading.it.md
+++ b/content/learn/upgrading.it.md
@@ -53,36 +53,36 @@ su `Services` e `Methods`. Ogni metodo descrive input e output. I DSL transport-
 come vengono come essi vengono costruiti da richieste HTTP o messaggi gRPC e come gli output sono 
 construiti e scrivono risposte HTTP o messaggi gRPC in uscita.
 
-> NOTA: I DSL v3 sono documentati nei [godoc](https://godoc.org/goa.design/goa/v3/dsl).
+> NOTA: I DSL v3 sono documentati nei [godoc](https://pkg.go.dev/goa.design/goa/v3/dsl).
 
 ### Types
 
 Per la maggior parte i DSL non hanno molte differenze nella definizione dei tipi:
 
-* `MediaType` ora è [ResultType](https://godoc.org/goa.design/goa/v3/dsl#ResultType) per rendere chiaro che
+* `MediaType` ora è [ResultType](https://pkg.go.dev/goa.design/goa/v3/dsl#ResultType) per rendere chiaro che
   il tipo usato da questo DSL descrive il risultato di un metodo. Nota che i tipi standard definiti usando
-  il DSL [Type](https://godoc.org/goa.design/goa/v3/dsl#Type) possono anche essere utilizzati per i
+  il DSL [Type](https://pkg.go.dev/goa.design/goa/v3/dsl#Type) possono anche essere utilizzati per i
   result types.
 * I result types possono omettere le viste. Se lo fanno una vista di default viene creata con
   tutti gli attributi.
-* Il nuovo DSL [Field](https://godoc.org/goa.design/goa/v3/dsl#Field) è identico a
-  [Attribute](https://godoc.org/goa.design/goa/v3/dsl#Attribute), ma permette di specificare un
+* Il nuovo DSL [Field](https://pkg.go.dev/goa.design/goa/v3/dsl#Field) è identico a
+  [Attribute](https://pkg.go.dev/goa.design/goa/v3/dsl#Attribute), ma permette di specificare un
   indice per il campo da far corrispondere al field number gRPC.
-* `HashOf` ora è [MapOf](https://godoc.org/goa.design/goa/v3/dsl#MapOf), più intuitivo per gli 
+* `HashOf` ora è [MapOf](https://pkg.go.dev/goa.design/goa/v3/dsl#MapOf), più intuitivo per gli 
   sviluppatori Go.
 * Ci sono nuovi primitivi per descrivere più precisamente il layout dei dati:
-  [Int](https://godoc.org/goa.design/goa/v3/dsl#Int),
-  [Int32](https://godoc.org/goa.design/goa/v3/dsl#Int32),
-  [Int64](https://godoc.org/goa.design/goa/v3/dsl#Int64),
-  [UInt](https://godoc.org/goa.design/goa/v3/dsl#UInt),
-  [UInt32](https://godoc.org/goa.design/goa/v3/dsl#UInt32),
-  [UInt64](https://godoc.org/goa.design/goa/v3/dsl#UInt64),
-  [Float32](https://godoc.org/goa.design/goa/v3/dsl#Float32),
-  [Float64](https://godoc.org/goa.design/goa/v3/dsl#Float64)
-  and [Bytes](https://godoc.org/goa.design/goa/v3/dsl#Bytes).
+  [Int](https://pkg.go.dev/goa.design/goa/v3/dsl#Int),
+  [Int32](https://pkg.go.dev/goa.design/goa/v3/dsl#Int32),
+  [Int64](https://pkg.go.dev/goa.design/goa/v3/dsl#Int64),
+  [UInt](https://pkg.go.dev/goa.design/goa/v3/dsl#UInt),
+  [UInt32](https://pkg.go.dev/goa.design/goa/v3/dsl#UInt32),
+  [UInt64](https://pkg.go.dev/goa.design/goa/v3/dsl#UInt64),
+  [Float32](https://pkg.go.dev/goa.design/goa/v3/dsl#Float32),
+  [Float64](https://pkg.go.dev/goa.design/goa/v3/dsl#Float64)
+  and [Bytes](https://pkg.go.dev/goa.design/goa/v3/dsl#Bytes).
 * I tipi `DateTime` e `UUID` vengono deprecati in favore di
-  [String](https://godoc.org/goa.design/goa/v3/dsl#String) e un corrispondente
-  validazione [Format](https://godoc.org/goa.design/goa/v3/dsl#Format).
+  [String](https://pkg.go.dev/goa.design/goa/v3/dsl#String) e un corrispondente
+  validazione [Format](https://pkg.go.dev/goa.design/goa/v3/dsl#Format).
 
 #### Esempio
 
@@ -131,10 +131,10 @@ var Person = ResultType("application/vnd.goa.person", func() {
 
 ### API
 
-Sono stati apportati i seguenti cambiamenti al DSL [API](https://godoc.org/goa.design/goa/v3/dsl#API):
+Sono stati apportati i seguenti cambiamenti al DSL [API](https://pkg.go.dev/goa.design/goa/v3/dsl#API):
 
-* I DSL `Host`, `Scheme` e `BasePath` sono rimpiazzati con [Server](https://godoc.org/goa.design/goa/v3/dsl#Server).
-* Il DSL [Server](https://godoc.org/goa.design/goa/v3/dsl#Server) permette di definire proprietà del server per ambienti differenti
+* I DSL `Host`, `Scheme` e `BasePath` sono rimpiazzati con [Server](https://pkg.go.dev/goa.design/goa/v3/dsl#Server).
+* Il DSL [Server](https://pkg.go.dev/goa.design/goa/v3/dsl#Server) permette di definire proprietà del server per ambienti differenti
   Ogni server può elencare i servizi che ospita e si possono definire più server in un unico design.
 * `Origin` ora fa parte del [plugin CORS](https://github.com/goadesign/plugins/tree/v3/cors).
 * `ResponseTemplate` e `Trait` sono stati deprecati.
@@ -194,16 +194,16 @@ var _ = API("cellar", func() {
 
 ### Services
 
-La funzione `Resource` ora si chiama [Service](https://godoc.org/goa.design/goa/v3/dsl#Service). I
+La funzione `Resource` ora si chiama [Service](https://pkg.go.dev/goa.design/goa/v3/dsl#Service). I
 DSL ora sono organizzati in sezioni che non dipendono più dal livello di trasporto, la quale
 elenca anche i potenziali errori ritornati dai metodi. Ci pensa il codice specifico per il trasporto 
 a tradurre questi errori o risultati in risposte HTTP o messaggi gRPC con gli stati corretti.
 
-* `BasePath` ora è [Path](https://godoc.org/goa.design/goa/v3/dsl#Path) e appare sotto il DSL
-  [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP).
-* `CanonicalActionName` ora si chiama [CanonicalMethod](https://godoc.org/goa.design/goa/v3/dsl#CanonicalMethod)
-  e appare sotto la DSL [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP).
-* `Response` viene rimpiazzata da [Error](https://godoc.org/goa.design/goa/v3/dsl#Error).
+* `BasePath` ora è [Path](https://pkg.go.dev/goa.design/goa/v3/dsl#Path) e appare sotto il DSL
+  [HTTP](https://pkg.go.dev/goa.design/goa/v3/dsl#HTTP).
+* `CanonicalActionName` ora si chiama [CanonicalMethod](https://pkg.go.dev/goa.design/goa/v3/dsl#CanonicalMethod)
+  e appare sotto la DSL [HTTP](https://pkg.go.dev/goa.design/goa/v3/dsl#HTTP).
+* `Response` viene rimpiazzata da [Error](https://pkg.go.dev/goa.design/goa/v3/dsl#Error).
 * `Origin` ora fa parte del [plugin CORS](https://github.com/goadesign/plugins/tree/v3/cors).
 * `DefaultMedia` viene deprecato.
 
@@ -243,16 +243,16 @@ Equivalent v3 design:
 
 ### Methods
 
-La funzione `Action` viene rimpiazzata da [Method](https://godoc.org/goa.design/goa/v3/dsl#Method). Come per i
+La funzione `Action` viene rimpiazzata da [Method](https://pkg.go.dev/goa.design/goa/v3/dsl#Method). Come per i
 servizi i DSL sono organizzati in sezioni agnostiche al livello di trasporto e sezioni specifiche ad essi.
 Le sezioni agnostic definiscono payload e risultati così come gli errori non definiti a livello di servizio.
 I DSL specifiche di trasporto mappano payload e risultati a costrutti specifici come header HTTP, corpo, 
 eccetera.
 
-* La maggior parte dei DSL presenti nella v1 sono specifici per HTTP e sono stati spostati sotto il DSL [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP).
-* [Param](https://godoc.org/goa.design/goa/v3/dsl#Param) e [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) ora richiedono un semplice
+* La maggior parte dei DSL presenti nella v1 sono specifici per HTTP e sono stati spostati sotto il DSL [HTTP](https://pkg.go.dev/goa.design/goa/v3/dsl#HTTP).
+* [Param](https://pkg.go.dev/goa.design/goa/v3/dsl#Param) e [Header](https://pkg.go.dev/goa.design/goa/v3/dsl#Header) ora richiedono un semplice
   elenco di attributi del payload o dei result type.
-* Le error response ora usano il DSL [Error](https://godoc.org/goa.design/goa/v3/dsl#Error).
+* Le error response ora usano il DSL [Error](https://pkg.go.dev/goa.design/goa/v3/dsl#Error).
 * I path parameters HTTP ora sono definiti con le parentesi graffe invece dei due punti: `/foo/{id}` anziché `/foo/:id`.
 
 ### Mapping di input e output

--- a/content/learn/upgrading.it.md
+++ b/content/learn/upgrading.it.md
@@ -53,36 +53,36 @@ su `Services` e `Methods`. Ogni metodo descrive input e output. I DSL transport-
 come vengono come essi vengono costruiti da richieste HTTP o messaggi gRPC e come gli output sono 
 construiti e scrivono risposte HTTP o messaggi gRPC in uscita.
 
-> NOTA: I DSL v3 sono documentati nei [godoc](https://godoc.org/goa.design/goa/dsl).
+> NOTA: I DSL v3 sono documentati nei [godoc](https://godoc.org/goa.design/goa/v3/dsl).
 
 ### Types
 
 Per la maggior parte i DSL non hanno molte differenze nella definizione dei tipi:
 
-* `MediaType` ora è [ResultType](https://godoc.org/goa.design/goa/dsl#ResultType) per rendere chiaro che
+* `MediaType` ora è [ResultType](https://godoc.org/goa.design/goa/v3/dsl#ResultType) per rendere chiaro che
   il tipo usato da questo DSL descrive il risultato di un metodo. Nota che i tipi standard definiti usando
-  il DSL [Type](https://godoc.org/goa.design/goa/dsl#Type) possono anche essere utilizzati per i
+  il DSL [Type](https://godoc.org/goa.design/goa/v3/dsl#Type) possono anche essere utilizzati per i
   result types.
 * I result types possono omettere le viste. Se lo fanno una vista di default viene creata con
   tutti gli attributi.
-* Il nuovo DSL [Field](https://godoc.org/goa.design/goa/dsl#Field) è identico a
-  [Attribute](https://godoc.org/goa.design/goa/dsl#Attribute), ma permette di specificare un
+* Il nuovo DSL [Field](https://godoc.org/goa.design/goa/v3/dsl#Field) è identico a
+  [Attribute](https://godoc.org/goa.design/goa/v3/dsl#Attribute), ma permette di specificare un
   indice per il campo da far corrispondere al field number gRPC.
-* `HashOf` ora è [MapOf](https://godoc.org/goa.design/goa/dsl#MapOf), più intuitivo per gli 
+* `HashOf` ora è [MapOf](https://godoc.org/goa.design/goa/v3/dsl#MapOf), più intuitivo per gli 
   sviluppatori Go.
 * Ci sono nuovi primitivi per descrivere più precisamente il layout dei dati:
-  [Int](https://godoc.org/goa.design/goa/dsl#Int),
-  [Int32](https://godoc.org/goa.design/goa/dsl#Int32),
-  [Int64](https://godoc.org/goa.design/goa/dsl#Int64),
-  [UInt](https://godoc.org/goa.design/goa/dsl#UInt),
-  [UInt32](https://godoc.org/goa.design/goa/dsl#UInt32),
-  [UInt64](https://godoc.org/goa.design/goa/dsl#UInt64),
-  [Float32](https://godoc.org/goa.design/goa/dsl#Float32),
-  [Float64](https://godoc.org/goa.design/goa/dsl#Float64)
-  and [Bytes](https://godoc.org/goa.design/goa/dsl#Bytes).
+  [Int](https://godoc.org/goa.design/goa/v3/dsl#Int),
+  [Int32](https://godoc.org/goa.design/goa/v3/dsl#Int32),
+  [Int64](https://godoc.org/goa.design/goa/v3/dsl#Int64),
+  [UInt](https://godoc.org/goa.design/goa/v3/dsl#UInt),
+  [UInt32](https://godoc.org/goa.design/goa/v3/dsl#UInt32),
+  [UInt64](https://godoc.org/goa.design/goa/v3/dsl#UInt64),
+  [Float32](https://godoc.org/goa.design/goa/v3/dsl#Float32),
+  [Float64](https://godoc.org/goa.design/goa/v3/dsl#Float64)
+  and [Bytes](https://godoc.org/goa.design/goa/v3/dsl#Bytes).
 * I tipi `DateTime` e `UUID` vengono deprecati in favore di
-  [String](https://godoc.org/goa.design/goa/dsl#String) e un corrispondente
-  validazione [Format](https://godoc.org/goa.design/goa/dsl#Format).
+  [String](https://godoc.org/goa.design/goa/v3/dsl#String) e un corrispondente
+  validazione [Format](https://godoc.org/goa.design/goa/v3/dsl#Format).
 
 #### Esempio
 
@@ -131,10 +131,10 @@ var Person = ResultType("application/vnd.goa.person", func() {
 
 ### API
 
-Sono stati apportati i seguenti cambiamenti al DSL [API](https://godoc.org/goa.design/goa/dsl#API):
+Sono stati apportati i seguenti cambiamenti al DSL [API](https://godoc.org/goa.design/goa/v3/dsl#API):
 
-* I DSL `Host`, `Scheme` e `BasePath` sono rimpiazzati con [Server](https://godoc.org/goa.design/goa/dsl#Server).
-* Il DSL [Server](https://godoc.org/goa.design/goa/dsl#Server) permette di definire proprietà del server per ambienti differenti
+* I DSL `Host`, `Scheme` e `BasePath` sono rimpiazzati con [Server](https://godoc.org/goa.design/goa/v3/dsl#Server).
+* Il DSL [Server](https://godoc.org/goa.design/goa/v3/dsl#Server) permette di definire proprietà del server per ambienti differenti
   Ogni server può elencare i servizi che ospita e si possono definire più server in un unico design.
 * `Origin` ora fa parte del [plugin CORS](https://github.com/goadesign/plugins/tree/v3/cors).
 * `ResponseTemplate` e `Trait` sono stati deprecati.
@@ -194,16 +194,16 @@ var _ = API("cellar", func() {
 
 ### Services
 
-La funzione `Resource` ora si chiama [Service](https://godoc.org/goa.design/goa/dsl#Service). I
+La funzione `Resource` ora si chiama [Service](https://godoc.org/goa.design/goa/v3/dsl#Service). I
 DSL ora sono organizzati in sezioni che non dipendono più dal livello di trasporto, la quale
 elenca anche i potenziali errori ritornati dai metodi. Ci pensa il codice specifico per il trasporto 
 a tradurre questi errori o risultati in risposte HTTP o messaggi gRPC con gli stati corretti.
 
-* `BasePath` ora è [Path](https://godoc.org/goa.design/goa/dsl#Path) e appare sotto il DSL
-  [HTTP](https://godoc.org/goa.design/goa/dsl#HTTP).
-* `CanonicalActionName` ora si chiama [CanonicalMethod](https://godoc.org/goa.design/goa/dsl#CanonicalMethod)
-  e appare sotto la DSL [HTTP](https://godoc.org/goa.design/goa/dsl#HTTP).
-* `Response` viene rimpiazzata da [Error](https://godoc.org/goa.design/goa/dsl#Error).
+* `BasePath` ora è [Path](https://godoc.org/goa.design/goa/v3/dsl#Path) e appare sotto il DSL
+  [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP).
+* `CanonicalActionName` ora si chiama [CanonicalMethod](https://godoc.org/goa.design/goa/v3/dsl#CanonicalMethod)
+  e appare sotto la DSL [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP).
+* `Response` viene rimpiazzata da [Error](https://godoc.org/goa.design/goa/v3/dsl#Error).
 * `Origin` ora fa parte del [plugin CORS](https://github.com/goadesign/plugins/tree/v3/cors).
 * `DefaultMedia` viene deprecato.
 
@@ -243,16 +243,16 @@ Equivalent v3 design:
 
 ### Methods
 
-La funzione `Action` viene rimpiazzata da [Method](https://godoc.org/goa.design/goa/dsl#Method). Come per i
+La funzione `Action` viene rimpiazzata da [Method](https://godoc.org/goa.design/goa/v3/dsl#Method). Come per i
 servizi i DSL sono organizzati in sezioni agnostiche al livello di trasporto e sezioni specifiche ad essi.
 Le sezioni agnostic definiscono payload e risultati così come gli errori non definiti a livello di servizio.
 I DSL specifiche di trasporto mappano payload e risultati a costrutti specifici come header HTTP, corpo, 
 eccetera.
 
-* La maggior parte dei DSL presenti nella v1 sono specifici per HTTP e sono stati spostati sotto il DSL [HTTP](https://godoc.org/goa.design/goa/dsl#HTTP).
-* [Param](https://godoc.org/goa.design/goa/dsl#Param) e [Header](https://godoc.org/goa.design/goa/dsl#Header) ora richiedono un semplice
+* La maggior parte dei DSL presenti nella v1 sono specifici per HTTP e sono stati spostati sotto il DSL [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP).
+* [Param](https://godoc.org/goa.design/goa/v3/dsl#Param) e [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) ora richiedono un semplice
   elenco di attributi del payload o dei result type.
-* Le error response ora usano il DSL [Error](https://godoc.org/goa.design/goa/dsl#Error).
+* Le error response ora usano il DSL [Error](https://godoc.org/goa.design/goa/v3/dsl#Error).
 * I path parameters HTTP ora sono definiti con le parentesi graffe invece dei due punti: `/foo/{id}` anziché `/foo/:id`.
 
 ### Mapping di input e output

--- a/content/learn/upgrading.ja.md
+++ b/content/learn/upgrading.ja.md
@@ -49,29 +49,29 @@ Goa v3 では、下層のトランスポートとは無関係にサービス API
 トランスポート固有の DSL は、入力タイプが HTTP リクエストまたは入力される gRPC メッセージからどのように組み立てられているか、
 また、出力タイプが HTTP レスポンスまたは出力される gRPC メッセージへどのように書き込まれるべきかを記述します。
 
-> 注： v3 DSL は [godoc](https://godoc.org/goa.design/goa/dsl) に大々的に文書化されています。
+> 注： v3 DSL は [godoc](https://godoc.org/goa.design/goa/v3/dsl) に大々的に文書化されています。
 
 ### 型
 
 型の記述に利用される DSL は、いくつかの違いはありますが、大部分は同じままです：
 
-* `MediaType` は [ResultType](https://godoc.org/goa.design/goa/dsl#ResultType) になり、この DSL を利用して記述された型がメソッドの結果として利用されることが明確になりました。
-   [Type](https://godoc.org/goa.design/goa/dsl#Type) DSL によって定義された標準の型も結果の型として使用できることに注意してください。 
+* `MediaType` は [ResultType](https://godoc.org/goa.design/goa/v3/dsl#ResultType) になり、この DSL を利用して記述された型がメソッドの結果として利用されることが明確になりました。
+   [Type](https://godoc.org/goa.design/goa/v3/dsl#Type) DSL によって定義された標準の型も結果の型として使用できることに注意してください。 
 * 結果の型はビューの定義を省略することがあります。結果の型がビューを定義していない場合は、すべての結果の型の属性をリストしたデフォルトビューが定義されます。
-* 新しい [Field](https://godoc.org/goa.design/goa/dsl#Field) DSL は [Attribute](https://godoc.org/goa.design/goa/dsl#Attribute) と同等ですが、
+* 新しい [Field](https://godoc.org/goa.design/goa/v3/dsl#Field) DSL は [Attribute](https://godoc.org/goa.design/goa/v3/dsl#Attribute) と同等ですが、
   gRPC のフィールドナンバーに対応するインデックスを指定することが可能です。
-* `HashOf` は [MapOf](https://godoc.org/goa.design/goa/dsl#MapOf) になりました。Go 開発者にはより直感的になりました。
+* `HashOf` は [MapOf](https://godoc.org/goa.design/goa/v3/dsl#MapOf) になりました。Go 開発者にはより直感的になりました。
 * データのバイナリレイアウトをより正確に記述するために、新しい基本型が導入されました：
-  [Int](https://godoc.org/goa.design/goa/dsl#Int),
-  [Int32](https://godoc.org/goa.design/goa/dsl#Int32),
-  [Int64](https://godoc.org/goa.design/goa/dsl#Int64),
-  [UInt](https://godoc.org/goa.design/goa/dsl#UInt),
-  [UInt32](https://godoc.org/goa.design/goa/dsl#UInt32),
-  [UInt64](https://godoc.org/goa.design/goa/dsl#UInt64),
-  [Float32](https://godoc.org/goa.design/goa/dsl#Float32),
-  [Float64](https://godoc.org/goa.design/goa/dsl#Float64),
-  [Bytes](https://godoc.org/goa.design/goa/dsl#Bytes)
-* [String](https://godoc.org/goa.design/goa/dsl#String) と対応する [Format](https://godoc.org/goa.design/goa/dsl#Format) バリデーションがあるので、
+  [Int](https://godoc.org/goa.design/goa/v3/dsl#Int),
+  [Int32](https://godoc.org/goa.design/goa/v3/dsl#Int32),
+  [Int64](https://godoc.org/goa.design/goa/v3/dsl#Int64),
+  [UInt](https://godoc.org/goa.design/goa/v3/dsl#UInt),
+  [UInt32](https://godoc.org/goa.design/goa/v3/dsl#UInt32),
+  [UInt64](https://godoc.org/goa.design/goa/v3/dsl#UInt64),
+  [Float32](https://godoc.org/goa.design/goa/v3/dsl#Float32),
+  [Float64](https://godoc.org/goa.design/goa/v3/dsl#Float64),
+  [Bytes](https://godoc.org/goa.design/goa/v3/dsl#Bytes)
+* [String](https://godoc.org/goa.design/goa/v3/dsl#String) と対応する [Format](https://godoc.org/goa.design/goa/v3/dsl#Format) バリデーションがあるので、
   `DateTime` と `UUID` は廃止されました。
 
 #### 例
@@ -121,10 +121,10 @@ var Person = ResultType("application/vnd.goa.person", func() {
 
 ### API
 
-[API](https://godoc.org/goa.design/goa/dsl#API) DSL に次のような変更が加えられました：
+[API](https://godoc.org/goa.design/goa/v3/dsl#API) DSL に次のような変更が加えられました：
 
-* `Host`, `Scheme` ならびに `BasePath` DSL は [Server](https://godoc.org/goa.design/goa/dsl#Server) に置き換えられます。
-* [Server](https://godoc.org/goa.design/goa/dsl#Server) DSL を使用するとさまざまな環境のサーバプロパティを定義できます。
+* `Host`, `Scheme` ならびに `BasePath` DSL は [Server](https://godoc.org/goa.design/goa/v3/dsl#Server) に置き換えられます。
+* [Server](https://godoc.org/goa.design/goa/v3/dsl#Server) DSL を使用するとさまざまな環境のサーバプロパティを定義できます。
   各サーバは、サーバがホストするサービスをリストして、1つのデザインで複数のサーバーの定義を可能にします。
 * `Origin` は [CORS プラグイン](https://github.com/goadesign/plugins/tree/v3/cors)の一部として実装されました。 
 * `ResponseTemplate` と `Trait` は廃止になりました。
@@ -184,14 +184,14 @@ var _ = API("cellar", func() {
 
 ### サービス
 
-`Resource` 関数は [Service](https://godoc.org/goa.design/goa/dsl#Service) になりました。 
+`Resource` 関数は [Service](https://godoc.org/goa.design/goa/v3/dsl#Service) になりました。 
 この DSL は現在、トランスポートに関わらないセクションとトランスポート固有の DSL とで構成されています。
 トランスポートに関わらないセクションはすべてのサービスメソッドによって返される可能性のあるエラーを列挙しています。
 トランスポート固有のセクションは、これらのエラーを HTTP ステータスコードまたは gRPC レスポンスコードにマッピングします。
 
-* `BasePath` は [Path](https://godoc.org/goa.design/goa/dsl#Path) と呼ばれるようになりました。[HTTP](https://godoc.org/goa.design/goa/dsl#HTTP) DSL に現れます。
-* `CanonicalActionName` は [CanonicalMethod](https://godoc.org/goa.design/goa/dsl#CanonicalMethod) と呼ばれるようになりました。[HTTP](https://godoc.org/goa.design/goa/dsl#HTTP) DSL に現れます。
-* `Response` は [Error](https://godoc.org/goa.design/goa/dsl#Error) に置き換えられました。
+* `BasePath` は [Path](https://godoc.org/goa.design/goa/v3/dsl#Path) と呼ばれるようになりました。[HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) DSL に現れます。
+* `CanonicalActionName` は [CanonicalMethod](https://godoc.org/goa.design/goa/v3/dsl#CanonicalMethod) と呼ばれるようになりました。[HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) DSL に現れます。
+* `Response` は [Error](https://godoc.org/goa.design/goa/v3/dsl#Error) に置き換えられました。
 * `Origin` は [CORS プラグイン](https://github.com/goadesign/plugins/tree/v3/cors)の一部として実装されました。 
 * `DefaultMedia` は廃止されました。
 
@@ -231,15 +231,15 @@ v1 のデザイン：
 
 ### メソッド
 
-`Action` 関数は [Method](https://godoc.org/goa.design/goa/dsl#Method) で置き換えられました。 
+`Action` 関数は [Method](https://godoc.org/goa.design/goa/v3/dsl#Method) で置き換えられました。 
 サービスと同様に、DSL はトランスポートに関わらないセクションとトランスポート固有の DSL で構成されます。
 トランスポートに関わらないセクションでは、ペイロードと結果の型、およびサービスレベルでまだ定義されていない、考えられるメソッド固有のすべてのエラーを定義します。
 トランスポート固有の DSL は、ペイロードと結果の型の属性を HTTPヘッダー、ボディなどのトランスポート固有の構造にマッピングします。
 
-* v1 に存在する DSL のほとんどは HTTP 特有のものなので、[HTTP](https://godoc.org/goa.design/goa/dsl#HTTP) DSL に移動しました。
-* [Param](https://godoc.org/goa.design/goa/dsl#Param) と [Header](https://godoc.org/goa.design/goa/dsl#Header) 関数は、
+* v1 に存在する DSL のほとんどは HTTP 特有のものなので、[HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) DSL に移動しました。
+* [Param](https://godoc.org/goa.design/goa/v3/dsl#Param) と [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) 関数は、
   メソッドペイロードや結果の型に対応するの属性の名前を列挙するだけですみます。
-* エラーレスポンスは [Error](https://godoc.org/goa.design/goa/dsl#Error) DSL を利用するようになりました。
+* エラーレスポンスは [Error](https://godoc.org/goa.design/goa/v3/dsl#Error) DSL を利用するようになりました。
 * HTTP パスパラメータはコロンの代わりに中括弧を使って定義されるようになりました： `/foo/:id` の代わりに `/foo/{id}` と記述します。
 
 入力と出力の対応は、

--- a/content/learn/upgrading.ja.md
+++ b/content/learn/upgrading.ja.md
@@ -49,29 +49,29 @@ Goa v3 では、下層のトランスポートとは無関係にサービス API
 トランスポート固有の DSL は、入力タイプが HTTP リクエストまたは入力される gRPC メッセージからどのように組み立てられているか、
 また、出力タイプが HTTP レスポンスまたは出力される gRPC メッセージへどのように書き込まれるべきかを記述します。
 
-> 注： v3 DSL は [godoc](https://godoc.org/goa.design/goa/v3/dsl) に大々的に文書化されています。
+> 注： v3 DSL は [godoc](https://pkg.go.dev/goa.design/goa/v3/dsl) に大々的に文書化されています。
 
 ### 型
 
 型の記述に利用される DSL は、いくつかの違いはありますが、大部分は同じままです：
 
-* `MediaType` は [ResultType](https://godoc.org/goa.design/goa/v3/dsl#ResultType) になり、この DSL を利用して記述された型がメソッドの結果として利用されることが明確になりました。
-   [Type](https://godoc.org/goa.design/goa/v3/dsl#Type) DSL によって定義された標準の型も結果の型として使用できることに注意してください。 
+* `MediaType` は [ResultType](https://pkg.go.dev/goa.design/goa/v3/dsl#ResultType) になり、この DSL を利用して記述された型がメソッドの結果として利用されることが明確になりました。
+   [Type](https://pkg.go.dev/goa.design/goa/v3/dsl#Type) DSL によって定義された標準の型も結果の型として使用できることに注意してください。 
 * 結果の型はビューの定義を省略することがあります。結果の型がビューを定義していない場合は、すべての結果の型の属性をリストしたデフォルトビューが定義されます。
-* 新しい [Field](https://godoc.org/goa.design/goa/v3/dsl#Field) DSL は [Attribute](https://godoc.org/goa.design/goa/v3/dsl#Attribute) と同等ですが、
+* 新しい [Field](https://pkg.go.dev/goa.design/goa/v3/dsl#Field) DSL は [Attribute](https://pkg.go.dev/goa.design/goa/v3/dsl#Attribute) と同等ですが、
   gRPC のフィールドナンバーに対応するインデックスを指定することが可能です。
-* `HashOf` は [MapOf](https://godoc.org/goa.design/goa/v3/dsl#MapOf) になりました。Go 開発者にはより直感的になりました。
+* `HashOf` は [MapOf](https://pkg.go.dev/goa.design/goa/v3/dsl#MapOf) になりました。Go 開発者にはより直感的になりました。
 * データのバイナリレイアウトをより正確に記述するために、新しい基本型が導入されました：
-  [Int](https://godoc.org/goa.design/goa/v3/dsl#Int),
-  [Int32](https://godoc.org/goa.design/goa/v3/dsl#Int32),
-  [Int64](https://godoc.org/goa.design/goa/v3/dsl#Int64),
-  [UInt](https://godoc.org/goa.design/goa/v3/dsl#UInt),
-  [UInt32](https://godoc.org/goa.design/goa/v3/dsl#UInt32),
-  [UInt64](https://godoc.org/goa.design/goa/v3/dsl#UInt64),
-  [Float32](https://godoc.org/goa.design/goa/v3/dsl#Float32),
-  [Float64](https://godoc.org/goa.design/goa/v3/dsl#Float64),
-  [Bytes](https://godoc.org/goa.design/goa/v3/dsl#Bytes)
-* [String](https://godoc.org/goa.design/goa/v3/dsl#String) と対応する [Format](https://godoc.org/goa.design/goa/v3/dsl#Format) バリデーションがあるので、
+  [Int](https://pkg.go.dev/goa.design/goa/v3/dsl#Int),
+  [Int32](https://pkg.go.dev/goa.design/goa/v3/dsl#Int32),
+  [Int64](https://pkg.go.dev/goa.design/goa/v3/dsl#Int64),
+  [UInt](https://pkg.go.dev/goa.design/goa/v3/dsl#UInt),
+  [UInt32](https://pkg.go.dev/goa.design/goa/v3/dsl#UInt32),
+  [UInt64](https://pkg.go.dev/goa.design/goa/v3/dsl#UInt64),
+  [Float32](https://pkg.go.dev/goa.design/goa/v3/dsl#Float32),
+  [Float64](https://pkg.go.dev/goa.design/goa/v3/dsl#Float64),
+  [Bytes](https://pkg.go.dev/goa.design/goa/v3/dsl#Bytes)
+* [String](https://pkg.go.dev/goa.design/goa/v3/dsl#String) と対応する [Format](https://pkg.go.dev/goa.design/goa/v3/dsl#Format) バリデーションがあるので、
   `DateTime` と `UUID` は廃止されました。
 
 #### 例
@@ -121,10 +121,10 @@ var Person = ResultType("application/vnd.goa.person", func() {
 
 ### API
 
-[API](https://godoc.org/goa.design/goa/v3/dsl#API) DSL に次のような変更が加えられました：
+[API](https://pkg.go.dev/goa.design/goa/v3/dsl#API) DSL に次のような変更が加えられました：
 
-* `Host`, `Scheme` ならびに `BasePath` DSL は [Server](https://godoc.org/goa.design/goa/v3/dsl#Server) に置き換えられます。
-* [Server](https://godoc.org/goa.design/goa/v3/dsl#Server) DSL を使用するとさまざまな環境のサーバプロパティを定義できます。
+* `Host`, `Scheme` ならびに `BasePath` DSL は [Server](https://pkg.go.dev/goa.design/goa/v3/dsl#Server) に置き換えられます。
+* [Server](https://pkg.go.dev/goa.design/goa/v3/dsl#Server) DSL を使用するとさまざまな環境のサーバプロパティを定義できます。
   各サーバは、サーバがホストするサービスをリストして、1つのデザインで複数のサーバーの定義を可能にします。
 * `Origin` は [CORS プラグイン](https://github.com/goadesign/plugins/tree/v3/cors)の一部として実装されました。 
 * `ResponseTemplate` と `Trait` は廃止になりました。
@@ -184,14 +184,14 @@ var _ = API("cellar", func() {
 
 ### サービス
 
-`Resource` 関数は [Service](https://godoc.org/goa.design/goa/v3/dsl#Service) になりました。 
+`Resource` 関数は [Service](https://pkg.go.dev/goa.design/goa/v3/dsl#Service) になりました。 
 この DSL は現在、トランスポートに関わらないセクションとトランスポート固有の DSL とで構成されています。
 トランスポートに関わらないセクションはすべてのサービスメソッドによって返される可能性のあるエラーを列挙しています。
 トランスポート固有のセクションは、これらのエラーを HTTP ステータスコードまたは gRPC レスポンスコードにマッピングします。
 
-* `BasePath` は [Path](https://godoc.org/goa.design/goa/v3/dsl#Path) と呼ばれるようになりました。[HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) DSL に現れます。
-* `CanonicalActionName` は [CanonicalMethod](https://godoc.org/goa.design/goa/v3/dsl#CanonicalMethod) と呼ばれるようになりました。[HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) DSL に現れます。
-* `Response` は [Error](https://godoc.org/goa.design/goa/v3/dsl#Error) に置き換えられました。
+* `BasePath` は [Path](https://pkg.go.dev/goa.design/goa/v3/dsl#Path) と呼ばれるようになりました。[HTTP](https://pkg.go.dev/goa.design/goa/v3/dsl#HTTP) DSL に現れます。
+* `CanonicalActionName` は [CanonicalMethod](https://pkg.go.dev/goa.design/goa/v3/dsl#CanonicalMethod) と呼ばれるようになりました。[HTTP](https://pkg.go.dev/goa.design/goa/v3/dsl#HTTP) DSL に現れます。
+* `Response` は [Error](https://pkg.go.dev/goa.design/goa/v3/dsl#Error) に置き換えられました。
 * `Origin` は [CORS プラグイン](https://github.com/goadesign/plugins/tree/v3/cors)の一部として実装されました。 
 * `DefaultMedia` は廃止されました。
 
@@ -231,15 +231,15 @@ v1 のデザイン：
 
 ### メソッド
 
-`Action` 関数は [Method](https://godoc.org/goa.design/goa/v3/dsl#Method) で置き換えられました。 
+`Action` 関数は [Method](https://pkg.go.dev/goa.design/goa/v3/dsl#Method) で置き換えられました。 
 サービスと同様に、DSL はトランスポートに関わらないセクションとトランスポート固有の DSL で構成されます。
 トランスポートに関わらないセクションでは、ペイロードと結果の型、およびサービスレベルでまだ定義されていない、考えられるメソッド固有のすべてのエラーを定義します。
 トランスポート固有の DSL は、ペイロードと結果の型の属性を HTTPヘッダー、ボディなどのトランスポート固有の構造にマッピングします。
 
-* v1 に存在する DSL のほとんどは HTTP 特有のものなので、[HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) DSL に移動しました。
-* [Param](https://godoc.org/goa.design/goa/v3/dsl#Param) と [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) 関数は、
+* v1 に存在する DSL のほとんどは HTTP 特有のものなので、[HTTP](https://pkg.go.dev/goa.design/goa/v3/dsl#HTTP) DSL に移動しました。
+* [Param](https://pkg.go.dev/goa.design/goa/v3/dsl#Param) と [Header](https://pkg.go.dev/goa.design/goa/v3/dsl#Header) 関数は、
   メソッドペイロードや結果の型に対応するの属性の名前を列挙するだけですみます。
-* エラーレスポンスは [Error](https://godoc.org/goa.design/goa/v3/dsl#Error) DSL を利用するようになりました。
+* エラーレスポンスは [Error](https://pkg.go.dev/goa.design/goa/v3/dsl#Error) DSL を利用するようになりました。
 * HTTP パスパラメータはコロンの代わりに中括弧を使って定義されるようになりました： `/foo/:id` の代わりに `/foo/{id}` と記述します。
 
 入力と出力の対応は、

--- a/content/learn/upgrading.md
+++ b/content/learn/upgrading.md
@@ -53,36 +53,36 @@ on `Services` and `Methods`. Each method describes its input and output types. T
 DSL then describes how the input types are built from HTTP request or inbound gRPC messages and how
 output types should be written to HTTP responses or outbound gRPC messages.
 
-> NOTE: The v3 DSL is documented extensively in [godoc](https://godoc.org/goa.design/goa/v3/dsl)
+> NOTE: The v3 DSL is documented extensively in [godoc](https://pkg.go.dev/goa.design/goa/v3/dsl)
 
 ### Types
 
 For the most part the DSL used to describes types remains the same with a few differences:
 
-* `MediaType` is now [ResultType](https://godoc.org/goa.design/goa/v3/dsl#ResultType) to make it clear
+* `MediaType` is now [ResultType](https://pkg.go.dev/goa.design/goa/v3/dsl#ResultType) to make it clear
   that types described using this DSL are intended to be used as method results. Note that standard
-  types defined using the [Type](https://godoc.org/goa.design/goa/v3/dsl#Type) DSL can also be used as
+  types defined using the [Type](https://pkg.go.dev/goa.design/goa/v3/dsl#Type) DSL can also be used as
   result types.
 * Result types may omit defining views. If a result type does not define a view then a default
   view is automatically defined that lists all the result type attributes.
-* The new [Field](https://godoc.org/goa.design/goa/v3/dsl#Field) DSL is identical to
-  [Attribute](https://godoc.org/goa.design/goa/v3/dsl#Attribute) but makes it possible to specify an
+* The new [Field](https://pkg.go.dev/goa.design/goa/v3/dsl#Field) DSL is identical to
+  [Attribute](https://pkg.go.dev/goa.design/goa/v3/dsl#Attribute) but makes it possible to specify an
   index for the field corresponding to the gRPC field number.
-* `HashOf` is now [MapOf](https://godoc.org/goa.design/goa/v3/dsl#MapOf) which is more intuitive to Go
+* `HashOf` is now [MapOf](https://pkg.go.dev/goa.design/goa/v3/dsl#MapOf) which is more intuitive to Go
   developers.
 * There are new primitive types to describe more precisely the binary layout of the data:
-  [Int](https://godoc.org/goa.design/goa/v3/dsl#Int),
-  [Int32](https://godoc.org/goa.design/goa/v3/dsl#Int32),
-  [Int64](https://godoc.org/goa.design/goa/v3/dsl#Int64),
-  [UInt](https://godoc.org/goa.design/goa/v3/dsl#UInt),
-  [UInt32](https://godoc.org/goa.design/goa/v3/dsl#UInt32),
-  [UInt64](https://godoc.org/goa.design/goa/v3/dsl#UInt64),
-  [Float32](https://godoc.org/goa.design/goa/v3/dsl#Float32),
-  [Float64](https://godoc.org/goa.design/goa/v3/dsl#Float64)
-  and [Bytes](https://godoc.org/goa.design/goa/v3/dsl#Bytes).
+  [Int](https://pkg.go.dev/goa.design/goa/v3/dsl#Int),
+  [Int32](https://pkg.go.dev/goa.design/goa/v3/dsl#Int32),
+  [Int64](https://pkg.go.dev/goa.design/goa/v3/dsl#Int64),
+  [UInt](https://pkg.go.dev/goa.design/goa/v3/dsl#UInt),
+  [UInt32](https://pkg.go.dev/goa.design/goa/v3/dsl#UInt32),
+  [UInt64](https://pkg.go.dev/goa.design/goa/v3/dsl#UInt64),
+  [Float32](https://pkg.go.dev/goa.design/goa/v3/dsl#Float32),
+  [Float64](https://pkg.go.dev/goa.design/goa/v3/dsl#Float64)
+  and [Bytes](https://pkg.go.dev/goa.design/goa/v3/dsl#Bytes).
 * The types `DateTime` and `UUID` are deprecated in favor of
-  [String](https://godoc.org/goa.design/goa/v3/dsl#String) and corresponding
-  [Format](https://godoc.org/goa.design/goa/v3/dsl#Format)
+  [String](https://pkg.go.dev/goa.design/goa/v3/dsl#String) and corresponding
+  [Format](https://pkg.go.dev/goa.design/goa/v3/dsl#Format)
   validations.
 
 #### Example
@@ -132,10 +132,10 @@ var Person = ResultType("application/vnd.goa.person", func() {
 
 ### API
 
-The following changes have been made to the [API](https://godoc.org/goa.design/goa/v3/dsl#API) DSL:
+The following changes have been made to the [API](https://pkg.go.dev/goa.design/goa/v3/dsl#API) DSL:
 
-* The `Host`, `Scheme` and `BasePath` DSLs are replaced with [Server](https://godoc.org/goa.design/goa/v3/dsl#Server).
-* The [Server](https://godoc.org/goa.design/goa/v3/dsl#Server) DSL makes it possible to define server properties for different environments. Each server may list the services it hosts making it possible to define multiple servers in one design.
+* The `Host`, `Scheme` and `BasePath` DSLs are replaced with [Server](https://pkg.go.dev/goa.design/goa/v3/dsl#Server).
+* The [Server](https://pkg.go.dev/goa.design/goa/v3/dsl#Server) DSL makes it possible to define server properties for different environments. Each server may list the services it hosts making it possible to define multiple servers in one design.
 * `Origin` is now implemented as part of the [CORS plugin](https://github.com/goadesign/plugins/tree/v3/cors).
 * `ResponseTemplate` and `Trait` have been deprecated.
 
@@ -194,16 +194,16 @@ var _ = API("cellar", func() {
 
 ### Services
 
-The `Resource` function is now called [Service](https://godoc.org/goa.design/goa/v3/dsl#Service). The
+The `Resource` function is now called [Service](https://pkg.go.dev/goa.design/goa/v3/dsl#Service). The
 DSL is now organized into a transport agnostic section and transport specific DSLs. The transport
 agnostic section lists the potential errors returned by all the service methods. The transport
 specific sections then map these errors to HTTP status code or gRPC response codes.
 
-* `BasePath` is now called [Path](https://godoc.org/goa.design/goa/v3/dsl#Path) and appears in the
-  [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) DSL.
-* `CanonicalActionName` is now called [CanonicalMethod](https://godoc.org/goa.design/goa/v3/dsl#CanonicalMethod)
-  and appears in the [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) DSL.
-* `Response` is replaced with [Error](https://godoc.org/goa.design/goa/v3/dsl#Error).
+* `BasePath` is now called [Path](https://pkg.go.dev/goa.design/goa/v3/dsl#Path) and appears in the
+  [HTTP](https://pkg.go.dev/goa.design/goa/v3/dsl#HTTP) DSL.
+* `CanonicalActionName` is now called [CanonicalMethod](https://pkg.go.dev/goa.design/goa/v3/dsl#CanonicalMethod)
+  and appears in the [HTTP](https://pkg.go.dev/goa.design/goa/v3/dsl#HTTP) DSL.
+* `Response` is replaced with [Error](https://pkg.go.dev/goa.design/goa/v3/dsl#Error).
 * `Origin` is now implemented as part of the [CORS plugin](https://github.com/goadesign/plugins/tree/v3/cors).
 * `DefaultMedia` is deprecated.
 
@@ -243,16 +243,16 @@ Equivalent v3 design:
 
 ### Methods
 
-The `Action` function is replaced by [Method](https://godoc.org/goa.design/goa/v3/dsl#Method). As with
+The `Action` function is replaced by [Method](https://pkg.go.dev/goa.design/goa/v3/dsl#Method). As with
 services the DSL is organized into a transport agnostic section and transport specific DSLs. The
 transport agnostic section defines the payload and result types as well as all the possible method
 specific errors not already defined at the service level. The transport specific DSLs then map the
 payload and result type attributes to transport specific constructs such as HTTP headers, body etc.
 
-* Most of the DSL present in v1 is HTTP specific and thus moved to the [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) DSL.
-* The [Param](https://godoc.org/goa.design/goa/v3/dsl#Param) and [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) functions
+* Most of the DSL present in v1 is HTTP specific and thus moved to the [HTTP](https://pkg.go.dev/goa.design/goa/v3/dsl#HTTP) DSL.
+* The [Param](https://pkg.go.dev/goa.design/goa/v3/dsl#Param) and [Header](https://pkg.go.dev/goa.design/goa/v3/dsl#Header) functions
   now need only list the names of attributes of the corresponding method payload or result types.
-* Error responses now use the [Error](https://godoc.org/goa.design/goa/v3/dsl#Error) DSL.
+* Error responses now use the [Error](https://pkg.go.dev/goa.design/goa/v3/dsl#Error) DSL.
 * HTTP path parameters are now defined using curly braces instead of colons: `/foo/{id}` instead of `/foo/:id`.
 
 #### The mapping of input and output types

--- a/content/learn/upgrading.md
+++ b/content/learn/upgrading.md
@@ -53,36 +53,36 @@ on `Services` and `Methods`. Each method describes its input and output types. T
 DSL then describes how the input types are built from HTTP request or inbound gRPC messages and how
 output types should be written to HTTP responses or outbound gRPC messages.
 
-> NOTE: The v3 DSL is documented extensively in [godoc](https://godoc.org/goa.design/goa/dsl)
+> NOTE: The v3 DSL is documented extensively in [godoc](https://godoc.org/goa.design/goa/v3/dsl)
 
 ### Types
 
 For the most part the DSL used to describes types remains the same with a few differences:
 
-* `MediaType` is now [ResultType](https://godoc.org/goa.design/goa/dsl#ResultType) to make it clear
+* `MediaType` is now [ResultType](https://godoc.org/goa.design/goa/v3/dsl#ResultType) to make it clear
   that types described using this DSL are intended to be used as method results. Note that standard
-  types defined using the [Type](https://godoc.org/goa.design/goa/dsl#Type) DSL can also be used as
+  types defined using the [Type](https://godoc.org/goa.design/goa/v3/dsl#Type) DSL can also be used as
   result types.
 * Result types may omit defining views. If a result type does not define a view then a default
   view is automatically defined that lists all the result type attributes.
-* The new [Field](https://godoc.org/goa.design/goa/dsl#Field) DSL is identical to
-  [Attribute](https://godoc.org/goa.design/goa/dsl#Attribute) but makes it possible to specify an
+* The new [Field](https://godoc.org/goa.design/goa/v3/dsl#Field) DSL is identical to
+  [Attribute](https://godoc.org/goa.design/goa/v3/dsl#Attribute) but makes it possible to specify an
   index for the field corresponding to the gRPC field number.
-* `HashOf` is now [MapOf](https://godoc.org/goa.design/goa/dsl#MapOf) which is more intuitive to Go
+* `HashOf` is now [MapOf](https://godoc.org/goa.design/goa/v3/dsl#MapOf) which is more intuitive to Go
   developers.
 * There are new primitive types to describe more precisely the binary layout of the data:
-  [Int](https://godoc.org/goa.design/goa/dsl#Int),
-  [Int32](https://godoc.org/goa.design/goa/dsl#Int32),
-  [Int64](https://godoc.org/goa.design/goa/dsl#Int64),
-  [UInt](https://godoc.org/goa.design/goa/dsl#UInt),
-  [UInt32](https://godoc.org/goa.design/goa/dsl#UInt32),
-  [UInt64](https://godoc.org/goa.design/goa/dsl#UInt64),
-  [Float32](https://godoc.org/goa.design/goa/dsl#Float32),
-  [Float64](https://godoc.org/goa.design/goa/dsl#Float64)
-  and [Bytes](https://godoc.org/goa.design/goa/dsl#Bytes).
+  [Int](https://godoc.org/goa.design/goa/v3/dsl#Int),
+  [Int32](https://godoc.org/goa.design/goa/v3/dsl#Int32),
+  [Int64](https://godoc.org/goa.design/goa/v3/dsl#Int64),
+  [UInt](https://godoc.org/goa.design/goa/v3/dsl#UInt),
+  [UInt32](https://godoc.org/goa.design/goa/v3/dsl#UInt32),
+  [UInt64](https://godoc.org/goa.design/goa/v3/dsl#UInt64),
+  [Float32](https://godoc.org/goa.design/goa/v3/dsl#Float32),
+  [Float64](https://godoc.org/goa.design/goa/v3/dsl#Float64)
+  and [Bytes](https://godoc.org/goa.design/goa/v3/dsl#Bytes).
 * The types `DateTime` and `UUID` are deprecated in favor of
-  [String](https://godoc.org/goa.design/goa/dsl#String) and corresponding
-  [Format](https://godoc.org/goa.design/goa/dsl#Format)
+  [String](https://godoc.org/goa.design/goa/v3/dsl#String) and corresponding
+  [Format](https://godoc.org/goa.design/goa/v3/dsl#Format)
   validations.
 
 #### Example
@@ -132,10 +132,10 @@ var Person = ResultType("application/vnd.goa.person", func() {
 
 ### API
 
-The following changes have been made to the [API](https://godoc.org/goa.design/goa/dsl#API) DSL:
+The following changes have been made to the [API](https://godoc.org/goa.design/goa/v3/dsl#API) DSL:
 
-* The `Host`, `Scheme` and `BasePath` DSLs are replaced with [Server](https://godoc.org/goa.design/goa/dsl#Server).
-* The [Server](https://godoc.org/goa.design/goa/dsl#Server) DSL makes it possible to define server properties for different environments. Each server may list the services it hosts making it possible to define multiple servers in one design.
+* The `Host`, `Scheme` and `BasePath` DSLs are replaced with [Server](https://godoc.org/goa.design/goa/v3/dsl#Server).
+* The [Server](https://godoc.org/goa.design/goa/v3/dsl#Server) DSL makes it possible to define server properties for different environments. Each server may list the services it hosts making it possible to define multiple servers in one design.
 * `Origin` is now implemented as part of the [CORS plugin](https://github.com/goadesign/plugins/tree/v3/cors).
 * `ResponseTemplate` and `Trait` have been deprecated.
 
@@ -194,16 +194,16 @@ var _ = API("cellar", func() {
 
 ### Services
 
-The `Resource` function is now called [Service](https://godoc.org/goa.design/goa/dsl#Service). The
+The `Resource` function is now called [Service](https://godoc.org/goa.design/goa/v3/dsl#Service). The
 DSL is now organized into a transport agnostic section and transport specific DSLs. The transport
 agnostic section lists the potential errors returned by all the service methods. The transport
 specific sections then map these errors to HTTP status code or gRPC response codes.
 
-* `BasePath` is now called [Path](https://godoc.org/goa.design/goa/dsl#Path) and appears in the
-  [HTTP](https://godoc.org/goa.design/goa/dsl#HTTP) DSL.
-* `CanonicalActionName` is now called [CanonicalMethod](https://godoc.org/goa.design/goa/dsl#CanonicalMethod)
-  and appears in the [HTTP](https://godoc.org/goa.design/goa/dsl#HTTP) DSL.
-* `Response` is replaced with [Error](https://godoc.org/goa.design/goa/dsl#Error).
+* `BasePath` is now called [Path](https://godoc.org/goa.design/goa/v3/dsl#Path) and appears in the
+  [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) DSL.
+* `CanonicalActionName` is now called [CanonicalMethod](https://godoc.org/goa.design/goa/v3/dsl#CanonicalMethod)
+  and appears in the [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) DSL.
+* `Response` is replaced with [Error](https://godoc.org/goa.design/goa/v3/dsl#Error).
 * `Origin` is now implemented as part of the [CORS plugin](https://github.com/goadesign/plugins/tree/v3/cors).
 * `DefaultMedia` is deprecated.
 
@@ -243,16 +243,16 @@ Equivalent v3 design:
 
 ### Methods
 
-The `Action` function is replaced by [Method](https://godoc.org/goa.design/goa/dsl#Method). As with
+The `Action` function is replaced by [Method](https://godoc.org/goa.design/goa/v3/dsl#Method). As with
 services the DSL is organized into a transport agnostic section and transport specific DSLs. The
 transport agnostic section defines the payload and result types as well as all the possible method
 specific errors not already defined at the service level. The transport specific DSLs then map the
 payload and result type attributes to transport specific constructs such as HTTP headers, body etc.
 
-* Most of the DSL present in v1 is HTTP specific and thus moved to the [HTTP](https://godoc.org/goa.design/goa/dsl#HTTP) DSL.
-* The [Param](https://godoc.org/goa.design/goa/dsl#Param) and [Header](https://godoc.org/goa.design/goa/dsl#Header) functions
+* Most of the DSL present in v1 is HTTP specific and thus moved to the [HTTP](https://godoc.org/goa.design/goa/v3/dsl#HTTP) DSL.
+* The [Param](https://godoc.org/goa.design/goa/v3/dsl#Param) and [Header](https://godoc.org/goa.design/goa/v3/dsl#Header) functions
   now need only list the names of attributes of the corresponding method payload or result types.
-* Error responses now use the [Error](https://godoc.org/goa.design/goa/dsl#Error) DSL.
+* Error responses now use the [Error](https://godoc.org/goa.design/goa/v3/dsl#Error) DSL.
 * HTTP path parameters are now defined using curly braces instead of colons: `/foo/{id}` instead of `/foo/:id`.
 
 #### The mapping of input and output types

--- a/layouts/partials/en/navigation.html
+++ b/layouts/partials/en/navigation.html
@@ -25,7 +25,7 @@
 						<ul id="results"></ul>
 					</li>
 
-					<li><a href="https://godoc.org/goa.design/goa/v3" title="GoDoc"><i class="fa fa-book"></i></a></li>
+					<li><a href="https://pkg.go.dev/goa.design/goa/v3" title="GoDoc"><i class="fa fa-book"></i></a></li>
 					<li><a href="https://github.com/goadesign/goa" title="GitHub"><span style="display:none">Github</span> <i class="fa fa-github"></i></a></li>
 					{{ if .IsPage }}<li><a href="https://github.com/goadesign/goa.design/edit/master/content/{{ trim .RelPermalink "/" }}.md" title="Edit"><i class="fa fa-edit"></i></a></li>{{ end }}
 				</ul>

--- a/layouts/partials/en/navigation.html
+++ b/layouts/partials/en/navigation.html
@@ -25,7 +25,7 @@
 						<ul id="results"></ul>
 					</li>
 
-					<li><a href="https://godoc.org/goa.design/goa" title="GoDoc"><i class="fa fa-book"></i></a></li>
+					<li><a href="https://godoc.org/goa.design/goa/v3" title="GoDoc"><i class="fa fa-book"></i></a></li>
 					<li><a href="https://github.com/goadesign/goa" title="GitHub"><span style="display:none">Github</span> <i class="fa fa-github"></i></a></li>
 					{{ if .IsPage }}<li><a href="https://github.com/goadesign/goa.design/edit/master/content/{{ trim .RelPermalink "/" }}.md" title="Edit"><i class="fa fa-edit"></i></a></li>{{ end }}
 				</ul>

--- a/layouts/partials/it/navigation.html
+++ b/layouts/partials/it/navigation.html
@@ -25,7 +25,7 @@
 						<ul id="results"></ul>
 					</li>
 
-					<li><a href="https://godoc.org/goa.design/goa/v3" title="GoDoc"><i class="fa fa-book"></i></a></li>
+					<li><a href="https://pkg.go.dev/goa.design/goa/v3" title="GoDoc"><i class="fa fa-book"></i></a></li>
 					<li><a href="https://github.com/goadesign/goa" title="GitHub"><span style="display:none">Github</span> <i class="fa fa-github"></i></a></li>
 					{{ if .IsPage }}<li><a href="https://github.com/goadesign/goa.design/edit/master/content/{{ trim .RelPermalink "/" }}.md" title="Edit"><i class="fa fa-edit"></i></a></li>{{ end }}
 				</ul>

--- a/layouts/partials/it/navigation.html
+++ b/layouts/partials/it/navigation.html
@@ -25,7 +25,7 @@
 						<ul id="results"></ul>
 					</li>
 
-					<li><a href="https://godoc.org/goa.design/goa" title="GoDoc"><i class="fa fa-book"></i></a></li>
+					<li><a href="https://godoc.org/goa.design/goa/v3" title="GoDoc"><i class="fa fa-book"></i></a></li>
 					<li><a href="https://github.com/goadesign/goa" title="GitHub"><span style="display:none">Github</span> <i class="fa fa-github"></i></a></li>
 					{{ if .IsPage }}<li><a href="https://github.com/goadesign/goa.design/edit/master/content/{{ trim .RelPermalink "/" }}.md" title="Edit"><i class="fa fa-edit"></i></a></li>{{ end }}
 				</ul>

--- a/layouts/partials/ja/navigation.html
+++ b/layouts/partials/ja/navigation.html
@@ -25,7 +25,7 @@
 						<ul id="results"></ul>
 					</li>
 
-					<li><a href="https://godoc.org/goa.design/goa/v3" title="GoDoc"><i class="fa fa-book"></i></a></li>
+					<li><a href="https://pkg.go.dev/goa.design/goa/v3" title="GoDoc"><i class="fa fa-book"></i></a></li>
 					<li><a href="https://github.com/goadesign/goa" title="GitHub"><span style="display:none">Github</span> <i class="fa fa-github"></i></a></li>
 					{{ if .IsPage }}<li><a href="https://github.com/goadesign/goa.design/edit/master/content/{{ trim .RelPermalink "/" }}.md" title="Edit"><i class="fa fa-edit"></i></a></li>{{ end }}
 				</ul>

--- a/layouts/partials/ja/navigation.html
+++ b/layouts/partials/ja/navigation.html
@@ -25,7 +25,7 @@
 						<ul id="results"></ul>
 					</li>
 
-					<li><a href="https://godoc.org/goa.design/goa" title="GoDoc"><i class="fa fa-book"></i></a></li>
+					<li><a href="https://godoc.org/goa.design/goa/v3" title="GoDoc"><i class="fa fa-book"></i></a></li>
 					<li><a href="https://github.com/goadesign/goa" title="GitHub"><span style="display:none">Github</span> <i class="fa fa-github"></i></a></li>
 					{{ if .IsPage }}<li><a href="https://github.com/goadesign/goa.design/edit/master/content/{{ trim .RelPermalink "/" }}.md" title="Edit"><i class="fa fa-edit"></i></a></li>{{ end }}
 				</ul>


### PR DESCRIPTION
This pull request updates the existing GoDoc links in our documentation. Currently, these links point to the v2 documentation. This update modifies them to direct users to the more recent v3 GoDoc pages. This change ensures that users accessing the documentation are directed to the latest and most relevant information.

![Goa____Design_first_](https://github.com/goadesign/goa.design/assets/4232165/86463bc2-2bb0-4d27-9d0a-2ea8c7827627)

![Design_Overview_·_Goa____Design_first_](https://github.com/goadesign/goa.design/assets/4232165/f747a1e0-e900-46f9-9d54-52e7f5ba95c2)
