### PR TITLE
Fix #175: Responsive layout - Address horizontal overflow and clipping

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -465,15 +465,12 @@ body {
 
 // Layout - Main Container
 .td-main:not(.td-home .td-main) {
-  display: flex;
-  justify-content: center;
-  gap: 2em;
-  padding: 0 2em;
+  padding: 0;
   margin-top: 2rem;
 
   // Left Sidebar
   .td-sidebar {
-    width: 16rem;
+    width: 15rem;
     flex-shrink: 0;
     font-size: $font-size-sm;
     padding-top: 0 !important;
@@ -505,7 +502,7 @@ body {
   .td-main main,
   .container-fluid {
     padding-top: 0;
-    max-width: 850px;
+    max-width: 720px;
     width: 100%;
     padding-left: 1rem !important;
 
@@ -637,7 +634,7 @@ body {
 
   // Right Sidebar
   .td-sidebar-toc {
-    width: 16rem;
+    width: 13rem;
     font-size: $font-size-sm;
     border-left: 0;
     padding-top: 0 !important;
@@ -693,15 +690,6 @@ body {
       }
     }
   }
-}
-
-.container, .container-fluid {
-  padding-left: 0;
-  padding-right: 0;
-  margin-left: 0;
-  margin-right: 0;
-  width: 100%;
-  max-width: none;
 }
 
 // Section styling


### PR DESCRIPTION
This Pull Request addresses the responsive layout issues reported in #175.

**Problem:**
The documentation site previously exhibited horizontal overflow on desktop and content clipping on mobile, leading to a suboptimal user experience where content was not properly contained within the viewport.

**Solution:**
This PR implements adjustments to the `width` properties of key layout elements and refactors some existing CSS to ensure content fits correctly within the screen, improving responsiveness across devices. Specifically:

* The widths of the left sidebar (`.td-sidebar`), the right sidebar / Table of Contents (`.td-sidebar-toc`), and the main content area (`.container-fluid`) have been adjusted.
* The problematic CSS rule `".container, .container-fluid {"` was removed from the styling, as it was causing the horizontal scroll issue.

These changes eliminate the need for horizontal scrolling and prevent content clipping, providing a cleaner and more consistent reading experience.

**Visual Proof (Before & After):**

---
**Before Changes:**

<img width="320" alt="4-concepts_5-interceptors_1-goa-interceptors_4-best-practices_desktop_before" src="https://github.com/user-attachments/assets/9416355c-c763-46de-9c0e-46a6643fd0d6" />

<img width="86" alt="4-concepts_5-interceptors_1-goa-interceptors_4-best-practices_desktop_before" src="https://github.com/user-attachments/assets/c771f52c-fa3d-4e2f-b9c9-6baad9708fe5" />

---

---
**After Changes:**

<img width="320" alt="4-concepts_5-interceptors_1-goa-interceptors_4-best-practices_desktop_after" src="https://github.com/user-attachments/assets/d6c3cdf8-7218-420c-8624-6ab29f1035be" />

<img width="86" alt="4-concepts_5-interceptors_1-goa-interceptors_4-best-practices_desktop_after" src="https://github.com/user-attachments/assets/a55890fe-e8b6-4b89-b983-da5248758567" />

---

---