### PR TITLE
fix: busted links for security>oauth2>next steps

### DIFF
--- a/content/en/docs/5-real-world/4-security/4-oauth2.md
+++ b/content/en/docs/5-real-world/4-security/4-oauth2.md
@@ -339,6 +339,6 @@ resources:
 
 ## Next Steps
 
-- [JWT Authentication](../3-jwt.md) - Often used with OAuth2
-- [API Key Authentication](../2-api-key.md) - A simpler alternative
-- [Security Best Practices](../5-best-practices.md) - General security guidelines
+- [JWT Authentication](3-jwt.md) - Often used with OAuth2
+- [API Key Authentication](2-api-key.md) - A simpler alternative
+- [Security Best Practices](5-best-practices.md) - General security guidelines


### PR DESCRIPTION
The Real World > Security > Next Steps links are busted.  This PR fixes them.

Page:  (https://www.goa.design/docs/5-real-world/4-security/4-oauth2/) 

![image](https://github.com/user-attachments/assets/95cd62c1-4a68-4ed9-86ec-49f49e2712f5)
