### PR TITLE
docs(jsonrpc): polish tutorials and concepts; fix frontmatter; clarify IDs, transports, batching/notifications; correct on-wire method names; refine error mapping

### DIFF
--- a/content/en/docs/3-tutorials/3-jsonrpc-service/1-designing.md
+++ b/content/en/docs/3-tutorials/3-jsonrpc-service/1-designing.md
@@ -1,0 +1,99 @@
+---
+title: "Designing a JSON‑RPC Service"
+linkTitle: "Designing"
+weight: 1
+description: "Learn to design a JSON‑RPC 2.0 service with Goa, including the shared endpoint, method exposure, ID mapping, and transport choices."
+---
+
+In this tutorial, you'll design a simple JSON‑RPC service with Goa. Goa
+provides first‑class support for JSON‑RPC 2.0 across HTTP, SSE, and WebSocket.
+
+What you'll learn:
+
+- Define a service and methods in Goa's DSL
+- Enable JSON‑RPC on the service and methods
+- Map JSON‑RPC IDs to fields
+- Choose transports (HTTP, SSE, WebSocket)
+
+## What We'll Build
+
+We'll create a `calculator` service with one method `add` that sums two
+integers.
+
+| Method | Description                 |
+|--------|-----------------------------|
+| add    | Returns the sum of `a + b`. |
+
+## 1. Create a new module and folder
+
+Create a fresh module `jsonrpccalc`:
+
+```bash
+mkdir jsonrpccalc
+cd jsonrpccalc
+go mod init jsonrpccalc
+```
+
+Create a `design/` directory:
+
+```bash
+mkdir design
+```
+
+## 2. Write the service design
+
+Create `design/calculator.go`:
+
+```go
+package design
+
+import (
+    . "goa.design/goa/v3/dsl"
+)
+
+// JSON‑RPC calculator service.
+var _ = Service("calculator", func() {
+    Description("A simple calculator exposed via JSON‑RPC")
+
+    // Expose this service via JSON‑RPC at POST /rpc
+    JSONRPC(func() { POST("/rpc") })
+
+    Method("add", func() {
+        Description("Add two integers")
+
+        Payload(func() {
+            Attribute("a", Int, "Left operand")
+            Attribute("b", Int, "Right operand")
+            Required("a", "b")
+        })
+
+        Result(func() {
+            Attribute("sum", Int, "Sum of a and b")
+            Required("sum")
+        })
+
+        // Enable JSON‑RPC for this method
+        JSONRPC(func() {})
+    })
+})
+```
+
+Key points:
+
+- `JSONRPC(func(){ POST("/rpc") })` defines a single shared HTTP route for all
+  service methods.
+- Each method exposed via JSON‑RPC declares `JSONRPC(func(){})`.
+- ID handling is automatic for non‑streaming: the response envelope `id` equals
+  the request `id`. You do not need to include ID fields. If you need to access
+  the ID in your handler, add `ID("request_id", String)` to the payload.
+- SSE and HTTP share the same route; content negotiation picks SSE when
+  `Accept: text/event-stream`.
+
+## 3. Next steps
+
+Proceed to [Implementing the Service](./2-implementing.md) to generate code and
+add the business logic.
+
+See also: [JSON‑RPC Overview](../../4-concepts/7-jsonrpc/1-overview).
+
+

--- a/content/en/docs/3-tutorials/3-jsonrpc-service/2-implementing.md
+++ b/content/en/docs/3-tutorials/3-jsonrpc-service/2-implementing.md
@@ -1,0 +1,66 @@
+---
+title: "Implementing the Service"
+linkTitle: "Implementing"
+weight: 2
+description: "Generate code and implement a basic JSON‑RPC service in Goa."
+---
+
+In this step you will generate code and implement the `calculator` service.
+
+## 1. Generate code
+
+```bash
+go install goa.design/goa/v3/cmd/goa@latest
+goa gen jsonrpccalc/design
+```
+
+This generates server and client code for JSON‑RPC over HTTP (and SSE if your
+methods use streaming results). For WebSocket streaming, see the JSON‑RPC
+concepts section.
+
+## 2. Implement service logic
+
+Create `cmd/server/main.go` and implement the `Add` method in the generated
+`service` package. The implementation mirrors the REST/gRPC tutorials.
+
+Example minimal server wiring:
+
+```go
+// cmd/server/main.go
+package main
+
+// Import generated packages for your service and the generated JSON‑RPC HTTP server.
+// The exact import paths depend on your module name and service name.
+
+type calcSvc struct{}
+
+// Implement the generated interface method.
+// func (calcSvc) Add(ctx context.Context, p *calc.AddPayload) (*calc.AddResult, error) {
+//     return &calc.AddResult{Sum: p.A + p.B}, nil
+// }
+
+func main() {
+    // 1) Create the service implementation
+    // 2) Build endpoints with the generated helper
+    // 3) Mount the generated JSON‑RPC HTTP server on your mux
+    // 4) Start the HTTP server on :8080
+}
+```
+
+Notes on IDs and streaming (authoritative):
+
+- Non‑streaming: If you don't declare an `ID()` field, the framework still
+  correlates responses using the request envelope `id`. Add `ID("request_id",
+  String)` in the payload only if your handler needs to read the `id` value.
+- SSE: `SendAndClose` sets the response envelope `id` to the result ID if set,
+  otherwise to the original request `id`.
+- WebSocket: bidirectional streaming uses a single connection per service; use
+  `StreamingPayload`/`StreamingResult` and include `ID()` in both when you need
+  typed correlation.
+
+## 3. Run the server
+
+Proceed to [Running](./3-running.md) to start the server and call it over HTTP
+and SSE.
+
+

--- a/content/en/docs/3-tutorials/3-jsonrpc-service/3-running.md
+++ b/content/en/docs/3-tutorials/3-jsonrpc-service/3-running.md
@@ -1,0 +1,48 @@
+---
+title: "Running the Service"
+linkTitle: "Running"
+weight: 3
+description: "Run and call the JSON‑RPC service over HTTP and SSE."
+---
+
+Start the server (from your module root):
+
+```bash
+go run ./cmd/server
+```
+
+### Call over HTTP
+
+Use curl to send a JSON‑RPC request:
+
+```bash
+curl -s -X POST localhost:8080/rpc -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":"1","method":"add","params":{"a":2,"b":40}}'
+```
+
+### Call over SSE (server‑streaming)
+
+When your method uses mixed results (non‑streaming + streaming), request SSE:
+
+```bash
+curl -N -X POST localhost:8080/rpc -H 'Accept: text/event-stream' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":"1","method":"add","params":{"a":2,"b":40}}'
+```
+
+### WebSocket (bidirectional streaming)
+
+For bidirectional streaming, expose the JSON‑RPC endpoint with `GET` to allow WebSocket upgrade and use `StreamingPayload`/`StreamingResult` in your design. Clients maintain a single connection per service and exchange JSON‑RPC messages over it.
+
+### Batching and notifications
+
+- To send a notification, omit the `id` in the request body; the server will not send a response.
+- To batch, send an array of request objects; the response is an array of results in the same order (notifications produce no entry).
+
+For details, see the JSON‑RPC concepts pages:
+
+- [WebSocket Streaming](../../4-concepts/7-jsonrpc/4-websocket-streaming)
+- [Batching and Notifications](../../4-concepts/7-jsonrpc/5-batching-and-notifications)
+- [Error Mapping](../../4-concepts/7-jsonrpc/6-error-mapping)
+
+

--- a/content/en/docs/3-tutorials/3-jsonrpc-service/_index.md
+++ b/content/en/docs/3-tutorials/3-jsonrpc-service/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Basic JSON‑RPC Service"
+linkTitle: "Basic JSON‑RPC Service"
+weight: 3
+description: "Design and implement a simple JSON‑RPC 2.0 service in Goa. Learn the DSL, ID mapping, transports (HTTP, SSE, WebSocket), notifications, and batching."
+---
+
+Build a small but complete JSON‑RPC 2.0 service using Goa’s design‑first workflow. You will define the API with the DSL, generate type‑safe code, implement the business logic, and run the service over HTTP, Server‑Sent Events (SSE), and WebSocket.
+
+### What you'll learn
+
+- JSON‑RPC service design using the Goa DSL
+- How JSON‑RPC IDs map to your payloads and results
+- Choosing between HTTP, SSE, and WebSocket (and when)
+- Sending notifications and batches
+- Running and calling the service with curl and the generated client
+
+### Prerequisites
+
+- Go 1.21+ installed
+- `goa` code generator installed (`go install goa.design/goa/v3/cmd/goa@latest`)
+- Basic familiarity with Goa’s REST/gRPC tutorials is helpful but not required
+
+### What you'll build
+
+A `calculator` service with a single `Add` method exposed via JSON‑RPC. You can call it over HTTP for simple request/response, and extend it to SSE/WebSocket as you progress.
+
+Continue with the first step: [Designing the Service](./1-designing.md).
+

--- a/content/en/docs/4-concepts/7-jsonrpc/1-overview.md
+++ b/content/en/docs/4-concepts/7-jsonrpc/1-overview.md
@@ -1,0 +1,50 @@
+---
+title: "JSON‑RPC Overview"
+weight: 1
+---
+
+Goa supports JSON‑RPC 2.0 over multiple transports:
+
+- HTTP (unary requests and responses)
+- HTTP Server‑Sent Events (SSE) for server‑initiated streaming
+- WebSocket for bidirectional streaming
+
+Key properties:
+
+- Batch requests and notifications are supported where applicable.
+- The same JSON‑RPC HTTP route can serve SSE by content negotiation using the
+  `Accept` header (`application/json` vs. `text/event-stream`).
+- JSON‑RPC WebSocket uses a single connection per service, shared by all
+  methods.
+
+Related concepts: see [Transports](../6-transports) for the matrix of allowed
+combinations within one service and per method.
+
+
+### Topics in this section
+
+- [IDs and Envelope Mapping](./2-ids-and-envelope)
+- [HTTP and SSE Semantics](./3-http-and-sse)
+- [WebSocket Streaming](./4-websocket-streaming)
+- [Batching and Notifications](./5-batching-and-notifications)
+- [Error Mapping](./6-error-mapping)
+
+If you prefer a guided build, start with the tutorial: [Basic JSON‑RPC Service](../../3-tutorials/3-jsonrpc-service/).
+
+### Method names
+
+On the wire, the JSON‑RPC `method` value is the DSL method name (for example: `add`). Each service has a single JSON‑RPC endpoint, so names are scoped to the service and do not need a `service.method` prefix.
+
+### Transport summary
+
+| Transport | Connection            | Patterns                         | Batching            | Notifications |
+|-----------|-----------------------|----------------------------------|---------------------|---------------|
+| HTTP      | Request/response      | Non‑streaming (unary)            | Yes (array body)    | Client → Yes  |
+| SSE       | Long‑lived HTTP resp. | Server streaming, mixed results  | Not applicable      | Server → Yes  |
+| WebSocket | Persistent (full‑duplex) | Client streaming, server streaming, bidirectional | Not typical (message‑oriented) | Both directions |
+
+Notes:
+
+- SSE shares the same route as HTTP. The client selects SSE via `Accept: text/event-stream` and the method must declare a streaming result (or mixed results).
+- WebSocket is enabled by using `GET` on the JSON‑RPC endpoint. Non‑streaming methods are not supported over JSON‑RPC WebSocket.
+

--- a/content/en/docs/4-concepts/7-jsonrpc/2-ids-and-envelope.md
+++ b/content/en/docs/4-concepts/7-jsonrpc/2-ids-and-envelope.md
@@ -1,0 +1,100 @@
+---
+title: "IDs and Envelope Mapping"
+weight: 2
+---
+
+This page summarizes how JSON‑RPC IDs map to your Goa design and how they behave
+at runtime across transports.
+
+## Design rules
+
+- To map the JSON‑RPC `id` field in your Goa design, use the `ID("request_id", String)` DSL function within your payload or result type. This marks the attribute that will carry the JSON‑RPC `id` value in requests or responses, enabling correlation between requests and responses.
+- In your design, the attribute specified by `ID()` must always be of type `String`. While the JSON‑RPC protocol allows `id` values to be either strings or numbers on the wire, the Goa framework will automatically accept numeric IDs from clients and normalize them to strings internally. This ensures consistent handling of IDs in your service logic.
+- You may declare an ID attribute in the result type only if the payload also declares an ID. This restriction ensures that the response can be properly correlated with the original request. If the payload does not include an ID, the result type should not declare one either, as there would be no request ID to propagate or return.
+
+## Non‑streaming (HTTP)
+
+- If the result ID is not set in your result type, the Goa framework will automatically set the response envelope's `id` field to match the original request's `id`. This means that, unless you explicitly include an ID attribute in your result and set its value, the server will handle the correlation for you by copying the request `id` into the response envelope. Importantly, in this case, the server does not inject the envelope `id` value into your result struct—your handler code will not see the `id` field in the result object unless you have explicitly declared it.
+
+- If you want your handler logic to access the request `id` (for example, to log it, propagate it to downstream systems, or include it in your result), you should declare an ID attribute in your payload using the `ID()` DSL function. This makes the request `id` available to your handler as part of the payload struct. However, if your handler does not need to access the request `id`, you can omit the `ID()` declaration in the payload, and the framework will still handle request-response correlation transparently.
+
+- Declaring an ID attribute in the result type is only necessary if you want to explicitly control the value of the response envelope's `id` (for example, to echo back a modified or application-specific ID), or if you want the handler to have access to the `id` in the result struct. In most cases, for non-streaming HTTP methods, it is sufficient to declare the ID in the payload only when needed, and omit it from the result unless you have a specific use case.
+
+## SSE (server streaming)
+
+- `Send(ctx, event)` emits a JSON‑RPC notification to the client. In the context of SSE (Server-Sent Events), this means the message sent does not include an `id` field in the JSON‑RPC envelope. Notifications are "fire-and-forget" messages: the client receives the event, but there is no request/response correlation, and the client should not expect a reply or acknowledgment for these messages. This is useful for server-initiated updates, such as progress events, logs, or other asynchronous information.
+
+- `SendAndClose(ctx, result)` sends a final JSON‑RPC response to the client and closes the stream. The response envelope's `id` field is determined as follows:
+  - If your result type includes an ID attribute (declared with `ID()` and set in your handler), the framework uses this value as the envelope's `id`. To prevent the same ID from appearing both in the envelope and inside the result object (which would be redundant), the framework automatically clears the ID field from the result before serializing it.
+  - If your result type does not include an ID attribute, or if the ID is not set, the framework automatically copies the original request's `id` into the response envelope. In this case, the result object sent to the client does not contain an ID field, but the envelope still provides the necessary correlation.
+  - This mechanism ensures that the client can always match the response to the original request, either by a custom ID you provide or by the framework's automatic propagation of the request ID.
+
+**Summary**
+
+- **Use `Send` for server-initiated notifications:**  
+  When you call `Send(ctx, event)` in an SSE (Server-Sent Events) method, the framework emits a JSON‑RPC notification to the client. In this case, the outgoing JSON‑RPC envelope does **not** include an `id` field. This is because notifications are designed to be "fire-and-forget" messages: the server sends information to the client (such as progress updates, logs, or asynchronous events), but the client does not send a response or acknowledgment, and there is no request/response correlation. This pattern is ideal for scenarios where the server needs to push updates to the client without expecting any reply.
+
+- **Use `SendAndClose` for final responses:**  
+  When you call `SendAndClose(ctx, result)`, the framework sends a final JSON‑RPC response to the client and closes the stream. The handling of the envelope's `id` field depends on your result type:
+
+    - If your result type **includes an ID attribute** (declared with `ID()` and set in your handler), the framework uses this value as the envelope's `id`. To avoid redundancy, the framework automatically removes the ID field from the result object before serializing it, so the ID only appears in the envelope and not inside the result payload.
+
+    - If your result type **does not include an ID attribute**, or if the ID is not set, the framework automatically copies the original request's `id` into the response envelope. In this case, the result object sent to the client does not contain an ID field, but the envelope still provides the necessary correlation.
+
+  This mechanism ensures that the client can always match the final response to the original request, either by a custom ID you provide or by the framework's automatic propagation of the request ID. The framework manages the envelope and result fields for you, preventing duplication and ensuring correct request-response correlation in all cases.
+
+## WebSocket (streaming)
+
+- When the server sends a reply to a client-initiated message over a WebSocket connection, the framework automatically uses the original request's `id` value in the response envelope. This ensures that each response can be correctly correlated with the corresponding request, even when multiple messages are in flight simultaneously.
+
+- If you want to enable bidirectional correlation—meaning both client and server can send messages that need to be matched with responses at the type level—you should declare an `ID()` attribute in both the `StreamingPayload` and `StreamingResult` types in your Goa design. This allows both sides to include and access the `id` in their respective message types, making it possible to match requests and responses programmatically within your handler logic.
+
+- For server-initiated notifications (messages sent by the server that are not replies to a specific client request), the framework omits the `id` field from the JSON‑RPC envelope. These notifications are "fire-and-forget" messages: the client receives them but does not send a response or acknowledgment, and there is no request/response correlation. This is useful for scenarios such as server-driven updates, alerts, or broadcast messages where no reply is expected.
+
+## When to use `ID()`
+
+- **Non‑streaming methods (HTTP/SSE):**  
+  Use `ID()` in the payload type if you want your handler to access the request `id` (for example, for logging, tracing, or propagating to downstream systems). Declaring `ID()` in the payload is optional—if omitted, the framework will still handle request-response correlation automatically, but your handler will not see the `id` in the payload struct.  
+  Use `ID()` in the result type only if you want to explicitly control the value of the response envelope's `id` (for example, to echo back a modified or application-specific ID), or if you want the handler to have access to the `id` in the result struct. In most cases, for non-streaming methods, declaring `ID()` in the payload is sufficient, and you can omit it from the result unless you have a specific need.
+
+- **WebSocket bidirectional streaming:**  
+  For full bidirectional correlation—where both client and server can send messages that need to be matched with responses—declare `ID()` in both the `StreamingPayload` and `StreamingResult` types. This allows both sides to include and access the `id` in their respective message types, enabling programmatic correlation of requests and responses within your handler logic.
+
+- **Notifications (fire-and-forget messages):**  
+  Do **not** declare `ID()` in the payload or result types for notifications. Notifications are messages that do not expect a response and are not correlated with a request, so the `id` field is omitted from the JSON‑RPC envelope. This applies to both client-initiated notifications (HTTP) and server-initiated notifications (SSE/WebSocket).
+
+### DSL examples
+
+Correlate request ids in handlers (non‑streaming):
+
+```go
+Method("track", func() {
+    Payload(func() {
+        ID("request_id", String)
+        Attribute("action", String)
+        Required("request_id", "action")
+    })
+    Result(func() { /* ... */ })
+    JSONRPC(func() {})
+})
+```
+
+Bidirectional correlation over WebSocket:
+
+```go
+Method("echo", func() {
+    StreamingPayload(func() {
+        ID("msg_id", String)
+        Attribute("text", String)
+        Required("msg_id", "text")
+    })
+    StreamingResult(func() {
+        ID("msg_id", String)
+        Attribute("echo", String)
+        Required("msg_id", "echo")
+    })
+    JSONRPC(func() {})
+})
+```
+
+

--- a/content/en/docs/4-concepts/7-jsonrpc/3-http-and-sse.md
+++ b/content/en/docs/4-concepts/7-jsonrpc/3-http-and-sse.md
@@ -1,0 +1,57 @@
+---
+title: "HTTP and SSE Semantics"
+weight: 3
+---
+
+HTTP and SSE share the same JSON‑RPC route (typically `POST /rpc`). The client selects SSE by sending `Accept: text/event-stream`. SSE is valid only for methods that declare a streaming result (or mixed results).
+
+## HTTP (unary)
+
+- Regular request/response.
+- Batch requests supported (array of request objects in the body).
+- Notifications are requests without `id` (no response is sent).
+
+Typical curl example:
+
+```bash
+curl -s -X POST localhost:8080/rpc -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":"1","method":"method","params":{}}'
+```
+
+## SSE (server streaming)
+
+- Server emits a sequence of events; each JSON‑RPC notification or response is a separate SSE event.
+- Use `Send(ctx, event)` to send notifications; use `SendAndClose(ctx, result)` to send the final JSON‑RPC response and finish the stream.
+- The SSE `id:` field mirrors the JSON‑RPC response `id` when present.
+
+Requesting SSE with curl:
+
+```bash
+curl -N -X POST localhost:8080/rpc -H 'Accept: text/event-stream' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":"1","method":"stream","params":{}}'
+```
+
+## Mixed results
+
+- Define both `Result` and `StreamingResult` to support content negotiation between HTTP and SSE on the same endpoint.
+- The server chooses HTTP vs. SSE based on `Accept`.
+
+Design sketch:
+
+```go
+Method("report", func() {
+    Payload(func() { /* ... */ })
+    Result(func() { /* non-streaming shape for HTTP */ })
+    StreamingResult(func() { /* streaming shape for SSE */ })
+    JSONRPC(func() { ServerSentEvents(func() {}) })
+})
+```
+
+Operational tips:
+
+- Set `Cache-Control: no-store` on SSE responses to avoid intermediary caching.
+- Send periodic keep‑alives (e.g., empty comments) if clients or proxies time out idle connections.
+- Limit SSE event size and frequency to avoid client buffer issues.
+
+

--- a/content/en/docs/4-concepts/7-jsonrpc/4-websocket-streaming.md
+++ b/content/en/docs/4-concepts/7-jsonrpc/4-websocket-streaming.md
@@ -1,0 +1,51 @@
+---
+title: "WebSocket Streaming"
+weight: 4
+---
+
+JSON‑RPC over WebSocket uses a single connection per service shared by all
+methods. Non‑streaming methods are not supported over JSON‑RPC WebSocket.
+
+## Patterns
+
+- StreamingPayload only: client‑to‑server notifications.
+- StreamingResult only: server‑to‑client notifications (no request `id`).
+- Both StreamingPayload and StreamingResult: bidirectional streaming.
+
+## Guidelines
+
+- Use `GET` on the JSON‑RPC endpoint for WebSocket.
+- Include `ID()` in both streaming payload and result to correlate messages at
+  the type level when needed.
+- Do not mix JSON‑RPC WebSocket endpoints with pure HTTP WebSocket endpoints in
+  the same service.
+
+Server handler sketch:
+
+```go
+func (s *service) HandleStream(ctx context.Context, stream svc.Stream) error {
+    defer stream.Close()
+    for {
+        if _, err := stream.Recv(ctx); err != nil { return err }
+        // Incoming messages are dispatched to generated method handlers.
+    }
+}
+```
+
+Replying to a client request inside a method:
+
+```go
+func (s *service) Echo(ctx context.Context, p *svc.EchoPayload, stream svc.EchoServerStream) error {
+    return stream.SendResponse(ctx, &svc.EchoResult{ /* echo fields */ })
+}
+```
+
+Lifecycle and errors:
+
+- The generated server upgrades HTTP to WebSocket and then calls your `HandleStream` method.
+- `Recv` decodes an incoming JSON‑RPC message and dispatches to the appropriate generated method handler.
+- When a request `id` is present, `SendResponse` and `SendError` correlate replies using that id automatically.
+- For malformed messages without an `id`, the server may ignore them to keep the connection alive.
+- Close the stream on unrecoverable errors; transient network issues should be retried by the client with backoff.
+
+

--- a/content/en/docs/4-concepts/7-jsonrpc/5-batching-and-notifications.md
+++ b/content/en/docs/4-concepts/7-jsonrpc/5-batching-and-notifications.md
@@ -1,0 +1,91 @@
+---
+title: "Batching and Notifications"
+weight: 5
+---
+
+Batching and notifications make JSON‑RPC efficient and flexible. Batching lets a client send multiple calls in a single HTTP request. Notifications let a client (or server in streaming transports) send fire‑and‑forget messages that do not expect a response.
+
+## Batching
+
+When to use:
+
+- Reduce network round‑trips when performing several independent calls.
+- Improve throughput for chatty clients that can tolerate independent failures.
+
+Behavior:
+
+- The request body is an array of JSON‑RPC request objects.
+- Each entry is processed independently; responses are returned as an array in the same order.
+- Entries that are notifications (missing `id`) do not produce response entries.
+
+Request body (JSON only):
+
+```json
+[
+  {"jsonrpc": "2.0", "id": "1", "method": "add", "params": {"a": 1, "b": 2}},
+  {"jsonrpc": "2.0", "id": "2", "method": "add", "params": {"a": 10, "b": 20}},
+  {"jsonrpc": "2.0", "method": "add", "params": {"a": 5, "b": 5}}
+]
+```
+
+Example HTTP call:
+
+```http
+POST /rpc HTTP/1.1
+Content-Type: application/json
+
+[ ... see JSON body above ... ]
+```
+
+Response:
+
+```json
+[
+  {"jsonrpc": "2.0", "result": {"sum": 3},  "id": "1"},
+  {"jsonrpc": "2.0", "result": {"sum": 30}, "id": "2"}
+]
+```
+
+Notes and pitfalls:
+
+- IDs should be unique per batch; duplicates are permitted by the spec but make correlation ambiguous.
+- Batches are not atomic. Some entries can succeed while others fail.
+- Avoid mixing long‑running and short operations in the same batch to reduce head‑of‑line blocking on the client.
+- Enforce reasonable body size limits to prevent abuse.
+
+## Notifications
+
+What they are:
+
+- A JSON‑RPC request without an `id`. The sender does not expect a response.
+- On SSE/WebSocket, server‑initiated messages are notifications by definition and also omit `id`.
+
+When to use:
+
+- Logging, telemetry, presence, or any update where the sender does not need a reply.
+- Server‑to‑client updates in streaming sessions.
+
+Client example (HTTP notification):
+
+```json
+{"jsonrpc": "2.0", "method": "audit.log", "params": {"action": "login", "user": "alice"}}
+```
+
+Guidelines:
+
+- Do not rely on notifications for critical operations; there is no delivery guarantee.
+- Prefer small, self‑contained payloads; large notifications cannot be retried safely.
+- For observability, consider sending a follow‑up request when acknowledgement is required.
+
+## Design and implementation
+
+- No special DSL is required for batching; any JSON‑RPC method exposed over HTTP can be batched.
+- Notifications are created by clients omitting the `id`. Server‑side, use the streaming helpers (`Send`, `SendNotification`) to emit notifications on SSE/WebSocket.
+
+## Best practices
+
+- Map application errors to appropriate JSON‑RPC codes so batch responses are predictable.
+- Document which methods are safe to call as notifications.
+- Validate batch sizes and entries server‑side; reject malformed entries with proper error codes.
+
+

--- a/content/en/docs/4-concepts/7-jsonrpc/6-error-mapping.md
+++ b/content/en/docs/4-concepts/7-jsonrpc/6-error-mapping.md
@@ -1,0 +1,105 @@
+---
+title: "Error Mapping"
+weight: 6
+---
+
+Map your service errors to JSON‑RPC error codes using the DSL. Clear mappings
+help clients reason about failures and build robust retries.
+
+## Standard codes
+
+The JSON‑RPC 2.0 specification defines a set of standard error codes that are reserved for core protocol errors. These codes are negative integers and each represents a specific type of failure that can occur during the processing of a JSON‑RPC request:
+
+- **Parse error (`-32700`)**  
+  This error occurs when the server receives invalid JSON and is unable to parse the request. It typically indicates a syntax error in the JSON sent by the client.
+
+- **Invalid request (`-32600`)**  
+  The received JSON is syntactically valid, but the structure of the request does not conform to the JSON‑RPC protocol (for example, missing required fields like `jsonrpc`, `method`, or `params`).
+
+- **Method not found (`-32601`)**  
+  The requested method does not exist or is not available on the server. This is returned when the `method` field in the request does not match any known method.
+
+- **Invalid params (`-32602`)**  
+  The parameters provided in the request are invalid or do not match the expected types or structure for the method. This can include missing required parameters or parameters of the wrong type.
+
+- **Internal error (`-32603`)**  
+  An internal JSON‑RPC error occurred on the server while processing the request. This is a generic error for unexpected conditions not covered by the other codes.
+
+These standard codes are reserved for protocol-level errors and should be used as appropriate to help clients distinguish between different classes of failures.
+
+## Error declarations and scope
+
+Goa lets you declare errors at three levels. The level determines both visibility and whether an error is considered returnable by a method.
+
+- API level (top‑level `API(...)`):
+  - Define the error details once (description, attributes/shape) so it can be referenced by services and methods.
+  - Optionally define a default transport mapping (when supported) so the code mapping does not need to be repeated.
+  - Declaring an error at the API level DOES NOT mean any method can return it. Methods must still opt‑in (directly or via service‑level declaration).
+
+- Service level (`Service(...)`):
+  - Referencing `Error("name")` here means any method of the service may return this error.
+  - You can also provide a service‑wide JSON‑RPC mapping in the service `JSONRPC` block. Methods can still override it.
+
+- Method level (`Method(...)`):
+  - Declare or reference `Error("name")` to state the method may return it.
+  - Provide method‑specific JSON‑RPC mapping in the method `JSONRPC` block when it differs from the service‑wide mapping.
+
+Mapping precedence: method mapping overrides service mapping, which overrides any default defined at a higher level.
+
+## How to map
+
+Typical pattern:
+
+1) Define the error once (API level), including description and, if desired, a default mapping.
+2) Make the error returnable where needed (service or method level) and provide more specific mappings only when necessary.
+
+### Example
+
+```go
+// API level: define the error details once (does not make it returnable)
+var _ = API("calc", func() {
+    Error("unauthorized", func() { Description("User is not authenticated") })
+    // Optionally define a default mapping if supported in your setup
+    // JSONRPC(func() { Response("unauthorized", func() { Code(-32001) }) })
+})
+
+// Service level: make the error returnable by any method in this service
+var _ = Service("calc", func() {
+    JSONRPC(func() { POST("/rpc") })
+
+    Error("unauthorized") // now any method may return it
+
+    // Service‑wide mapping (methods can override)
+    JSONRPC(func() {
+        Response("unauthorized", func() { Code(-32001) })
+    })
+
+    Method("divide", func() {
+        Payload(func() {
+            Attribute("a", Int)
+            Attribute("b", Int)
+            Required("a", "b")
+        })
+        Result(Int)
+
+        // Method‑specific error
+        Error("div_zero")
+        JSONRPC(func() { Response("div_zero", func() { Code(-32602) }) })
+    })
+})
+```
+
+## Summary
+
+- API‑level error: defines details/mapping reuse only; does not imply returnability.
+- Service‑level error: makes the error returnable by any method of the service.
+- Method‑level error: makes the error returnable by that method (and can override mappings).
+
+## Guidelines
+
+- Prefer specific application errors mapped to appropriate codes.
+- Unmapped errors default to Internal error (-32603).
+
+Tip: Use consistent application error messages and, when helpful, include `data` with structured fields that aid debugging and client UX.
+
+

--- a/content/en/docs/4-concepts/7-jsonrpc/_index.md
+++ b/content/en/docs/4-concepts/7-jsonrpc/_index.md
@@ -1,0 +1,16 @@
+---
+title: "JSON‑RPC Advanced Topics"
+linkTitle: "JSON‑RPC"
+weight: 7
+description: "Designing and implementing JSON‑RPC 2.0 services in Goa: transports (HTTP, SSE, WebSocket), streaming patterns, batching, and notifications."
+---
+
+This section provides focused guidance for building JSON‑RPC 2.0 services with
+Goa. It complements the high‑level transport matrix by detailing the JSON‑RPC
+DSL, transport semantics, streaming patterns, batching, notifications, and error
+mapping.
+
+If you are new to transport combinations, start with the [Transports](../6-transports)
+page, then return here for JSON‑RPC specifics.
+
+


### PR DESCRIPTION
This PR improves the new JSON-RPC docs:

- Fix frontmatter and formatting
- Clarify on-wire method naming (method == DSL method name)
- Expand overview with transport matrix and method naming note
- Improve HTTP/SSE and WebSocket pages (examples, lifecycle, ops tips)
- Rework batching & notifications narrative with examples and best practices
- Flesh out IDs/envelope page with DSL examples and structure
- Clarify error declaration semantics (API vs service vs method) and mapping precedence

All examples updated accordingly.