### PR TITLE
Fix: Optimize CI deployment triggers to prevent duplicate runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 name: Publish
 
 on:
-  pull_request:
-    types: [ closed ]
   push:
     branches: [ master ]
 env:


### PR DESCRIPTION
## Summary
- Remove pull_request trigger from publish workflow to eliminate duplicate deployments
- Keep only push to master trigger which automatically fires when PRs are merged
- Prevents deployment on PR creation/updates while ensuring merged PRs are properly deployed

## Test plan
- [ ] Verify workflow only runs on push to master
- [ ] Confirm merged PRs trigger deployment
- [ ] Ensure PR creation/updates don't trigger deployment

🤖 Generated with [Claude Code](https://claude.ai/code)