### PR TITLE
fix typo of 内蔵

### DIFF
--- a/layouts/index.ja.html
+++ b/layouts/index.ja.html
@@ -40,7 +40,7 @@
 
                 <div class="span4">
                     <span class="circle" style="background:#5DB9F2;"><i class="fa fa-bolt"></i></span>
-                    <h3 class="inline">内臓のベストプラクティス</h3>
+                    <h3 class="inline">内蔵のベストプラクティス</h3>
                     <p>
                     Goaは、ベストプラクティスに従ってマイクロサービスベースのシステムアーキテクチャ構築に適したコードを生成します。コードはレイヤーとして整理されているため、トランスポート固有の懸念事項がビジネスロジックに漏れたりすることはありません。
                     </p>


### PR DESCRIPTION
"内臓" and "内蔵" look similar but have completely different meanings in Japanese.

- 内臓: visceral organ; viscus; viscera
- 内蔵: built-in

In this case, we should use "内蔵"; the original English sentence is "Built-in Best Practice".

-----

[内臓](https://ja.wikipedia.org/w/index.php?title=%E5%86%85%E8%87%93&redirect=no) は胃、腸、肝臓などの臓器を表す単語です。
一方、[内蔵](https://ja.wikipedia.org/wiki/%E5%86%85%E8%94%B5) は「あるものが内部に別のものを納め持っていること」です。
原文は"Built-in"なので、対応する訳語としては「内蔵」のほうが適切です。