### PR TITLE
fix the hugo bind address to run in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 # Default Hugo port
 PORT ?= 1313
 
+# Default HUGO bind interface
+BIND ?= localhost
+
 # Colors for help text
 BLUE := \033[34m
 RESET := \033[0m
@@ -53,8 +56,8 @@ start: setup serve
 
 ## Start the Hugo server with live reload
 serve:
-	@echo "Starting Hugo server on http://localhost:$(PORT)..."
-	hugo server -D -p $(PORT) --disableFastRender
+	@echo "Starting Hugo server on http://$(BIND):$(PORT)..."
+	hugo server -D --bind $(BIND) -p $(PORT) --disableFastRender
 
 ## Clean generated files (public/ and resources/)
 clean:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Run in a terminal:
 
 ```bash
 cd goa.design;
-docker run --name goadocs --volume .:/go/src/app -p 1313:1313 -it golang:1.21.2 bash;
+docker run --name goadocs --volume .:/go/src/app -p 1313:1313 -e BIND=0.0.0.0 -it golang:1.21.2 bash;
 # in the container:
 cd /go/src/app;
 make;


### PR DESCRIPTION
`hugo` will bind - default - to localhost. When running in docker, we need to bind to any address or the development server won't be available to the exported port.

The Makefile will keep the default bind to `localhost` to keep the default security.