### PR TITLE
Upgrade Docsy to v0.15.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Build
         run: hugo --minify
         env:
+          BROWSERSLIST_ROOT_PATH: .
           HUGO_GIT_SHA: ${{ github.sha }}
 
       - name: Auth

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ help:
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 	@echo
 
-## Initialize Hugo modules and install dependencies
+## Resolve pinned Hugo modules
 setup:
-	hugo mod get -u
+	go mod download
 	hugo mod tidy
 
 ## Start the Hugo server with live reload (alias for 'serve')

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ start: setup serve
 ## Start the Hugo server with live reload
 serve:
 	@echo "Starting Hugo server on http://$(BIND):$(PORT)..."
-	hugo server -D --bind $(BIND) -p $(PORT) --disableFastRender
+	BROWSERSLIST_ROOT_PATH=. hugo server -D --bind $(BIND) -p $(PORT) --disableFastRender
 
 ## Clean generated files (public/ and resources/)
 clean:
@@ -69,7 +69,7 @@ clean:
 ## Build the site for production with minification
 build: setup diagrams
 	@echo "Building site..."
-	hugo --minify
+	BROWSERSLIST_ROOT_PATH=. hugo --minify
 
 ## Generate architecture diagrams from Model DSL
 diagrams:

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ clean:
 ## Build the site for production with minification
 build: setup diagrams
 	@echo "Building site..."
-	hugo --minify
+	BROWSERSLIST_ROOT_PATH=. hugo --minify
 
 ## Generate architecture diagrams from Model DSL
 diagrams:

--- a/config.toml
+++ b/config.toml
@@ -191,3 +191,9 @@ defaultContentLanguageInSubdir = false
   resampleFilter = "CatmullRom"
   quality = 75
   anchor = "smart"
+
+[security]
+  [security.exec]
+    # Keep Hugo's default exec environment allowlist, plus BROWSERSLIST_ROOT_PATH
+    # so Browserslist stops searching for config above the repository root.
+    osEnv = ['(?i)^((HTTPS?|NO)_PROXY|PATH(EXT)?|APPDATA|TE?MP|TERM|GO\w+|(XDG_CONFIG_)?HOME|USERPROFILE|SSH_AUTH_SOCK|DISPLAY|LANG|SYSTEMDRIVE|PROGRAMDATA|BROWSERSLIST_ROOT_PATH)$']

--- a/config.toml
+++ b/config.toml
@@ -3,9 +3,6 @@
   [[module.imports]]
     path = "github.com/google/docsy"
     disable = false
-  [[module.imports]]
-    path = "github.com/google/docsy/dependencies"
-    disable = false
 
 baseURL = "https://goa.design/"
 title = "Goa"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/goadesign/goa.design
 
 go 1.23.3
+
+require github.com/google/docsy v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.15.0 h1:MNJ1nrE2ZuweXlUNaegTo/UbSKZJu+WMczahfZaxosI=
+github.com/google/docsy v0.15.0/go.mod h1:1Fj1W1O3esZh7IBQ8XAYtxtg10udBXuGI89+LUQc1AU=
+github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
The earlier upgrade commit said it upgraded Docsy (https://github.com/goadesign/goa.design/pull/220/changes/995b6ac00ad058e3137af380c9f34800ce02c032), but it removed the module requirements from `go.mod`, so the project no longer explicitly pinned Docsy at all.

This PR restores the intended Hugo module setup by declaring Docsy as the direct site dependency, removes the obsolete `docsy/dependencies` import, and keeps Bootstrap and Font Awesome as transitive dependencies provided by Docsy.

It also prevents `make setup` from silently upgrading Hugo modules and fixes the Hugo v0.161+/PostCSS/Browserslist build failure caused by Node permission restrictions.

## Changes

- Pin `github.com/google/docsy v0.15.0` as the direct Hugo module dependency.
- Remove the obsolete `github.com/google/docsy/dependencies` module import.
- Stop running `hugo mod get -u` during setup.
- Download the pinned Go/Hugo module graph with `go mod download`.
- Constrain Browserslist config lookup to the repository root during Hugo builds.
- Allow `BROWSERSLIST_ROOT_PATH` through Hugo’s exec environment allowlist.

## Validation

- `make setup`
- `hugo mod graph`
- `BROWSERSLIST_ROOT_PATH=. hugo --minify`