### PR TITLE
Document Goa-AI tool recovery choices

### DIFF
--- a/content/en/docs/2-goa-ai/runtime.md
+++ b/content/en/docs/2-goa-ai/runtime.md
@@ -852,6 +852,30 @@ The runtime chooses one next state in this order:
 
 This keeps planner intent from becoming a second retry policy. A recoverable failure is repaired first; a successful or terminally failed final batch proceeds to synthesis. The runtime rejects tool calls returned from a `SynthesisOnly` turn.
 
+Each recoverable `ToolFailure` also selects a `Recovery.Action`:
+
+- `correct_call` keeps the failed tool available and gives the next planner turn
+  the rejected input, generated validation issues, field guidance, and example.
+  It does not require one replacement call per failure. The planner may combine
+  work, make any number of valid calls to advertised tools, wait for input, or
+  answer from the evidence already collected.
+- `replan` removes the failed tool from the next planner turn. The planner may
+  use another advertised tool, wait for input, or answer.
+- `finish` removes all tools and requires a final answer from the available
+  evidence.
+
+The runtime records the exact tool catalog shown on a recovery turn and rejects
+every executable call outside it, including a call embedded in a request for
+user or external input. Generated codecs still validate every payload, and the
+run's tool, failure, and time limits still stop repeated invalid work. If a
+recovery turn waits for input, its failure evidence remains available when the
+run resumes; choosing a tool call or final answer clears that evidence.
+
+Recovery activity inputs and their advertised catalog are part of durable
+workflow history. A deployment that changes this contract must drain or stop
+old workers and running workflows before starting the new worker bundle. Mixed
+worker versions are not safe across this boundary.
+
 When `PlanResumeInput.Finalize` is set, planners may return terminal bookkeeping tools; those calls are not replayed into a later planner turn and must durably finish finalization.
 
 Planners also receive a `PlannerContext` via `input.Agent` that exposes runtime services:

--- a/content/es/docs/2-goa-ai/runtime.md
+++ b/content/es/docs/2-goa-ai/runtime.md
@@ -804,6 +804,34 @@ El runtime elige un único estado siguiente en este orden:
 
 Esto evita que la intención del planner se convierta en una segunda política de reintentos. Un fallo recuperable se repara primero; un lote final correcto o con fallo terminal pasa a síntesis. El runtime rechaza las llamadas a herramientas devueltas desde un turno `SynthesisOnly`.
 
+Cada `ToolFailure` recuperable también selecciona una `Recovery.Action`:
+
+- `correct_call` mantiene disponible la herramienta que falló y entrega al
+  siguiente turno del planner la entrada rechazada, los problemas de validación
+  generados, la guía de campos y un ejemplo. No exige una llamada de reemplazo
+  por cada fallo. El planner puede combinar trabajo, realizar cualquier número
+  de llamadas válidas a herramientas anunciadas, esperar una entrada o responder
+  con la evidencia ya recopilada.
+- `replan` elimina la herramienta que falló del siguiente turno del planner. El
+  planner puede usar otra herramienta anunciada, esperar una entrada o responder.
+- `finish` elimina todas las herramientas y exige una respuesta final basada en
+  la evidencia disponible.
+
+El runtime registra el catálogo exacto de herramientas mostrado en un turno de
+recuperación y rechaza cualquier llamada ejecutable que quede fuera de él,
+incluidas las llamadas incorporadas en una solicitud de entrada del usuario o
+de un sistema externo. Los codecs generados siguen validando cada payload, y
+los límites de herramientas, fallos y tiempo de la ejecución siguen deteniendo
+el trabajo inválido repetido. Si un turno de recuperación espera una entrada,
+su evidencia de fallo sigue disponible cuando la ejecución continúa; elegir
+una llamada o una respuesta final elimina esa evidencia.
+
+Las entradas de las actividades de recuperación y su catálogo anunciado forman
+parte del historial duradero del workflow. Un despliegue que cambie este
+contrato debe drenar o detener los workers antiguos y los workflows en curso
+antes de iniciar el nuevo conjunto de workers. No es seguro mezclar versiones
+de workers a través de este límite.
+
 Cuando `PlanResumeInput.Finalize` está presente, los planners pueden devolver herramientas terminales de bookkeeping; esas llamadas no se reproducen en un turno posterior del planner y deben terminar la finalización de forma duradera.
 
 Los planificadores también reciben un `PlannerContext` a través de `input.Agent` que expone servicios del runtime:

--- a/content/fr/docs/2-goa-ai/runtime.md
+++ b/content/fr/docs/2-goa-ai/runtime.md
@@ -845,6 +845,34 @@ reprise. Un échec récupérable est réparé d'abord ; un lot final réussi ou
 échec terminal passe à la synthèse. Le runtime rejette les appels d'outils
 renvoyés depuis un tour `SynthesisOnly`.
 
+Chaque `ToolFailure` récupérable sélectionne aussi une `Recovery.Action` :
+
+- `correct_call` garde l'outil en échec disponible et transmet au prochain tour
+  du planificateur l'entrée rejetée, les problèmes de validation générés, les
+  indications sur les champs et un exemple. Il n'impose pas un appel de
+  remplacement par échec. Le planificateur peut regrouper le travail, effectuer
+  autant d'appels valides que nécessaire aux outils annoncés, attendre une
+  entrée ou répondre avec les éléments déjà recueillis.
+- `replan` retire l'outil en échec du prochain tour. Le planificateur peut
+  utiliser un autre outil annoncé, attendre une entrée ou répondre.
+- `finish` retire tous les outils et exige une réponse finale fondée sur les
+  éléments disponibles.
+
+Le runtime enregistre le catalogue exact présenté pendant un tour de
+récupération et rejette tout appel exécutable qui n'en fait pas partie, y
+compris un appel intégré à une demande d'entrée utilisateur ou externe. Les
+codecs générés valident toujours chaque charge utile, et les limites d'outils,
+d'échecs et de temps arrêtent toujours les travaux invalides répétés. Si un
+tour de récupération attend une entrée, ses éléments d'échec restent
+disponibles à la reprise ; le choix d'un appel d'outil ou d'une réponse finale
+les efface.
+
+Les entrées d'activité de récupération et leur catalogue annoncé font partie de
+l'historique durable du workflow. Un déploiement qui modifie ce contrat doit
+drainer ou arrêter les anciens workers et les workflows en cours avant de
+démarrer le nouveau groupe de workers. Mélanger les versions de workers à cette
+frontière n'est pas sûr.
+
 Lorsque `PlanResumeInput.Finalize` est défini, les planificateurs peuvent
 renvoyer des outils terminaux de comptabilité ; ces appels ne sont pas rejoués
 dans un tour ultérieur et doivent terminer durablement la finalisation.

--- a/content/it/docs/2-goa-ai/runtime.md
+++ b/content/it/docs/2-goa-ai/runtime.md
@@ -664,6 +664,33 @@ Un errore recuperabile viene riparato per primo; un batch finale riuscito o con
 errore terminale passa alla sintesi. Il runtime rifiuta chiamate agli strumenti
 restituite da un turno `SynthesisOnly`.
 
+Ogni `ToolFailure` recuperabile seleziona anche una `Recovery.Action`:
+
+- `correct_call` mantiene disponibile lo strumento che ha fallito e fornisce al
+  turno successivo del planner l'input rifiutato, i problemi di validazione
+  generati, le indicazioni sui campi e un esempio. Non richiede una chiamata
+  sostitutiva per ogni errore. Il planner può combinare il lavoro, effettuare un
+  numero qualsiasi di chiamate valide agli strumenti annunciati, attendere un
+  input o rispondere usando le prove già raccolte.
+- `replan` rimuove lo strumento che ha fallito dal turno successivo. Il planner
+  può usare un altro strumento annunciato, attendere un input o rispondere.
+- `finish` rimuove tutti gli strumenti e richiede una risposta finale basata
+  sulle prove disponibili.
+
+Il runtime registra il catalogo esatto mostrato durante un turno di recupero e
+rifiuta ogni chiamata eseguibile che non ne faccia parte, incluse le chiamate
+incorporate in una richiesta di input utente o esterno. I codec generati
+continuano a validare ogni payload e i limiti di strumenti, errori e tempo del
+run continuano a interrompere il lavoro non valido ripetuto. Se un turno di
+recupero attende un input, le prove dell'errore restano disponibili alla
+ripresa; la scelta di una chiamata o di una risposta finale le elimina.
+
+Gli input delle attività di recupero e il catalogo annunciato fanno parte della
+cronologia durevole del workflow. Un deployment che modifica questo contratto
+deve drenare o arrestare i vecchi worker e i workflow in esecuzione prima di
+avviare il nuovo gruppo di worker. Non è sicuro combinare versioni diverse dei
+worker attraverso questo limite.
+
 Quando `PlanResumeInput.Finalize` è impostato, i planner possono restituire
 strumenti terminali di bookkeeping; queste chiamate non vengono riprodotte in
 un turno successivo e devono completare durevolmente la finalizzazione.

--- a/content/ja/docs/2-goa-ai/runtime.md
+++ b/content/ja/docs/2-goa-ai/runtime.md
@@ -798,6 +798,30 @@ recoverable failure を先に修復し、成功した final batch または term
 含む final batch は synthesis に進みます。ランタイムは `SynthesisOnly` turn
 から返された tool call を拒否します。
 
+recoverable な `ToolFailure` は `Recovery.Action` も 1 つ選択します。
+
+- `correct_call` は失敗した tool を引き続き利用可能にし、拒否された input、
+  生成済み validation issue、field guidance、example を次の planner turn に
+  渡します。失敗 1 件につき replacement call 1 件を要求するものではありません。
+  planner は作業をまとめ、表示された tool を任意の回数だけ正しく呼び出し、
+  input を待つか、すでに集めた evidence から回答できます。
+- `replan` は失敗した tool を次の planner turn から除外します。planner は別の
+  表示済み tool を使うか、input を待つか、回答できます。
+- `finish` はすべての tool を除外し、利用可能な evidence に基づく最終回答を
+  要求します。
+
+ランタイムは recovery turn で表示した tool catalog を正確に記録し、その外側の
+実行可能な call をすべて拒否します。user または外部 input の要求に埋め込まれた
+call も対象です。生成済み codec は引き続きすべての payload を検証し、run の
+tool・failure・time limit は無効な作業の繰り返しを停止します。recovery turn が
+input を待つ場合、failure evidence は再開後も利用できます。tool call または最終
+回答を選ぶと、その evidence は消去されます。
+
+recovery activity の input と表示された catalog は、durable workflow history の
+一部です。この contract を変更する deployment では、新しい worker bundle を
+開始する前に、古い worker と実行中 workflow を drain または stop する必要が
+あります。この境界をまたいで worker version を混在させることは安全ではありません。
+
 `PlanResumeInput.Finalize` が設定されている場合、プランナーは terminal
 bookkeeping tool を返せます。これらは後続プランナーターンには再生されず、
 finalization を永続的に完了する必要があります。


### PR DESCRIPTION
## Outcome

The Runtime guide now explains what a planner may do after a tool call fails and which decisions the runtime still enforces.

Previously, the guide described only a generic repair turn. It did not distinguish the three recovery actions, so readers could not tell whether a failed call had to be retried, whether another tool was legal, or how deployment compatibility worked.

## Contract

The English, Spanish, French, Italian, and Japanese Runtime pages now document:

- correct_call keeps the failed tool available and supplies rejected input plus generated validation guidance;
- correct_call does not require one replacement call per failure;
- replan removes the failed tool for the next turn;
- finish requires a tool-free final answer;
- every executable call must belong to the exact catalog shown to the planner;
- generated codecs and execution caps remain authoritative; and
- recovery evidence survives an input wait and clears after the next chosen action.

The guide also states that a recovery-contract change requires old workers and running durable workflows to be drained before the new worker bundle starts.

## Compatibility

This is documentation only. It does not change site routes, runtime code, generated contracts, or stored data.

## Validation

- Hugo production build for all five languages
- 70 website tests
- git diff --check

## Review guide

Compare the three recovery actions and the deployment paragraph with the current Goa-AI runtime contract.
