### PR TITLE
fixed prereqs dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Run in a terminal:
 
 ```bash
 cd goa.design;
-docker run --name goadocs --volume .:/go/src/app -p 1313:1313 -it golang:1.21.2 bash;
+docker run --name goadocs --volume .:/go/src/app -p 1313:1313 -it golang:1.24.2 bash;
 # in the container:
+curl -fsSL https://deb.nodesource.com/setup_22.x | bash -;
+apt install -y nodejs;
 cd /go/src/app;
 make;
 ```
@@ -41,7 +43,7 @@ To remove the container:
 ```bash
 docker stop goadocs;
 docker rm goadocs;
-docker rmi golang:1.21.2;
+docker rmi golang:1.24.2;
 ```
 
 ## Translations

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "goa.design",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
It turns out, that `make prereqs` wants to install a `hugo` release that won't work with the suggested `golang:1.21.2` version. It requires at least go 1.23.

This also clarifies the instructions of the README.md file, that the dockerized run requires nodejs.

Since we only need nodejs and npm, installing the versions that debian provides is a very slow process. So we mitigate this by using the nodejs version from nodejs.org.