### PR TITLE
Document Goa-AI v0.77.3 runtime contracts

### DIFF
--- a/content/en/docs/2-goa-ai/_index.md
+++ b/content/en/docs/2-goa-ai/_index.md
@@ -44,18 +44,24 @@ Agent("assistant", "A helpful coding assistant", func() {
 })
 ```
 
-When a planner calls this tool with invalid arguments - say, an empty `code`
-string or `language: "cobol"` - Goa-AI rejects the call at the typed boundary and
-returns a structured retry hint. Your planner can use that hint to ask a precise
-follow-up question or retry with corrected arguments. No ad-hoc string parsing
-or hand-maintained JSON schema required.
+When planner code builds this call with `planner.NewToolRequest`, generated
+encoding errors return directly to the planner. When a model emits
+schema-invalid arguments - say, an empty `code` string or
+`language: "cobol"` - the validated model client returns
+`model.OutputValidationError`; the planner/runtime surfaces
+`planner.OutputContractError` before executor or service code runs.
+
+`ToolFailure` and `RecoveryCorrectCall` apply later: a model-authored call must
+first pass validation and be admitted, then its executor or domain boundary
+must return a recoverable failure. The runtime uses that failure to guide the
+next planner turn without ad-hoc string parsing or hand-maintained JSON schema.
 
 **Benefits:**
 - **Single source of truth** — The DSL defines behavior, types, and documentation
 - **Compile-time safety** — Catch mismatched payloads before runtime
 - **Auto-generated clients** — Type-safe tool invocations without manual wiring
 - **Consistent patterns** — Every agent follows the same structure
-- **Repairable tool calls** — Validation errors produce structured retry hints with feedback
+- **Repairable execution failures** — Admitted model-authored calls can return typed failure details and recovery directives
 
 → Learn more in the [DSL Reference](dsl-reference/) and [Quickstart](quickstart/)
 
@@ -129,14 +135,14 @@ Completion names are part of the structured-output contract. They must be
 1-64 ASCII characters, may contain letters, digits, `_`, and `-`, and must
 start with a letter or digit.
 
-Codegen emits `gen/<service>/completions/` with the JSON schema, typed codecs,
-and generated helpers that request provider-enforced structured output and
-decode the final assistant response through the generated codec. Streaming
-helpers stay on the raw `model.Streamer` surface: `completion_delta` chunks are
-preview-only, exactly one final `completion` chunk is canonical, and generated
-`Decode<Name>Chunk(...)` helpers decode only that final payload. Providers that
-do not implement structured output fail explicitly with
-`model.ErrStructuredOutputUnsupported`.
+Codegen emits `gen/<service>/completions/` with private schema and codec
+details plus public typed helpers. Unary helpers return the accepted typed
+value. Streaming helpers return `completion.Streamer[T]`: `Recv` yields
+preview-only `completion_delta` fragments, and `Value()` returns the typed
+result only after the provider closes a valid stream. Providers that do not
+implement structured output fail explicitly with
+`model.ErrStructuredOutputUnsupported`; malformed output fails with a
+non-retryable `planner.OutputContractError`.
 
 **Benefits:**
 - **One contract surface** — Reuse Goa types, validations, and `OneOf` for direct assistant output
@@ -205,10 +211,14 @@ Goa-AI uses **Temporal** for durable execution. Agent runs become workflows; too
 rt := runtime.New()
 
 // Production: Temporal for durability
-eng, _ := temporal.NewWorker(temporal.Options{
+eng, err := temporal.NewWorker(temporal.Options{
     ClientOptions: &client.Options{HostPort: "localhost:7233"},
     WorkerOptions: temporal.WorkerOptions{TaskQueue: "my-agents"},
 })
+if err != nil {
+    panic(err)
+}
+defer eng.Close()
 rt := runtime.New(runtime.WithEngine(eng))
 ```
 
@@ -216,7 +226,9 @@ rt := runtime.New(runtime.WithEngine(eng))
 - **No wasted inference** — Failed tools retry without re-calling the LLM
 - **Crash recovery** — Restart workers anytime; runs resume from last checkpoint
 - **Rate limit handling** — Exponential backoff absorbs API throttling
-- **Deployment-safe** — Rolling deploys don't lose in-flight work
+- **Version-aware deployment** — Follow the
+  [Production rollout contract](production/#transparent-rollouts) for compatible
+  rolling releases and incompatible generated changes
 
 → Setup guide and retry configuration in [Production](production/#temporal-setup)
 
@@ -337,7 +349,12 @@ Goa-AI ships first-class adapters for four LLM providers:
 - **AWS Bedrock** (`features/model/bedrock`)
 - **Google Vertex AI** (`features/model/vertex`) — a native Gemini adapter plus a pure-construction helper for Claude models hosted on Vertex (which delegates translation and error classification to `features/model/anthropic`)
 
-All four implement the same `model.Client` interface used by planners. Applications register model clients with the runtime using `rt.RegisterModel("provider-id", client)` and refer to them by ID from planners and generated agent configs, so swapping providers is a configuration change rather than a redesign.
+All four expose the same opaque `model.Client` used by planners. Applications
+register model clients with the runtime using
+`rt.RegisterModel("provider-id", client)` and refer to them by ID from planners
+and generated agent configs, so swapping providers is a configuration change
+rather than a redesign. Goa-AI validates every request and complete response
+before application code can observe it.
 
 Gemini 3-class models attach an opaque thought signature to tool-call
 (`functionCall`) parts to authenticate the reasoning that produced them. The
@@ -348,11 +365,19 @@ whether or not the configured model uses this feature. See
 
 Adding a new provider follows the same pattern:
 
-1. Implement `model.Client` for your provider by mapping its SDK types onto `model.Request`, `model.Response`, and streaming `model.Chunk`s.
-2. Optionally wrap the client with shared middleware (for example, `features/model/middleware.NewAdaptiveRateLimiter`) for adaptive rate limiting and metrics.
-3. Call `rt.RegisterModel("my-provider", client)` before registering agents, then reference `"my-provider"` from your planners or agent configs.
+1. Implement `model.Provider` by mapping the provider SDK onto
+   `model.Request`, `model.Response`, and raw transport chunks.
+2. Construct the validated client with `model.NewClient(provider)`. Install
+   provider middleware with `model.WrapClient`; external packages cannot
+   implement or bypass `model.Client`.
+3. Call `rt.RegisterModel("my-provider", client)`, then reference
+   `"my-provider"` from planners or agent configs.
 
-Because planners and the runtime depend only on `model.Client`, new providers plug in without changes to your Goa designs or generated agent code.
+Because planners and the runtime depend only on the validated `model.Client`,
+new providers plug in without changes to Goa designs or generated agent code.
+See [Runtime → LLM Integration](runtime/#llm-integration) for request and
+response limits, provider capability differences, remote model gateways, and
+coordinated upgrade requirements.
 
 ## Quick Example
 

--- a/content/en/docs/2-goa-ai/agent-composition.md
+++ b/content/en/docs/2-goa-ai/agent-composition.md
@@ -202,6 +202,10 @@ The runtime maintains this tree using:
 - `run.Handle` – a lightweight handle with `RunID`, `AgentID`, `ParentRunID`, `ParentToolCallID`
 - Agent-as-tool helpers and toolset registrations that **always create real child runs** for nested agents (no hidden inline hacks)
 
+Temporal child workflow IDs include the exact runtime tool-call ID. This keeps
+parallel calls to the same nested agent distinct; a release that changes this
+derivation is not compatible with already-running child workflows.
+
 ---
 
 ## Agent-as-Tool and RunLink
@@ -359,31 +363,28 @@ sub, err := stream.NewSubscriberWithProfile(sink, toolsOnlyProfile)
 
 ---
 
-## Validation Errors and Retry Hints
+## Validation Errors and Recovery
 
-Tool calls often fail due to missing fields, invalid enum values, or wrong JSON shapes.
-Goa‑AI surfaces these failures as **structured retry hints** so planners and UIs can
-ask precise follow‑up questions without parsing error strings.
+Schema-invalid model tool calls do not enter recovery. The validated model
+client rejects them as `model.OutputValidationError`, and the planner/runtime
+surfaces `planner.OutputContractError` before executor or service code runs.
+Planner-authored calls built with `planner.NewToolRequest` return encoding
+failures directly to planner code.
 
-### Where Retry Hints Come From
+### Where Recovery Evidence Comes From
 
-Goa‑AI produces `RetryHint` from validation failures in two places:
-
-1. **Decode‑time (tool codecs)**  
-   Generated tool codecs validate tool input JSON before execution. When validation
-   fails, the error carries structured field issues (missing fields, constraints, allowed
-   values) which the runtime converts into a `RetryHint`.
-
-2. **Execution‑time (tool providers / services)**  
-   When a tool provider calls a bound service method, the method may return a Goa
-   validation error (e.g., missing required fields or invalid lengths). Providers should
-   include structured field issues in the tool result error so consumers can build the
-   same `RetryHint` deterministically.
+`ToolFailure` begins only after a model-authored call passes validation and the
+runtime admits it. Its executor or domain boundary may then return a recoverable
+failure with structured field issues. When that failure selects
+`RecoveryCorrectCall`, the runtime supplies the original model-authored input
+and generated example to the next planner turn. Calls without model provenance
+cannot request same-call correction.
 
 ### Practical Effect
 
-- UIs can render “missing fields” prompts and show example payloads.
-- Planners can ask a single, targeted clarifying question and retry with correct input.
+- UIs can render field issues and examples from admitted recoverable failures.
+- Planners can ask a targeted question and make a corrected call when
+  `RecoveryCorrectCall` permits it.
 
 Applications choose the profile when wiring sinks and bridges (e.g., Pulse, SSE, WebSocket) so:
 - Chat UIs stay clean and structured (nested agent cards driven by `child_run_linked`)

--- a/content/en/docs/2-goa-ai/dsl-reference.md
+++ b/content/en/docs/2-goa-ai/dsl-reference.md
@@ -101,7 +101,7 @@ This document provides a complete reference for Goa-AI's DSL functions. Use it a
 | `Attribute`                                             | Args, Return, ServerData | Defines schema field (general use)                                                                                 |
 | `Field`                                                 | Args, Return, ServerData | Defines numbered proto field (gRPC)                                                                                |
 | `Required`                                              | Schema                   | Marks fields as required                                                                                           |
-| `Example`                                               | Schema                   | Attaches an explicit example; authored top-level tool payload examples become provider-native examples and retry hints |
+| `Example`                                               | Schema                   | Attaches an explicit example; authored top-level tool payload examples become provider-native examples and structured correction evidence |
 
 ### Evaluation DSL
 
@@ -215,7 +215,13 @@ Running `goa gen` produces:
 - Activity handlers for plan/execute/resume loops
 - Registration helpers that wire the design into the runtime
 
-A contextual `AGENTS_QUICKSTART.md` is written at the module root unless disabled via `DisableAgentDocs()`.
+A contextual `AGENTS_QUICKSTART.md` is regenerated at the module root unless
+disabled via `DisableAgentDocs()`.
+
+`goa example` is separate. It creates runnable `cmd/`, bootstrap, planner, and
+example-executor files only when they do not already exist. Those files belong
+to the application and are never overwritten on later runs. Generated files
+under `gen/` and `AGENTS_QUICKSTART.md` continue to refresh from the design.
 
 ### Quickstart Example
 
@@ -282,21 +288,25 @@ Running `goa gen example.com/assistant/design` produces:
 - `gen/orchestrator/agents/chat/exports/<export>`: exported toolsets (agent-as-tool) packages
 - MCP-aware registration helpers when an MCP-backed toolset is referenced via `Use`
 
-### Typed Tool Identifiers
+### Typed Tool Descriptors
 
-Each per-toolset specs package defines typed tool identifiers (`tools.Ident`) for every generated tool:
+Each per-toolset specs package defines a typed identifier and a `<Tool>Tool()`
+descriptor that pairs that identifier with generated payload/result codecs:
 
 ```go
 const (
     Search tools.Ident = "orchestrator.search.search"
 )
 
-var Specs = []tools.ToolSpec{
-    { Name: Search, /* ... */ },
+func SearchTool() tools.TypedTool[*SearchPayload, *SearchResult] {
+    // Returns fresh generated specs and codecs.
 }
 ```
 
-Use these constants anywhere you need to reference tools.
+Construct planner-authored calls with
+`planner.NewToolRequest(SearchTool(), payload)`. Generated accessors return
+fresh copies, so mutating one returned schema or example cannot change later
+model requests.
 
 ### Service-Owned Typed Completions
 
@@ -324,21 +334,23 @@ start with a letter or digit.
 
 `goa gen` emits a package under `gen/<service>/completions` with:
 
-- generated result schemas and typed Go types
-- generated JSON codecs and validation helpers
-- typed `completion.Spec` values
-- generated `Complete<Name>(ctx, client, req)` helpers
-- generated `StreamComplete<Name>(ctx, client, req)` and `Decode<Name>Chunk(...)`
-helpers
+- typed result and union types
+- private schemas and generated codecs
+- public `Complete<Name>(ctx, client, req)` helpers
+- typed `StreamComplete<Name>(ctx, client, req)` helpers
+- `<Name>Example()` when the root result has an authored `Example(...)`
 
-Unary helpers decode the final assistant response directly. Streaming helpers
-stay on the raw `model.Streamer` surface: `completion_delta` chunks are
-preview-only, exactly one final `completion` chunk is canonical, and
-`Decode<Name>Chunk(...)` decodes only that final payload.
+Unary helpers decode the accepted assistant response directly and expose the
+exact provider response as `Response.ModelResponse`. Streaming helpers return
+`completion.Streamer[T]`: `Recv` yields preview fragments, while `Value()`
+becomes available only after clean end-of-stream and validation. There is no
+public decoder for unchecked chunks.
 
 Generated completion helpers reject tool-enabled requests and caller-supplied
 `StructuredOutput`. Providers that do not implement structured output fail
-explicitly with `model.ErrStructuredOutputUnsupported`.
+explicitly with `model.ErrStructuredOutputUnsupported`. Invalid unary or
+streamed output returns a non-retryable `planner.OutputContractError` without a
+correction model request.
 The generated schema remains the canonical service contract; model adapters may
 normalize it for provider-specific constrained decoding, but they must reject
 providers that cannot represent the declared contract.
@@ -615,6 +627,11 @@ Tool("search", "Search documentation", func() {
 })
 ```
 
+`Return` is optional for method-backed tools whose service method has no
+result. Code generation then emits an empty result `TypeSpec`: no result schema
+and no result codec. The executor reports successful completion with
+`&planner.ToolResult{Name: call.Name}` and does not invent a JSON value.
+
 **Reusing types:**
 
 ```go
@@ -849,6 +866,11 @@ result := &planner.ToolResult{
     },
 }
 ```
+
+`agent.Bounds.NextCursor` has type `*string`. Set it only when the generated
+tool spec declares paging, `Truncated` is true, and the pointed-to cursor is
+non-empty. Leave it nil for complete results and non-paged bounded tools; the
+runtime rejects bounds that violate these rules.
 
 When a bounded tool executes:
 
@@ -1107,7 +1129,7 @@ For reminders that depend on runtime conditions, use the planner API instead:
 func (p *MyPlanner) PlanResume(ctx context.Context, input *planner.PlanResumeInput) (*planner.PlanResult, error) {
     // Add a dynamic reminder based on tool results
     for _, tr := range input.ToolOutputs {
-        if tr.Name != "get_time_series" || tr.Error != nil {
+        if tr.Name != specs.GetTimeSeries || tr.Failure != nil {
             continue
         }
         result, err := specs.UnmarshalGetTimeSeriesResult(tr.Result)
@@ -1169,7 +1191,7 @@ Keep the built-in contracts canonical:
 
 - use `Tags` for generic allow/deny and capability filtering,
 - use `Bookkeeping` and `TerminalRun` for accounting and terminal behavior,
-- use `RetryHint` for per-result failure handling,
+- use `ToolFailure` and its `Recovery` action for per-result failure handling,
 - use planner fields such as `SynthesizeAfterTools` for per-batch transitions.
 
 ### BindTo
@@ -1316,7 +1338,9 @@ Tool("set_step_status", "Update step status", func() {
 - Bookkeeping calls contribute zero cost to `MaxToolCalls` and do not change the consecutive-failure counter.
 - Each model-authored tool-call batch is atomic. The runtime admits the whole batch when all budgeted calls fit, or rejects the whole batch when they do not. It never removes individual calls from the provider response.
 - Calls and results remain durable stream/run-log events and remain in the provider transcript. Successful bookkeeping results are omitted only from compact future `ToolOutputs`.
-- A failed bookkeeping result enters a repair turn only when `RetryHint.AllowsRetry()` returns true.
+- A failed bookkeeping result enters another planner turn according to
+  `ToolFailure.Recovery`: correct the same call, replan without that tool, or
+  finish.
 - Unknown tools are treated as budgeted; only tools declared `Bookkeeping()` in the DSL (or marked bookkeeping on the runtime `ToolSpec`) are exempt.
 - A bookkeeping-only turn must resolve in the same turn (`TerminalRun()`, `FinalResponse`, `FinalToolResult`, or await/pause).
 
@@ -1567,7 +1591,13 @@ Compression summarizes older turns using a model while keeping a bounded exact t
 - `CompressAtTurns(n)` and `CompressAtMaxInputTokens(n)` decide when summarization runs. If both are set, either trigger may start compression.
 - `KeepMaxTurns(n)` and `KeepMaxInputTokens(n)` decide which newest complete turns remain exact after summarization. If both are set, both retention caps apply.
 
-Token budgets are counted at runtime through the configured history model because tokenization is model-specific. `KeepMaxInputTokens` never truncates a turn; the runtime walks backward from the newest turn and keeps only complete turns that fit the budget.
+Token budgets are counted at runtime through the configured history model
+because tokenization is model-specific. One count includes preserved system
+messages, candidate complete turns, and the currently advertised tools.
+`CompressAtMaxInputTokens` is exclusive: a request exactly at the threshold
+fits; a larger request triggers compression. `KeepMaxInputTokens` never
+truncates a turn; the runtime walks backward from the newest turn and keeps only
+complete turns that fit.
 
 ```go
 RunPolicy(func() {
@@ -1593,7 +1623,14 @@ At least one `CompressAt...` trigger and at least one `KeepMax...` retention bud
 
 **HistoryModel Requirement:**
 
-When using compression, you must supply a `model.Client` via the generated `HistoryModel` field on the agent config. The runtime uses this client with `ModelClassSmall` to summarize older turns and, when a token budget is configured, to count the provider-visible request. Token-budget compression requires the history model to implement `model.TokenCounter` with exact counts; the Bedrock adapter does this with Bedrock's native `CountTokens` API.
+When using compression, you must supply a `model.Client` via the generated
+`HistoryModel` field on the agent config. The runtime uses this client with
+`ModelClassSmall` to summarize older turns and, when a token budget is
+configured, to count the provider-visible request. Token-budget compression
+requires exact `model.TokenCounter` support. Bedrock uses Runtime `CountTokens`
+where available, but returns `model.ErrTokenCountingUnsupported` for
+structured-output requests and for Claude Opus 4.7, Sonnet 5, and Mythos 5,
+which require AWS's separate Mantle endpoint.
 
 ```go
 // Generated agent config includes HistoryModel when compression is configured.

--- a/content/en/docs/2-goa-ai/evaluations.md
+++ b/content/en/docs/2-goa-ai/evaluations.md
@@ -396,8 +396,11 @@ loudly instead of silently running nothing.
 
 ## How judging works
 
-`eval/judge` builds a judge from any `model.Client`, the same model-client
-interface the rest of Goa-AI uses, so it works with any configured provider.
+`eval/judge` builds a judge from any validated `model.Client`, the same opaque
+client the rest of Goa-AI uses, so it works with any configured provider. Tests
+that need a deterministic judge client should implement `model.Provider` and
+pass it through `model.NewClient`; application code cannot implement
+`model.Client` directly.
 
 For each scenario the judge receives the answer and the scenario's claims, and
 returns exactly one label and a short rationale per claim:
@@ -457,3 +460,13 @@ that:
 Regenerate before compiling application code. Generated suite packages and
 application hooks live in one Go binary, so there is no version-mixing concern
 across a network: a mismatch is a compile error, not a runtime surprise.
+
+## Remote Judge Models
+
+Evaluation suites use the same opaque validated `model.Client` as planners. If
+the judge model runs in another process, expose the provider with
+`gateway.NewServer` and connect with `gateway.NewRemoteClient` or
+`gateway.NewCountingRemoteClient`. The counting client is required when an
+evaluation policy needs exact input-token counts. See
+[Remote Model Gateways](./runtime/#remote-model-gateways) for the transport and
+validation contract.

--- a/content/en/docs/2-goa-ai/mcp-integration.md
+++ b/content/en/docs/2-goa-ai/mcp-integration.md
@@ -15,8 +15,12 @@ MCP integration follows this workflow:
 1. **Service design**: Declare the MCP server via Goa's MCP DSL
 2. **Agent design**: Reference that suite via a toolset declared with `FromMCP(...)` or `FromExternalMCP(...)`
 3. **Code generation**: Produces the MCP JSON-RPC server (when Goa-backed) plus runtime registration helpers and toolset-owned specs/codecs for the suite
-4. **Runtime wiring**: Instantiate an `mcpruntime.Caller` transport (HTTP/SSE/stdio). Generated helpers register the toolset and adapt JSON-RPC errors into `planner.RetryHint` values
-5. **Planner execution**: Planners simply enqueue tool calls with canonical JSON payloads; the runtime forwards them to the MCP caller, persists results via hooks, and surfaces structured telemetry
+4. **Runtime wiring**: Instantiate an `mcpruntime.Caller` transport
+   (HTTP/SSE/stdio). Generated helpers register the toolset and adapt JSON-RPC
+   errors into `planner.ToolFailure` values
+5. **Planner execution**: Planners construct calls with generated typed tool
+   descriptors; the runtime forwards canonical JSON to the MCP caller, records
+   results, and surfaces structured telemetry
 
 ---
 
@@ -234,10 +238,13 @@ caller := mcpassistant.NewCaller(client) // Uses Goa-generated client
 
 ## Tool Execution Flow
 
-1. Planner returns tool calls referencing MCP tools (payload is `json.RawMessage`)
-2. Runtime detects MCP toolset registration
-3. Forwards canonical JSON payload to MCP caller
-4. Invokes MCP caller with tool name and payload
+1. Planner returns tool calls constructed from the generated MCP tool
+   descriptors, or forwards validated model calls with
+   `planner.ToolRequestFromModelCall`
+2. Runtime validates the complete planner result and assigns execution IDs,
+   producing `runtime.ToolCall` values
+3. Runtime detects MCP toolset registration
+4. Forwards the runtime call's canonical JSON payload to the MCP caller
 5. MCP caller handles transport (HTTP/SSE/stdio) and JSON-RPC protocol
 6. Decodes result using generated codec
 7. Returns `ToolResult` to planner
@@ -246,13 +253,14 @@ caller := mcpassistant.NewCaller(client) // Uses Goa-generated client
 
 ## Error Handling
 
-Generated helpers adapt JSON-RPC errors into `planner.RetryHint` values:
+Generated helpers adapt JSON-RPC errors into `planner.ToolFailure` values:
 
-- **Validation errors** → `RetryHint` with guidance for planners
-- **Network errors** → Retry hints with backoff recommendations
-- **Server errors** → Error details preserved in tool results
+- **Validation errors** → invalid-call failures with exact correction evidence
+- **Network errors** → unavailable or timeout failures with an explicit
+  replanning or finish action
+- **Server errors** → structured causes preserved in the failure
 
-This allows planners to recover from MCP errors using the same retry patterns as native toolsets.
+This gives MCP and native toolsets the same enforced recovery contract.
 
 ---
 
@@ -350,24 +358,33 @@ Your planner can reference MCP tools just like native toolsets:
 
 ```go
 func (p *MyPlanner) PlanStart(ctx context.Context, in *planner.PlanInput) (*planner.PlanResult, error) {
+    call, err := planner.NewToolRequest(
+        mcpspecs.SearchTool(),
+        &mcpspecs.SearchPayload{Query: "golang tutorials"},
+    )
+    if err != nil {
+        return nil, err
+    }
     return &planner.PlanResult{
-        ToolCalls: []planner.ToolRequest{
-            {
-                Name:    "assistant.assistant-mcp.search",
-                Payload: []byte(`{"query": "golang tutorials"}`),
-            },
-        },
+        ToolCalls: []planner.ToolRequest{call},
     }, nil
 }
 ```
+
+Here `mcpspecs` is the generated specs package for the MCP toolset. When
+forwarding a validated model-emitted tool call instead, use
+`planner.ToolRequestFromModelCall` so its provider correlation ID is preserved.
 
 ---
 
 ## Best Practices
 
-- **Let codegen manage registration**: Use the generated helper to register MCP toolsets; avoid hand-written glue so codecs and retry hints stay consistent
+- **Let codegen manage registration**: Use the generated helper to register MCP
+  toolsets; avoid hand-written glue so codecs and structured failure recovery
+  stay consistent
 - **Use typed callers**: Prefer Goa-generated JSON-RPC callers when available for type safety
-- **Handle errors gracefully**: Map MCP errors to `RetryHint` values to help planners recover
+- **Handle errors explicitly**: Map MCP errors to `ToolFailure` values with the
+  correct failure kind and recovery action
 - **Monitor telemetry**: MCP calls emit structured telemetry events; use them for observability
 - **Choose the right transport**: Use HTTP for simple request/response, SSE for streaming, stdio for subprocess-based servers
 

--- a/content/en/docs/2-goa-ai/memory-sessions.md
+++ b/content/en/docs/2-goa-ai/memory-sessions.md
@@ -58,6 +58,25 @@ The high-level transcript contract in Goa-AI is:
 
 There is **no separate "tool history" API**; the transcript is the history.
 
+Model adapters are stateless across calls. The complete provider-ready
+transcript must be present in each `model.Request`; a run identifier does not
+cause an adapter to load earlier messages. Public model clients validate the
+request and complete response before planner code can observe them.
+
+### History Compression
+
+An agent's `History(...)` policy may summarize older turns while keeping a
+bounded exact tail. `CompressAt...` values decide when summarization starts;
+`KeepMax...` values decide which newest whole turns remain unchanged. The
+runtime never truncates a turn.
+
+Compression requires a configured `HistoryModel`. Token-based triggers and
+retention also require exact token counting from that model client. Bedrock
+Runtime cannot count structured-output requests, and some current Claude
+models require AWS's separate Mantle endpoint. See [Runtime → History
+Policies](../runtime/#history-policies) and [DSL Reference →
+History](../dsl-reference/#history) for the complete contract.
+
 ### How This Simplifies Planners and UIs
 
 - **Planners**: Receive the current transcript in `planner.PlanInput.Messages` and `planner.PlanResumeInput.Messages`. Can decide what to do based purely on the messages, without threading extra state.
@@ -66,28 +85,16 @@ There is **no separate "tool history" API**; the transcript is the history.
 
 ---
 
-## Transcript Ledger
+## Run-Log Transcript Replay
 
-The **transcript ledger** is a provider-precise record that maintains conversation history in the exact format required by model providers. It ensures deterministic replay and provider fidelity without leaking provider SDK types into workflow state.
-
-### Provider Fidelity
-
-Different model providers (Bedrock, OpenAI, etc.) have strict requirements about message ordering and structure. The ledger enforces these constraints:
-
-| Provider Requirement | Ledger Guarantee |
-|---------------------|------------------|
-| Thinking must precede tool_use in assistant messages | Ledger orders parts: thinking → text → tool_use |
-| Tool results must follow their corresponding tool_use | Ledger correlates tool_result via ToolUseID |
-| Message alternation (assistant → user → assistant) | Ledger flushes assistant before appending user results |
-
-For Bedrock specifically, when thinking is enabled:
-- Assistant messages containing tool_use **must** start with a thinking block
-- User messages with tool_result must immediately follow the assistant message declaring the tool_use
-- Tool result count cannot exceed the prior tool_use count
+The runtime stores provider-ready transcript additions as ordered run-log
+events. A transcript event contains a JSON-encoded slice of `model.Message`
+values. Replay appends those slices in run-log order; it does not reorder parts,
+invent missing messages, or expose a mutable transcript object.
 
 ### Ordering Requirements
 
-The ledger stores parts in the canonical order required by providers:
+Stored messages keep the part order required by providers:
 
 ```
 Assistant Message:
@@ -99,84 +106,63 @@ User Message:
   1. ToolResultPart(s) - tool results correlated via ToolUseID
 ```
 
-This ordering is **sacred** — the ledger never reorders parts, and provider adapters re-encode them into provider-specific blocks in the same sequence.
+Provider adapters re-encode these parts into provider-specific blocks in the
+same sequence.
 
-### Automatic Ledger Maintenance
+### Public Replay API
 
-The runtime automatically maintains the transcript ledger. You do not need to manage it manually:
+The `runtime/agent/transcript` package exposes these run-log operations:
 
-1. **Event Capture**: As the run progresses, the runtime persists memory events (`EventThinking`, `EventAssistantMessage`, `EventToolCall`, `EventToolResult`) in order
+- `EncodeRunLogDelta(messages)` accepts the `[]*model.Message` values added at
+  one point in a run and returns their JSON payload as `rawjson.Message`.
+  Encoding failures are returned as errors.
+- `DecodeRunLogDelta(payload)` accepts one JSON payload from a transcript
+  run-log event and returns the `[]*model.Message` values stored in it. Invalid
+  JSON is returned as an error.
+- `ReplayRunLogEvents(events)` accepts an already ordered slice of
+  `*runlog.Event`. It skips events that are not transcript seed or append
+  records, appends the decoded message slices in input order, and returns the
+  messages, a boolean that reports whether any transcript event was found, and
+  an error.
+- `BuildMessagesFromRunLog(ctx, store, runID)` pages through a `runlog.Store`
+  for one run and returns its complete ordered `[]*model.Message` transcript.
+  It returns an error when the store or run ID is missing, listing or decoding
+  fails, or the run has no transcript events.
 
-2. **Ledger Reconstruction**: The `BuildMessagesFromEvents` function rebuilds provider-ready messages from stored events:
+Most applications let the runtime write transcript events and use
+`BuildMessagesFromRunLog` when they need the provider-ready history:
 
 ```go
-// Reconstruct messages from persisted events
-events := loadEventsFromStore(agentID, runID)
-messages := transcript.BuildMessagesFromEvents(events)
-
-// Messages are now in canonical provider order
-// Ready to pass to model.Client.Complete() or Stream()
-```
-
-3. **Validation**: Before sending to providers, the runtime can validate message structure:
-
-```go
-// Validate Bedrock constraints when thinking is enabled
-if err := transcript.ValidateBedrock(messages, thinkingEnabled); err != nil {
-    // Handle constraint violation
+messages, err := transcript.BuildMessagesFromRunLog(ctx, runEventStore, runID)
+if err != nil {
+    return err
 }
 ```
 
-### Ledger API
-
-For advanced use cases, you can interact with the ledger directly. The ledger provides these key methods:
-
-| Method | Description |
-|--------|-------------|
-| `NewLedger()` | Creates a new empty ledger |
-| `AppendThinking(part)` | Appends a thinking part to the current assistant message |
-| `AppendText(text)` | Appends visible text to the current assistant message |
-| `DeclareToolUse(id, name, args)` | Declares a tool invocation in the current assistant message |
-| `FlushAssistant()` | Finalizes the current assistant message and prepares for user input |
-| `AppendUserToolResults(results)` | Appends tool results as a user message |
-| `BuildMessages()` | Returns the complete transcript as `[]*model.Message` |
-
-**Example usage:**
+Use the validators after constructing or replaying messages:
 
 ```go
-import "goa.design/goa-ai/runtime/agent/transcript"
-
-// Create a new ledger
-l := transcript.NewLedger()
-
-// Record assistant turn
-l.AppendThinking(transcript.ThinkingPart{
-    Text:      "Let me search for that...",
-    Signature: "provider-sig",
-    Index:     0,
-    Final:     true,
-})
-l.AppendText("I'll search the database.")
-l.DeclareToolUse("tu-1", "search_db", map[string]any{"query": "status"})
-l.FlushAssistant()
-
-// Record user tool results
-l.AppendUserToolResults([]transcript.ToolResultSpec{{
-    ToolUseID: "tu-1",
-    Content:   map[string]any{"results": []string{"item1", "item2"}},
-    IsError:   false,
-}})
-
-// Build provider-ready messages
-messages := l.BuildMessages()
+if err := transcript.ValidatePlannerTranscript(messages); err != nil {
+    return err
+}
+if err := transcript.ValidateBedrock(messages, thinkingEnabled); err != nil {
+    return err
+}
 ```
 
-**Note:** Most users don't need to interact with the ledger directly. The runtime automatically maintains the ledger through event capture and reconstruction. Use the ledger API only for advanced scenarios like custom planners or debugging tools.
+`ValidatePlannerTranscript(messages)` accepts `[]*model.Message` and returns
+`nil` only when every assistant tool-call group is followed immediately by one
+user message containing exactly one matching result for every tool-call ID.
+`ValidateBedrock(messages, thinkingEnabled)` checks Bedrock's additional
+thinking rule. It performs no additional check when thinking is disabled. When
+thinking is enabled, it returns an error unless each assistant message
+containing a tool call begins with a `ThinkingPart`. Neither validator changes
+the messages.
 
 ### Why This Matters
 
 - **Deterministic Replay**: Stored events can rebuild the exact transcript for debugging, auditing, or re-running failed turns
-- **Provider Agnostic Storage**: The ledger stores JSON-friendly parts without provider SDK dependencies
+- **Provider Agnostic Storage**: Run-log payloads store `model.Message` JSON without provider SDK dependencies
 - **Simplified Planners**: Planners receive correctly ordered messages without managing provider constraints
 - **Validation**: Catch ordering violations before they reach the provider and cause cryptic errors
 
@@ -196,7 +182,7 @@ Goa-AI separates conversation state into three layers:
 
 - **Transcript** – the full history of messages and tool interactions for a run:
   - Represented as `[]*model.Message`
-  - Persisted via `memory.Store` as ordered memory events
+  - Persisted as transcript seed and append events in `runlog.Store`
 
 ### SessionID & TurnID in Practice
 
@@ -244,6 +230,15 @@ Key types:
 ### Run Log (`runlog.Store`)
 
 Persists the **canonical, append-only event log** for runs. The runtime appends hook events as the run executes (start/phase changes/tools/messages/completion) and callers can list them using cursor pagination for UIs and diagnostics.
+
+For Temporal planner activities, `PlanActivityInput.ToolOutputs` carries
+references containing the call run ID, result run ID, and tool-call ID. The
+planner activity uses those references to load the tool input, result body,
+server data, and planner-visible metadata from this run log before invoking the
+planner. References avoid repeating full result bodies across the planner
+activity boundary. They do not mean that no second copy exists: the runtime's
+private suspension checkpoint still contains transcript and tool-output state
+so a suspended workflow can resume.
 
 ```go
 type Store interface {
@@ -307,7 +302,7 @@ rt := runtime.New(
 
 Once configured:
 - Default subscribers persist memory and run events automatically
-- You can rebuild transcripts from `memory.Store` at any time to re-call models, power UIs, or run offline analysis
+- You can rebuild provider-ready transcripts from `runlog.Store` at any time to re-call models, power UIs, or run offline analysis
 
 ---
 
@@ -348,7 +343,7 @@ type Store interface {
 ### Search and Dashboards
 
 - Page through `runlog.Store` by `RunID` for audit/debug UIs
-- Load transcripts from `memory.Store` on demand for selected runs
+- Replay transcripts from `runlog.Store` on demand for selected runs
 
 ---
 

--- a/content/en/docs/2-goa-ai/production.md
+++ b/content/en/docs/2-goa-ai/production.md
@@ -29,7 +29,11 @@ Every model provider enforces rate limits. Exceed them and your requests fail wi
 
 ### Overview
 
-The `features/model/middleware` package provides an **AIMD-style adaptive rate limiter** that sits at the model client boundary. It estimates token costs, blocks callers until capacity is available, and automatically adjusts its tokens-per-minute budget in response to rate limiting signals from providers.
+The `features/model/middleware` package provides an **AIMD-style adaptive rate
+limiter** beneath the validated model client. It asks the provider for the exact
+input-token count, blocks callers until that capacity is available, and adjusts
+its input-tokens-per-minute budget in response to provider throttling. It never
+estimates tokens and does not meter output quotas.
 
 ### AIMD Strategy
 
@@ -51,41 +55,38 @@ Create a single limiter per process and wrap your model client:
 ```go
 import (
     "context"
-    "os"
 
-    "goa.design/goa-ai/features/model/openai"
     "goa.design/goa-ai/features/model/middleware"
     "goa.design/goa-ai/runtime/agent/runtime"
 )
 
 func main() {
     ctx := context.Background()
+    rt := runtime.New()
 
-    // Create the adaptive rate limiter
-    // Parameters: context, rmap (nil for local), key, initialTPM, maxTPM
-    limiter := middleware.NewAdaptiveRateLimiter(
-        ctx,
-        nil,     // nil = process-local limiter
-        "",      // key (unused when rmap is nil)
-        60000,   // initial tokens per minute
-        120000,  // maximum tokens per minute
-    )
-
-    // Create your underlying model client
-    modelClient, err := openai.New(openai.Options{
-        APIKey:       os.Getenv("OPENAI_API_KEY"),
-        DefaultModel: "gpt-5-mini",
-        HighModel:    "gpt-5",
-        SmallModel:   "gpt-5-nano",
+    // Vertex Gemini exposes the exact CountTokens operation required by the limiter.
+    modelClient, err := rt.NewVertexGeminiModelClient(ctx, runtime.VertexConfig{
+        ProjectID:    "my-gcp-project",
+        Location:     "us-central1",
+        DefaultModel: "gemini-2.5-flash",
     })
     if err != nil {
         panic(err)
     }
 
-    // Wrap with rate limiting middleware
-    rateLimitedClient := limiter.Middleware()(modelClient)
+    limiter := middleware.NewAdaptiveRateLimiter(
+        ctx,
+        nil,     // process-local limiter
+        "",      // unused for a process-local limiter
+        60000,   // initial input tokens per minute
+        120000,  // maximum input tokens per minute
+    )
 
-    rt := runtime.New()
+    rateLimitedClient, err := limiter.Middleware()(modelClient)
+    if err != nil {
+        panic(err)
+    }
+
     if err := rt.RegisterModel("default", rateLimitedClient); err != nil {
         panic(err)
     }
@@ -108,59 +109,72 @@ func main() {
     ctx := context.Background()
 
     // Create a Pulse replicated map backed by Redis
-    rm, err := rmap.NewMap(ctx, "rate-limits", rmap.WithRedis(redisClient))
+    rm, err := rmap.Join(ctx, "rate-limits", redisClient)
     if err != nil {
         panic(err)
     }
+    defer rm.Close()
 
-    // Create cluster-aware limiter
-    // All processes sharing this map and key coordinate their budgets
     limiter := middleware.NewAdaptiveRateLimiter(
         ctx,
         rm,
-        "claude-sonnet",  // shared key for this model
+        "vertex:gemini",  // shared key for this model family
         60000,            // initial TPM
         120000,           // max TPM
     )
 
-    // Wrap your client as before
-    rateLimitedClient := limiter.Middleware()(bedrockClient)
+    rateLimitedClient, err := limiter.Middleware()(vertexClient)
+    if err != nil {
+        panic(err)
+    }
 }
 ```
 
-When using cluster-aware limiting:
+While replicated-map reads and writes succeed:
 - **Backoff propagates globally**: When any process receives `ErrRateLimited`, all processes reduce their budget
 - **Probing is coordinated**: Successful requests increment the shared budget
 - **Automatic reconciliation**: Processes watch for external changes and update their local limiters
 
-### Token Estimation
+Passing a nil map or empty key deliberately creates a process-local limiter.
+When both are set, the shared key is absent, and the middleware cannot seed it,
+the limiter also falls back to process-local operation. After startup, shared
+backoff/probe update errors do not fail model calls; that process keeps its
+local adaptive budget until a later replicated-map event reconciles it. Monitor
+Redis availability if cluster-wide coordination is required.
 
-The limiter estimates request cost using a simple heuristic:
-- Counts characters in text parts and string tool results
-- Converts to tokens using ~3 characters per token
-- Adds a 500-token buffer for system prompts and provider overhead
+### Exact Token Counting
 
-This estimation is intentionally conservative to avoid under-counting.
+The limiter calls the wrapped client's `CountTokens` operation before reserving
+capacity. It requires `Exact=true` and never estimates.
+
+Vertex Gemini exposes a native count operation. Bedrock uses Runtime
+`CountTokens` where supported, but returns
+`model.ErrTokenCountingUnsupported` for structured-output requests and for
+models such as Claude Opus 4.7, Sonnet 5, and Mythos 5 that require the separate
+AWS Mantle endpoint. A remote gateway preserves counting only when constructed
+with `gateway.NewCountingRemoteClient`. OpenAI has no native token counter.
+
+Wrapping a client succeeds even when counting is unsupported. The first
+`Complete` or `Stream` call then returns
+`model.ErrTokenCountingUnsupported` before inference.
+
+The limiter probes upward after a successful unary call or clean stream end. It
+backs off after a terminal `model.ErrRateLimited`. Opening or closing a stream
+without reaching a terminal outcome does not alter capacity.
 
 ### Integration with Runtime
 
 Wire rate-limited clients into the Goa-AI runtime:
 
 ```go
-// Create limiters for each model you use
-claudeLimiter := middleware.NewAdaptiveRateLimiter(ctx, nil, "", 60000, 120000)
-gptLimiter := middleware.NewAdaptiveRateLimiter(ctx, nil, "", 90000, 180000)
-
-// Wrap underlying clients
-claudeClient := claudeLimiter.Middleware()(bedrockClient)
-gptClient := gptLimiter.Middleware()(openaiClient)
-
-// Configure runtime with rate-limited clients
-rt := runtime.New(runtime.WithEngine(temporalEng))
-if err := rt.RegisterModel("claude", claudeClient); err != nil {
+vertexLimiter := middleware.NewAdaptiveRateLimiter(ctx, nil, "", 60000, 120000)
+limitedVertex, err := vertexLimiter.Middleware()(vertexClient)
+if err != nil {
     panic(err)
 }
-if err := rt.RegisterModel("gpt-4", gptClient); err != nil {
+
+rt := runtime.New(runtime.WithEngine(temporalEng))
+if err := rt.RegisterModel("gemini", limitedVertex); err != nil {
     panic(err)
 }
 ```
@@ -191,18 +205,10 @@ if err := rt.RegisterModel("gpt-4", gptClient); err != nil {
 
 ### Monitoring
 
-Track rate limiter behavior with metrics and logs:
-
-```go
-// The limiter logs backoff events at WARN level
-// Monitor for sustained throttling by tracking:
-// - Wait time distribution (how long requests queue)
-// - Backoff frequency (how often 429s occur)
-// - Current TPM vs. initial TPM
-
-// Example: export current capacity to Prometheus
-currentTPM := limiter.CurrentTPM()
-```
+Measure model-call latency and terminal `model.ErrRateLimited` errors in the
+telemetry around the wrapped client. Also monitor Redis when using a replicated
+map, because the middleware intentionally keeps model calls running with a
+process-local budget if shared-state initialization or updates fail.
 
 ### Best Practices
 
@@ -356,10 +362,6 @@ import (
     temporalclient "go.temporal.io/sdk/client"
     "go.temporal.io/sdk/worker"
     "go.temporal.io/sdk/workflow"
-
-    // Your generated tool specs aggregate.
-    // The generated package exposes: func Spec(tools.Ident) (*tools.ToolSpec, bool)
-    specs "<module>/gen/<service>/agents/<agent>/specs"
 )
 
 const releaseBuildID = "git-sha-or-image-digest"
@@ -368,10 +370,6 @@ temporalEng, err := runtimeTemporal.NewWorker(runtimeTemporal.Options{
     ClientOptions: &temporalclient.Options{
         HostPort:  "127.0.0.1:7233",
         Namespace: "default",
-        // Required: enforce goa-ai's workflow boundary contract.
-        // Tool results and server-data cross workflow boundaries as canonical JSON bytes
-        // (for example api.ToolEvent payloads), not decoded planner.ToolResult values.
-        DataConverter: runtimeTemporal.NewAgentDataConverter(specs.Spec),
     },
     WorkerOptions: runtimeTemporal.WorkerOptions{
         TaskQueue: "orchestrator.chat",
@@ -394,6 +392,23 @@ defer temporalEng.Close()
 
 rt := runtime.New(runtime.WithEngine(temporalEng))
 ```
+
+Do not set `ClientOptions.DataConverter`. The Temporal engine rejects a custom
+converter and installs Goa-AI's bounded converter itself so every worker and
+client uses the same persisted contract.
+
+### Temporal Payload Contract
+
+Every workflow or activity argument list has an aggregate encoded limit of
+`engine.MaxPayloadBytes` (1 MiB). Before encoding, the converter also rejects a
+value graph deeper than 64 levels or larger than 100,000 visited values. It
+does not truncate oversized data.
+
+`planner.ToolResult` is an in-process value and cannot cross a Temporal
+boundary. Workflows carry `api.ToolEvent` with canonical JSON bytes instead.
+When a valid tool result can exceed 1 MiB, the tool executor must save it in
+application-owned storage and return a typed reference; the runtime does not
+silently replace the result.
 
 ### Timing and Activity Retries
 
@@ -480,8 +495,8 @@ workflow when it requests human or external input and stores a private
 checkpoint under the completed run ID. The accepted answer starts a new
 workflow on the current worker version. The new version must therefore keep
 the saved checkpoint version, generated result codecs, and required tool names
-compatible. If that is impossible, migrate saved checkpoints before promoting
-the release. Worker versioning cannot translate incompatible stored values.
+compatible for a transparent release. Worker versioning cannot translate
+incompatible stored values.
 
 The rest of the application must preserve availability during the same
 overlap:
@@ -530,6 +545,22 @@ versions during a rolling overlap.
 Worker Deployment Versioning protects workflow replay. It does not protect a
 workflow from an unavailable dependency, an incompatible API, or an
 incompatible checkpoint.
+
+#### Generated contract changes
+
+When generated agents, completion packages, or persisted runtime payloads
+change incompatibly, do not apply the mixed-version procedure above. Regenerate
+all agents and completions, drain or stop affected work, and deploy the runtime,
+workers, and callers as one coordinated release. Goa-AI does not provide a
+dual-read mode for generated runtime contracts.
+
+Goa-AI v0.77.3 accepts only `goa-ai.run-suspension.v4`. Planners that wait for
+questions, clarification, or external tools preserve the provider's
+`ModelToolCallID`; the workflow assigns the runtime `ToolCallID` before it saves
+the suspension. Regenerate consumers and deploy all affected workers together.
+V3 suspensions do not resume on v4 workers, and mixed worker versions are
+unsupported. Historical completed-session records remain stored unchanged, and
+no database migration is required.
 
 #### Release verification
 

--- a/content/en/docs/2-goa-ai/quickstart.md
+++ b/content/en/docs/2-goa-ai/quickstart.md
@@ -106,22 +106,30 @@ Expected shape:
 
 ```text
 RunID: orchestrator-chat-...
-Assistant: Hello from example planner.
+Assistant: Tool helpers.answer returned {"text":"Tokyo is the capital of Japan."}
 Completion draft_task: ...
 Completion stream draft_task: ...
 ```
 
-`goa gen` creates generated contracts. `goa example` creates application-owned
-scaffold:
+When the design has an authored payload example and either an authored result
+example or no result, the scaffold planner demonstrates that tool. If no tool
+has a usable example, it returns the greeting instead.
+
+`goa gen` always refreshes generated contracts and
+`AGENTS_QUICKSTART.md` (unless `DisableAgentDocs()` is set). `goa example`
+creates application-owned files only when they do not already exist:
 
 - `gen/`: generated code. Do not edit this directory by hand.
-- `cmd/orchestrator/main.go`: runnable example entry point.
-- `internal/agents/bootstrap/bootstrap.go`: runtime construction and agent registration.
-- `internal/agents/chat/planner/planner.go`: stub planner to replace.
+- `cmd/orchestrator/main.go`: runnable example entry point (create-once).
+- `internal/agents/bootstrap/bootstrap.go`: runtime construction and agent registration (create-once).
+- `internal/agents/chat/planner/planner.go`: stub planner to replace (create-once).
+- `internal/agents/chat/toolsets/helpers/execute.go`: example executor (create-once).
 - `gen/orchestrator/completions/`: typed direct-completion helpers.
+- `AGENTS_QUICKSTART.md`: regenerated implementation guide at the module root.
 
-Regenerate after DSL changes. Re-run `goa example` when you want scaffold
-updates, then keep application edits in `cmd/` and `internal/`.
+Each create-once file states that the application owns later edits. Rerunning
+`goa example` does not overwrite it. Update application scaffolds manually, or
+delete a file before rerunning if you intentionally want a fresh stub.
 
 ---
 
@@ -141,8 +149,12 @@ returning terminal bookkeeping tools. The runtime executes only
 requires them to succeed before the run is considered closed.
 
 The generated example starts with a stub planner so this flow is visible before
-you connect a model. A real planner follows the same contract; it just delegates
-the decision to a model client.
+you connect a model. When a tool has an authored payload example, `PlanStart`
+constructs the call with `planner.NewToolRequest(gentool.<Tool>Tool(), args)`.
+`PlanResume` checks `ToolOutput.Failure` and formats the successful canonical
+tool JSON into the final assistant message. A no-result tool succeeds with an
+empty result. A real planner follows the same contract; it delegates the
+semantic decision to a model client.
 
 ---
 
@@ -199,20 +211,13 @@ type HelpersExecutor struct{}
 func (e *HelpersExecutor) Execute(
 	ctx context.Context,
 	meta *runtime.ToolCallMeta,
-	call *planner.ToolRequest,
+	call *runtime.ToolCall,
 ) (*runtime.ToolExecutionResult, error) {
 	switch call.Name {
 	case helpers.Answer:
-		args, err := helpers.AnswerTool.Payload.FromJSON(call.Payload)
+		args, err := helpers.AnswerTool().Payload.FromJSON(call.Payload)
 		if err != nil {
-			return runtime.Executed(&planner.ToolResult{
-				Name: call.Name,
-				Failure: &planner.ToolFailure{
-					Kind:     planner.FailureInvalidCall,
-					Error:    planner.ToolErrorFromError(err),
-					Recovery: planner.RecoveryDirective{Action: planner.RecoveryCorrectCall},
-				},
-			}), nil
+			return nil, fmt.Errorf("decode admitted %s payload: %w", call.Name, err)
 		}
 		return runtime.Executed(&planner.ToolResult{
 			Name:   call.Name,
@@ -284,20 +289,21 @@ func (p *Planner) PlanStart(ctx context.Context, in *planner.PlanInput) (*planne
 	if len(summary.ToolCalls) > 0 {
 		return &planner.PlanResult{ToolCalls: summary.ToolCalls}, nil
 	}
+	final := summary.FinalResponse()
+	if final == nil {
+		return nil, errors.New("model stream ended without a canonical response")
+	}
 	return &planner.PlanResult{
-		FinalResponse: &planner.FinalResponse{
-			Message: &model.Message{
-				Role:  model.ConversationRoleAssistant,
-				Parts: []model.Part{model.TextPart{Text: summary.Text}},
-			},
-		},
+		FinalResponse: final,
 		Streamed: true,
 	}, nil
 }
 ```
 
-Use `in.Agent.ModelClient("default")` when you need raw stream control and pair
-it with `planner.ConsumeStream`. Choose one stream owner per planner turn.
+Use `in.Agent.ModelClient("default")` when you need to drain the validated
+stream yourself with `planner.ConsumeStream(ctx, stream)`. Choose one stream
+owner per planner turn. Provider constructors return opaque clients whose
+responses are validated before planner code receives them.
 
 ---
 
@@ -355,8 +361,9 @@ fmt.Println(resp.Value.Name)
 
 Completion names are part of the structured-output contract: 1-64 ASCII
 characters, letters/digits/`_`/`-`, starting with a letter or digit. Streaming
-completion helpers expose preview `completion_delta` chunks and decode only the
-final canonical `completion` chunk.
+completion helpers return `completion.Streamer[T]`: read preview fragments with
+`Recv`, drain to `io.EOF`, and then read the accepted typed value with
+`Value()`. There is no public decoder for unchecked chunks.
 
 ---
 

--- a/content/en/docs/2-goa-ai/runtime.md
+++ b/content/en/docs/2-goa-ai/runtime.md
@@ -89,11 +89,11 @@ DSL and regenerate.
 
 `goa gen` emits `gen/<service>/completions` with:
 
-- result schemas and typed result/union types
-- generated JSON codecs and validation helpers
-- typed `completion.Spec` values
+- typed result and union types
+- private result schemas and generated codecs
 - generated `Complete<Name>(ctx, client, req)` helpers
-- generated `StreamComplete<Name>(ctx, client, req)` and `Decode<Name>Chunk(chunk)` helpers
+- typed `StreamComplete<Name>(ctx, client, req)` helpers
+- `<Name>Example()` when the root result has an authored `Example(...)`
 
 Services may declare completions without declaring any `Agent(...)`. Agent
 quickstart/example scaffolding is emitted only for services that actually own
@@ -117,8 +117,16 @@ if err != nil {
 fmt.Println(resp.Value.Name)
 ```
 
-Streaming completions stay on the raw `model.Streamer` surface and decode the
-final canonical `completion` chunk only:
+Every low-level `model.StructuredOutput` requires a nonempty name. Generated
+helpers derive it from the validated completion DSL. Unary completion makes
+exactly one model call. Invalid JSON returns a non-retryable
+`planner.OutputContractError` and a nil response; it never triggers a correction
+request. On success, `resp.ModelResponse` contains the exact provider response
+and token usage.
+
+Streaming completions return `completion.Streamer[T]`. `Recv` exposes preview
+fragments, while `Value()` stays unavailable until the stream ends and the
+terminal response agrees with the final completion:
 
 ```go
 stream, err := taskcompletion.StreamCompleteDraftFromTranscript(ctx, modelClient, &model.Request{
@@ -140,14 +148,14 @@ for {
     if err != nil {
         panic(err)
     }
-    value, ok, err := taskcompletion.DecodeDraftFromTranscriptChunk(chunk)
-    if err != nil {
-        panic(err)
-    }
-    if ok {
-        fmt.Println(value.Name)
-    }
+    // Render preview completion_delta chunks here when useful.
+    _ = chunk
 }
+value, ok := stream.Value()
+if !ok {
+    panic("completion stream ended without a typed value")
+}
+fmt.Println(value.Name)
 ```
 
 Typed completion helpers are intentionally strict:
@@ -156,9 +164,12 @@ Typed completion helpers are intentionally strict:
 - Completion names are validated at the DSL boundary: 1-64 ASCII characters,
   letters/digits/`_`/`-` only, and must start with a letter or digit.
 - Unary and streaming helpers reject tool-enabled requests and caller-supplied `StructuredOutput`.
-- Streaming providers emit `completion_delta*` preview fragments plus exactly one canonical `completion` chunk, or reject the request explicitly.
-- `Decode<Name>Chunk` ignores preview chunks and decodes only the final `completion`.
-- Completion streams stay on the direct `model.Streamer` path; do not route them through planner streaming helpers, which are for assistant transcript text/tool execution events.
+- Streaming providers may emit `completion_delta*` previews plus exactly one
+  final `completion`, or reject the request explicitly.
+- The typed wrapper releases `Value()` only after clean end-of-stream and full
+  validation. There is no public decoder that accepts an unchecked chunk.
+- Completion streams use their generated typed wrapper directly; planner
+  streaming helpers are for assistant transcript text and tool calls.
 - Providers that do not implement structured output surface `model.ErrStructuredOutputUnsupported`.
 - Generated schemas are canonical and provider-neutral; provider adapters may normalize them to a supported subset, but must fail explicitly when they cannot preserve the declared contract.
 
@@ -242,7 +253,16 @@ if err := rt.Seal(ctx); err != nil {
 1. The runtime starts a workflow for the agent (in-memory or Temporal) and records a new `run.Context` with `RunID`, `SessionID`, `TurnID`, labels, and policy caps.
 2. It calls your planner's `PlanStart` with the current messages and run context.
 3. It schedules tool calls returned by the planner (planner passes canonical JSON payloads; the runtime handles encoding/decoding using generated codecs).
-4. It calls `PlanResume` with the surviving planner-visible tool results; budgeted tools are visible by default, while bookkeeping tools replay only when `RetryHint.AllowsRetry()` authorizes repair. The loop repeats until the planner returns a final response, a final tool result, or a successful `TerminalRun` tool completes the run. If forced finalization is active because caps or deadlines were hit, the planner may close through terminal bookkeeping tools instead of prose. As execution progresses, the run advances through `run.Phase` values (`prompted`, `planning`, `executing_tools`, `synthesizing`, terminal phases).
+4. It calls `PlanResume` with the surviving planner-visible tool outputs.
+   Budgeted tools are visible by default. A failed bookkeeping tool schedules
+   another planner turn according to `ToolFailure.Recovery`: correction,
+   replanning without that tool, or finalization. The loop repeats until the
+   planner returns a final response, a final tool result, or a successful
+   `TerminalRun` tool completes the run. If caps or deadlines force
+   finalization, the planner may close through terminal bookkeeping tools
+   instead of prose. As execution progresses, the run advances through
+   `run.Phase` values (`prompted`, `planning`, `executing_tools`,
+   `synthesizing`, terminal phases).
 5. Hooks and stream subscribers emit events (planner thoughts, tool start/update/end, awaits, usage, workflow, agent-run links) and, when configured, persist transcript entries and run metadata.
 
 ---
@@ -351,7 +371,9 @@ This becomes a `runtime.RunPolicy` attached to the agent's registration:
 - **Time budget**: `TimeBudget` – wall-clock budget for the run. `FinalizerGrace` (runtime-only) – optional reserved window for finalization.
 - **Interrupts**: `InterruptsAllowed` – opt-in for pause/resume.
 - **Missing fields behavior**: `OnMissingFields` – governs what happens when validation indicates missing fields.
-- **Terminal tools**: Tools declared `TerminalRun()` automatically become bookkeeping and complete the run once they succeed—no follow-up `PlanResume` turn is scheduled. A terminal commit can therefore be admitted with no retrieval budget remaining. During forced finalization, the runtime admits only terminal bookkeeping calls, executes them inside the remaining hard-deadline window, and closes the run only if every terminal side effect succeeds.
+- **Terminal tools**: Tools declared `TerminalRun()` automatically become bookkeeping and complete the run once they succeed—no follow-up `PlanResume` turn is scheduled. A terminal commit can therefore be admitted with no retrieval budget remaining. During forced finalization, the runtime admits only terminal bookkeeping calls, executes them inside the remaining hard-deadline window, and closes the run only if every terminal side effect succeeds. Before execution, the runtime writes the exact `planner.TerminationReason` to `runtime.FinalizationReasonLabel` (`goa-ai.finalization_reason`). Run labels, policy labels, planner output, and model output cannot choose or replace this value. Ordinary calls do not receive it.
+
+  `runtime.LimitReasonLabel` and `goa-ai.limit_reason` were removed in v0.77.2. Consumers of fixed-limit or planner-authored terminal calls, including `tool_failure`, must use `runtime.FinalizationReasonLabel`. Deploy those consumers and runtime workers together; mixed versions are unsupported. No saved session or run-history data needs migration.
 
 ### Runtime Policy Overrides
 
@@ -387,11 +409,13 @@ Only non-zero fields are applied (and `InterruptsAllowed` when `true`). This all
 
 ### Labels and Policy Engines
 
-Goa-AI integrates with pluggable policy engines via `policy.Engine`. Policies receive tool metadata (IDs, tags), run context (SessionID, TurnID, labels), and `RetryHint` information after tool failures.
+Goa-AI integrates with pluggable policy engines via `policy.Engine`. Policies
+receive tool metadata (IDs, tags), run context (SessionID, TurnID, labels), and
+the structured `ToolFailure` after failed execution.
 
 Labels flow into:
 - `run.Context.Labels` – available to planners during a run
-- tool activity input (`api.ToolInput.Labels`) – cloned into dispatched tool executions so tool activities observe the same run-scoped metadata unless the planner overrides labels for one specific call
+- tool activity input (`api.ToolInput.Labels`) – cloned into dispatched tool executions so activities observe run and policy metadata; terminal finalization calls also receive the runtime-owned reason under `runtime.FinalizationReasonLabel`
 - run log events (`runlog.Store`) – persisted alongside lifecycle events for audit/search/dashboards (where indexed)
 - terminal completion and snapshots – the start labels come back out at the end of the run on `hooks.RunCompletedEvent.Labels` and `run.Snapshot.Labels`, so completion hooks and `GetRunSnapshot` readers recover run identity without out-of-band tracking
 
@@ -419,10 +443,9 @@ out, err := client.Run(ctx, "session-1", messages,
 )
 ```
 
-The runtime latches restricted-tool repair turns when a retry hint sets
-`RestrictToTool`, so the follow-up planner turn sees only the tool that needs a
-corrected payload. This keeps validation repair focused and prevents the model
-from drifting into unrelated tools.
+This is a run-wide caller policy. Tool failures use a separate contract:
+`ToolFailure.Recovery` selects correction, replanning, or finishing and the
+runtime enforces the resulting tool catalog on the next planner turn.
 
 ---
 
@@ -521,7 +544,6 @@ if err != nil {
 }
 
 resp, err := modelClient.Complete(ctx, &model.Request{
-    RunID:      input.RunContext.RunID,
     Messages:   input.Messages,
     PromptRefs: []prompt.PromptRef{content.Ref},
 })
@@ -533,7 +555,7 @@ resp, err := modelClient.Complete(ctx, &model.Request{
 
 ## Memory, Streaming, Telemetry
 
-- **Hook bus** publishes structured hook events for the full agent lifecycle: run start/completion, phase changes, `prompt_rendered`, tool scheduling/results/updates, planner notes and thinking blocks, awaits, retry hints, and agent-as-tool links.
+- **Hook bus** publishes structured hook events for the full agent lifecycle: run start/completion, phase changes, `prompt_rendered`, tool scheduling/results/updates, planner notes and thinking blocks, awaits, `ToolFailure` recovery directives, and agent-as-tool links.
 
 - **Memory stores** (`memory.Store`) subscribe and append durable memory events (user/assistant messages, tool calls, tool results, planner notes, thinking) per `(agentID, RunID)`.
 
@@ -667,7 +689,7 @@ generic runtime stays honest across both Temporal and the in-memory engine.
 - `SessionID` is required for sessionful starts. `Start` and `Run` fail fast when `SessionID` is empty or whitespace
 - `StartOneShot` and `OneShotRun` are explicitly sessionless. They do not require or create a session and do not emit session-scoped stream events
 - Agents must be registered before the first run. The runtime rejects registration after the first run submission with `ErrRegistrationClosed` to keep engine workers deterministic
-- Tool executors receive explicit per-call metadata (`ToolCallMeta`) rather than fishing values from `context.Context`
+- Tool executors receive explicit per-call metadata (`ToolCallMeta`) rather than fishing values from `context.Context`. Its labels contain cloned run and policy labels plus `runtime.FinalizationReasonLabel` only when that call is executing terminal finalization
 - Do not rely on implicit fallbacks; all domain identifiers (run, session, turn, correlation) must be passed explicitly
 
 ---
@@ -828,7 +850,16 @@ type Planner interface {
 }
 ```
 
-`PlanResult` contains tool calls, a final response, a final tool result, annotations, and the selected post-tool transition. `PlanResumeInput` tells the planner why it is being called.
+`PlanResult` contains tool requests, a final response, a final tool result,
+annotations, and the selected post-tool transition. `PlanResumeInput` tells the
+planner why it is being called.
+
+Planner-authored requests contain domain intent only. Use
+`planner.NewToolRequest(typedTool, payload)` to encode one. When forwarding a
+validated provider call, use `planner.ToolRequestFromModelCall(call)` so the
+provider correlation ID is preserved without becoming the runtime execution
+ID. The runtime validates the complete plan before it assigns execution IDs or
+publishes tool events.
 
 These contracts are separate:
 
@@ -838,7 +869,7 @@ These contracts are separate:
 | `ToolSpec.Meta` | A tool, for every run | Inert generated annotations whose semantics belong to the named consumer; metadata alone changes no runtime behavior. |
 | `ToolSpec.Bookkeeping` | A tool, for every run | The call is a durable control record whose success does not require another planner turn. It consumes no retrieval or consecutive-failure budget. |
 | `ToolSpec.TerminalRun` | A tool, for every run | Successful execution itself ends the run. It automatically implies bookkeeping. |
-| `RetryHint.AllowsRetry()` | One failed result | Another tool attempt is permitted in this run. A timeout hint classifies a terminal failure and returns false. |
+| `ToolFailure.Recovery` | One failed result | Selects same-tool correction, replanning without the failed tool, or finalization. |
 | `PlanResult.SynthesizeAfterTools` | One selected batch | If the batch has no recoverable failure, the next planner turn must answer. |
 | `PlanResumeInput.SynthesisOnly` | One planner activity | Return a final answer; tool calls are invalid. |
 | `PlanResumeInput.Finalize` | Runtime-forced termination | A cap or deadline has prohibited normal work. |
@@ -858,7 +889,8 @@ This keeps planner intent from becoming a second retry policy. A recoverable fai
 Each recoverable `ToolFailure` also selects a `Recovery.Action`:
 
 - `correct_call` keeps the failed tool available and gives the next planner turn
-  the rejected input, generated validation issues, field guidance, and example.
+  the original model-authored input, generated validation issues, field
+  guidance, and example.
   It does not require one replacement call per failure. The planner may combine
   work, make any number of valid calls to advertised tools, wait for input, or
   answer from the evidence already collected.
@@ -866,6 +898,15 @@ Each recoverable `ToolFailure` also selects a `Recovery.Action`:
   use another advertised tool, wait for input, or answer.
 - `finish` removes all tools and requires a final answer from the available
   evidence.
+
+The workflow owns model-facing correction evidence. It replaces executor-
+supplied prior input and examples with the original provider call and the
+registered tool specification before the failure enters run history. A
+runtime-created continuation has no model-authored input, so it cannot request
+`correct_call`; this prevents private cursors or injected execution fields from
+appearing in a later model request. Model transcripts correlate results with
+`ModelToolCallID`, while activities, retries, and stored execution records use
+the separate runtime `ToolCallID`.
 
 The runtime records the exact tool catalog shown on a recovery turn and rejects
 every executable call outside it, including a call embedded in a request for
@@ -902,13 +943,20 @@ Planners also receive a `PlannerContext` via `input.Agent` that exposes runtime 
 - `features/runlog/mongo` – run event log store (append-only, cursor-paginated)
 - `features/session/mongo` – session metadata store
 - `features/stream/pulse` – Pulse sink/subscriber helpers
-- `features/model/{anthropic,bedrock,openai}` – model client adapters for planners
-- `features/model/middleware` – shared `model.Client` middlewares (e.g., adaptive rate limiting)
-- `features/policy/basic` – simple policy engine with allow/block lists and retry hint handling
+- `features/model/{anthropic,bedrock,openai,vertex}` – provider adapters that
+  return validated model clients
+- `features/model/gateway` – remote provider server and validated transport
+  clients
+- `features/model/middleware` – provider middleware installed beneath client
+  validation, including exact-token adaptive rate limiting
+- `features/policy/basic` – simple policy engine with allow/block lists and `ToolFailure` handling
 
 ### Model Client Throughput & Rate Limiting
 
-Goa-AI ships a provider-agnostic adaptive rate limiter under `features/model/middleware`. It wraps any `model.Client`, estimates tokens per request, queues callers using a token bucket, and adjusts its effective tokens-per-minute budget using an additive-increase/multiplicative-decrease (AIMD) strategy when providers report throttling.
+Goa-AI ships an adaptive input-token limiter under
+`features/model/middleware`. It asks the wrapped client for the exact request
+token count, reserves that capacity before the call, and adjusts its effective
+input-tokens-per-minute budget when providers report throttling.
 
 ```go
 import (
@@ -919,18 +967,24 @@ import (
 )
 
 awsClient := bedrockruntime.NewFromConfig(cfg)
-bed, _ := bedrock.New(awsClient, bedrock.Options{
+bed, err := bedrock.New(awsClient, bedrock.Options{
     DefaultModel: "us.anthropic.claude-4-5-sonnet-20251120-v1:0",
 })
+if err != nil {
+    panic(err)
+}
 
 rl := mdlmw.NewAdaptiveRateLimiter(
     ctx,
     throughputMap,       // *rmap.Map joined earlier (nil for process-local)
     "bedrock:sonnet",    // key for this model family
-    80_000,              // initial TPM
-    1_000_000,           // max TPM
+    80_000,              // initial input tokens per minute
+    1_000_000,           // maximum input tokens per minute
 )
-limited := rl.Middleware()(bed)
+limited, err := rl.Middleware()(bed)
+if err != nil {
+    panic(err)
+}
 
 rt := runtime.New()
 if err := rt.RegisterModel("bedrock", limited); err != nil {
@@ -938,22 +992,47 @@ if err := rt.RegisterModel("bedrock", limited); err != nil {
 }
 ```
 
+Middleware construction does not test token-count support. If the selected
+provider or request cannot be counted exactly, the first `Complete` or `Stream`
+call returns `model.ErrTokenCountingUnsupported` before inference. Vertex
+Gemini supports exact counting; Bedrock supports it only for requests and
+models accepted by Runtime `CountTokens`. OpenAI has no native counter.
+
+The limiter meters input tokens only. A unary success or clean stream end
+probes upward; a unary or terminal streaming rate-limit error backs off. Merely
+opening or closing a stream does not count as success.
+
 ---
 
 ## LLM Integration
 
 Goa-AI planners interact with large language models through a **provider-agnostic interface**. This design lets you swap providers—AWS Bedrock, OpenAI, Google Vertex AI (Gemini and Claude-on-Vertex), or custom endpoints—without changing your planner code.
 
-### The model.Client Interface
+### The Validated Model Client
 
-All LLM interactions go through the `model.Client` interface:
+All planner interactions go through an opaque `model.Client`:
 
 ```go
-type Client interface {
-    Complete(ctx context.Context, req *Request) (*Response, error)
-    Stream(ctx context.Context, req *Request) (Streamer, error)
-}
+resp, err := client.Complete(ctx, req)
+stream, err := client.Stream(ctx, req) // *model.ValidatedStream
 ```
+
+Provider integrations implement `model.Provider`, which produces raw transport
+responses and chunks. Goa-AI constructs `model.Client` with
+`model.NewClient(provider)` and validates requests and complete responses around
+that provider. External packages cannot implement `model.Client` or expose raw
+provider chunks to planners.
+
+Before a provider call, the client validates tool names and schemas, message
+parts, thinking options, structured-output metadata, and the request's dynamic
+values. Requests and unary responses are limited to 16 MiB and 100,000 visited
+values. Nested dynamic metadata is limited to depth 64. Streaming applies one
+cumulative budget across chunks and the terminal response. These limits reject
+the whole operation; Goa-AI never truncates, repairs, or coerces model data.
+
+`ValidatedStream` must be drained to `io.EOF`. Only then does `Response()`
+return the accepted canonical response. An incomplete, malformed, or
+contradictory stream returns an error and no accepted response.
 
 ### Provider Adapters
 
@@ -975,19 +1054,30 @@ modelClient, err := bedrock.New(awsClient, bedrock.Options{
     MaxTokens:    4096,
     Temperature:  0.7,
 })
+if err != nil {
+    panic(err)
+}
 ```
 
 **OpenAI**
 
 ```go
-import "goa.design/goa-ai/features/model/openai"
+import (
+    "os"
 
-modelClient, err := openai.New(openai.Options{
-    APIKey:       apiKey,
+    "goa.design/goa-ai/runtime/agent/runtime"
+)
+
+rt := runtime.New()
+modelClient, err := rt.NewOpenAIModelClient(runtime.OpenAIConfig{
+    APIKey:       os.Getenv("OPENAI_API_KEY"),
     DefaultModel: "gpt-5-mini",
     HighModel:    "gpt-5",
     SmallModel:   "gpt-5-nano",
 })
+if err != nil {
+    panic(err)
+}
 ```
 
 **Google Vertex AI (Gemini and Claude-on-Vertex)**
@@ -1033,6 +1123,41 @@ ID when rebuilding the provider transcript. `planner.ToolRequest` never
 carries a signature field; planner code does not need to know signatures
 exist.
 
+### Provider Capability Differences
+
+The shared request type is provider-neutral, but adapters reject combinations
+their APIs cannot preserve:
+
+| Provider | Contract enforced before or during the call |
+| --- | --- |
+| OpenAI | Structured output uses strict schema projection. Tools and structured output cannot be combined. Overlapping `oneOf` branches are rejected rather than widened. Strict schemas are bounded to 5,000 properties, 1,000 enum values, 10 object levels, and 120,000 aggregate name/enum characters; fine-tuned models reject additional unsupported keywords. Thinking requests reject temperature. |
+| Anthropic | Current Claude models use native structured output where supported. Adaptive thinking permits tools and normal forced choice, while older manual thinking rejects forced `any` or named-tool choice. Current-generation Claude models omit deprecated sampling parameters. Streams must close every content block and report a stop reason. |
+| Bedrock | Claude 4.5 and 4.6 use native `OutputConfig`; other Claude models use one private forced tool and validate its result against the same contract. Event-stream exceptions retain their provider error kind. Runtime `CountTokens` rejects models that require the separate Mantle endpoint and cannot count structured-output requests. |
+| Vertex Gemini | Gemini 3 uses thinking levels, rejects numeric thinking budgets and explicit thinking disablement, and forwards API-valid temperatures. Tool-call thought signatures are retained and replayed by the runtime. Streams require exactly one candidate and a finish reason. |
+
+For Claude Opus 4.7+, Sonnet 5+, Haiku 5+, Fable, and Mythos, the Anthropic and
+Bedrock adapters omit `temperature`, `top_p`, and `top_k` because those models
+reject the parameters. Older Claude generations continue to receive configured
+sampling values.
+
+Provider adapters are stateless with respect to conversation history. Every
+request must carry the complete provider-ready `Messages` transcript; a
+`RunID` does not ask an adapter to load prior messages.
+
+Common sentinel errors include:
+
+- `model.ErrStructuredOutputUnsupported` when an adapter cannot express the
+  requested output contract
+- `model.ErrTokenCountingUnsupported` when exact provider counting is
+  unavailable
+- `model.ErrEmptyStream` when a provider closes without model output
+- `model.ErrRateLimited` for retryable provider throttling
+
+`*planner.OutputContractError` is a structured error, not a sentinel. Detect it
+with `errors.As` and inspect its origin to distinguish invalid model, planner,
+or tool output. It is non-retryable because another request must not hide a
+contract violation.
+
 ### Canonical Message Metadata and Citation Replay
 
 `model.Message.Meta` contains provider-authored data needed to replay a
@@ -1055,14 +1180,16 @@ Planners obtain model clients through the runtime's `PlannerContext`. There are
 two explicit integration styles:
 
 - `PlannerModelClient(id)` for planner-scoped streaming with runtime-owned event emission
-- `ModelClient(id)` when you need raw transport access and will pair it with `planner.ConsumeStream` or emit `PlannerEvents` yourself
+- `ModelClient(id)` when you need direct validated model access and will drain
+  the returned stream with `planner.ConsumeStream`
 
 #### PlannerModelClient (Recommended)
 
 `PlannerContext.PlannerModelClient(id)` returns a planner-scoped client that
 owns `AssistantChunk`, `PlannerThinkingBlock`, and `UsageDelta` emission. Its
 `Stream(...)` method drains the underlying provider stream and returns a
-`planner.StreamSummary`:
+`planner.StreamSummary`. `PlannerModelClient` permits exactly one `Complete` or
+`Stream` invocation in that planner turn:
 
 ```go
 func (p *MyPlanner) PlanStart(ctx context.Context, input *planner.PlanInput) (*planner.PlanResult, error) {
@@ -1095,16 +1222,17 @@ func (p *MyPlanner) PlanStart(ctx context.Context, input *planner.PlanInput) (*p
 }
 ```
 
-This is the safest integration style because the planner-scoped client does not
-expose a raw `model.Streamer`, so it cannot be combined accidentally with
-`planner.ConsumeStream`. Returning `sum.FinalResponse()` also selects the exact
+This is the simplest integration style because the planner-scoped client drains
+and summarizes the validated stream itself. Returning `sum.FinalResponse()`
+also selects the exact
 provider response captured for that invocation; rebuilding a text-only message
 would discard thinking, citations, signatures, metadata, and message boundaries.
 
-#### Raw Client + ConsumeStream
+#### Validated Client + ConsumeStream
 
-When you need the raw `model.Client`, fetch it from `PlannerContext.ModelClient`
-and pair it with `planner.ConsumeStream`:
+When you need direct `model.Client` access, fetch it from
+`PlannerContext.ModelClient` and pair its validated stream with
+`planner.ConsumeStream`:
 
 ```go
 mc, ok := input.Agent.ModelClient("anthropic.claude-3-5-sonnet-20241022-v2:0")
@@ -1116,23 +1244,101 @@ req := &model.Request{
     Tools:    input.Agent.AdvertisedToolDefinitions(),
     Stream:   true,
 }
-streamer, err := mc.Stream(ctx, req)
+stream, err := mc.Stream(ctx, req)
 if err != nil {
     return nil, err
 }
-sum, err := planner.ConsumeStream(ctx, streamer, req, input.Events)
+sum, err := planner.ConsumeStream(ctx, stream)
 if err != nil {
     return nil, err
 }
+if len(sum.ToolCalls) > 0 {
+    return &planner.PlanResult{ToolCalls: sum.ToolCalls}, nil
+}
+final := sum.FinalResponse()
+if final == nil {
+    return nil, errors.New("model stream ended without a canonical response")
+}
+return &planner.PlanResult{
+    FinalResponse: final,
+    Streamed:      true,
+}, nil
 ```
 
-This helper drains the stream, emits assistant/thinking/usage events, and
-returns a `StreamSummary` with accumulated text and tool calls.
+This helper only drains the stream and returns a `StreamSummary` with
+accumulated text and tool calls. The runtime model-invocation journal publishes
+accepted presentation and usage events later.
 
-Use the raw client path when you need full control over stream consumption, want
-custom early-stop behavior, or want to manage `PlannerEvents` explicitly. Do not
-mix `PlannerModelClient.Stream(...)` with `planner.ConsumeStream`; choose one
-stream owner per planner turn.
+Generated tool definitions use `model.ToolDefinitionFromSpec`, which retains
+the generated payload decoder. Caller-authored tools use
+`model.AdvertisedToolInputFromSchema`. Both paths reject unknown tools and
+invalid payloads before planner code receives a provider tool call.
+
+Use the direct client path when planner logic needs to inspect validated preview
+chunks or make multiple model calls in one planner turn. Drain every selected
+stream to its terminal result; closing early does not produce an accepted
+response. The returned `PlanResult` must forward one exact selected result:
+either that summary's complete `ToolCalls` set or its `FinalResponse()`. The
+runtime rejects modified, mixed, or ambiguous results. Do not mix
+`PlannerModelClient.Stream(...)` with `planner.ConsumeStream`; choose one stream
+owner per planner turn.
+
+### Remote Model Gateways
+
+`features/model/gateway` carries model requests to a separately deployed
+provider process without weakening validation. The server operates on a raw
+`model.Provider`, so provider-side middleware runs before the transport:
+
+```go
+server, err := gateway.NewServer(
+    gateway.WithProvider(provider),
+    gateway.WithUnary(unaryMiddleware...),
+    gateway.WithStream(streamMiddleware...),
+)
+```
+
+The consumer constructs a validated client from its transport functions:
+
+```go
+client, err := gateway.NewRemoteClient(completeRemote, streamRemote)
+countingClient, err := gateway.NewCountingRemoteClient(
+    completeRemote,
+    streamRemote,
+    countRemote,
+)
+```
+
+Use `NewCountingRemoteClient` only when the remote endpoint implements exact
+token counting. `NewRemoteClient` deliberately returns
+`model.ErrTokenCountingUnsupported` for count requests instead of estimating.
+
+### History Policies
+
+History compression separates the condition that starts summarization from the
+amount of exact recent history retained:
+
+- `CompressAtTurns` and `CompressAtMaxInputTokens` are ORed triggers.
+- `KeepMaxTurns` and `KeepMaxInputTokens` both constrain the newest complete
+  turns retained after summarization; the runtime never cuts a turn in half.
+- Token policies require a `HistoryModel` whose client's `CountTokens` operation
+  returns an exact count. The count includes preserved system messages,
+  candidate turns, and currently advertised tools.
+- `CompressAtMaxInputTokens` is exclusive: a request exactly at the threshold
+  fits; only a larger request triggers compression.
+
+Bedrock Runtime cannot count structured-output requests. Claude Opus 4.7,
+Sonnet 5, and Mythos 5 require AWS's separate Mantle count endpoint, so the
+Bedrock adapter returns `model.ErrTokenCountingUnsupported` for those models.
+The generated agent config exposes `HistoryCompression` for deployment-specific
+overrides without changing the design defaults.
+
+### Coordinated Generated-System Releases
+
+Compatible releases may roll transparently; incompatible generated changes
+require a coordinated drain and cutover. See the authoritative
+[Production rollout contract](../production/#transparent-rollouts) for the
+checkpoint-version, generated-codec, required-tool-name, and worker-retention
+requirements.
 
 ### Bedrock Message Ordering Validation
 
@@ -1150,6 +1356,11 @@ bedrock: assistant message with tool_use must start with thinking
 ```
 
 This validation ensures that transcript ledger reconstruction produces provider-compliant message sequences.
+
+This ordering check runs before the provider call. Stream validation is a
+separate boundary: incomplete content blocks, unsigned reasoning, and missing
+stop reasons fail as output-contract errors before planner code receives an
+accepted response.
 
 ---
 

--- a/content/en/docs/2-goa-ai/testing.md
+++ b/content/en/docs/2-goa-ai/testing.md
@@ -49,67 +49,62 @@ func TestChatAgent(t *testing.T) {
 }
 ```
 
-### Testing Planners with Mock Model Clients
+### Testing Planners with Fake Providers
 
-Isolate planner logic by mocking the model client:
+`model.Client` is framework-owned and cannot be implemented by application test
+doubles. Implement `model.Provider`, then construct the same validated client
+used in production:
 
 ```go
-type MockModelClient struct {
-    responses []model.Message
-    callCount int
+type FakeProvider struct {
+    response *model.Response
 }
 
-func (m *MockModelClient) Complete(ctx context.Context, req *model.Request) (*model.Response, error) {
-    if m.callCount >= len(m.responses) {
-        return nil, fmt.Errorf("no more mock responses")
-    }
-    resp := &model.Response{
-        Content: []model.Message{m.responses[m.callCount]},
-    }
-    m.callCount++
-    return resp, nil
+func (p *FakeProvider) Complete(context.Context, *model.Request) (*model.Response, error) {
+    return p.response, nil
 }
 
-func (m *MockModelClient) Stream(ctx context.Context, req *model.Request) (model.Streamer, error) {
-    // Return a mock streamer for streaming tests
-    return &MockStreamer{response: m.responses[m.callCount]}, nil
+func (p *FakeProvider) Stream(context.Context, *model.Request) (model.Streamer, error) {
+    return nil, model.ErrStreamingUnsupported
 }
 
-func TestPlannerWithMockClient(t *testing.T) {
-    mockClient := &MockModelClient{
-        responses: []model.Message{
-            {
-                Role: model.ConversationRoleAssistant,
-                Parts: []model.Part{
-                    model.TextPart{Text: "I'll search for that."},
-                    model.ToolUsePart{
-                        ID:    "call-1",
-                        Name:  "search",
-                        Input: json.RawMessage(`{"query": "test"}`),
-                    },
-                },
-            },
-        },
-    }
-    
-    planner := &MyPlanner{client: mockClient}
-    
-    input := &planner.PlanInput{
+func TestValidatedModelResponse(t *testing.T) {
+    provider := &FakeProvider{response: &model.Response{
+        Content: []model.Message{{
+            Role: model.ConversationRoleAssistant,
+            Parts: []model.Part{model.TextPart{Text: "Hello."}},
+        }},
+        StopReason: "stop",
+    }}
+    client, err := model.NewClient(provider)
+    require.NoError(t, err)
+
+    resp, err := client.Complete(context.Background(), &model.Request{
         Messages: []*model.Message{{
             Role:  model.ConversationRoleUser,
-            Parts: []model.Part{model.TextPart{Text: "Search for test"}},
+            Parts: []model.Part{model.TextPart{Text: "Hello"}},
         }},
-    }
-    
-    result, err := planner.PlanStart(context.Background(), input)
+    })
     require.NoError(t, err)
-    
-    // Assert planner returned tool calls
-    assert.NotNil(t, result.ToolCalls)
-    assert.Len(t, result.ToolCalls, 1)
-    assert.Equal(t, "search", string(result.ToolCalls[0].Name))
+    assert.Len(t, resp.Content, 1)
 }
 ```
+
+For planner unit tests that do not need model validation, inject deterministic
+planner inputs and typed tool requests directly. Use a fake provider when the
+test must prove request validation, tool-payload decoding, output bounds, or
+stream termination behavior.
+
+Streaming fakes must emit a complete valid chunk sequence and then return
+`io.EOF`; only then does `ValidatedStream.Response()` expose the accepted
+response. To test rejection, return malformed provider output and assert the
+boundary error. Generated completion tests should assert
+`planner.OutputContractError` and a nil response when output violates the
+generated codec.
+
+Rate-limiter and token-budget history tests need a fake provider that also
+implements exact `model.TokenCounter`. A non-counting fake should produce
+`model.ErrTokenCountingUnsupported`, not an estimated result.
 
 ### Testing Tools in Isolation
 
@@ -131,9 +126,21 @@ func TestSearchToolExecutor(t *testing.T) {
         ToolCallID: "call-1",
     }
     
-    call := &planner.ToolRequest{
-        Name:    specs.Search,
-        Payload: json.RawMessage(`{"query": "test", "limit": 5}`),
+    request, err := planner.NewToolRequest(specs.SearchTool(), &specs.SearchPayload{
+        Query: "test",
+        Limit: 5,
+    })
+    require.NoError(t, err)
+
+    // Executors run after validation and execution-ID assignment. Build the
+    // runtime call from the valid bytes produced by the generated descriptor.
+    call := &runtime.ToolCall{
+        Name:       request.Name,
+        Payload:    request.Payload,
+        RunID:      meta.RunID,
+        SessionID:  meta.SessionID,
+        TurnID:     meta.TurnID,
+        ToolCallID: meta.ToolCallID,
     }
     
     // Execute tool
@@ -142,7 +149,7 @@ func TestSearchToolExecutor(t *testing.T) {
     require.NotNil(t, result.ToolResult)
     
     // Assert on result
-    assert.Nil(t, result.ToolResult.Error)
+    assert.Nil(t, result.ToolResult.Failure)
     assert.NotNil(t, result.ToolResult.Result)
     
     // Unmarshal and verify typed result
@@ -152,31 +159,31 @@ func TestSearchToolExecutor(t *testing.T) {
 }
 ```
 
-### Testing Tool Validation and Retry Hints
+### Testing Tool Validation and Recovery
 
-Verify that tools return proper errors and hints for invalid input:
+Test malformed external JSON at the generated codec boundary. Invalid model
+tool calls are rejected before planner or executor code receives them:
 
 ```go
-func TestToolValidationReturnsHint(t *testing.T) {
-    executor := &SearchExecutor{}
-    
-    // Invalid payload - missing required field
-    call := &planner.ToolRequest{
-        Name:    specs.Search,
-        Payload: json.RawMessage(`{"limit": 5}`), // missing "query"
-    }
-    
-    result, err := executor.Execute(context.Background(), &runtime.ToolCallMeta{}, call)
-    require.NoError(t, err) // Executor should not return error
-    require.NotNil(t, result.ToolResult)
-    
-    // Should return ToolError with RetryHint
-    assert.NotNil(t, result.ToolResult.Error)
-    assert.NotNil(t, result.ToolResult.RetryHint)
-    assert.Equal(t, planner.RetryReasonMissingFields, result.ToolResult.RetryHint.Reason)
-    assert.Contains(t, result.ToolResult.RetryHint.MissingFields, "query")
+func TestSearchPayloadRequiresQuery(t *testing.T) {
+    _, err := specs.SearchTool().Payload.FromJSON(
+        rawjson.Message(`{"limit":5}`),
+    )
+    require.Error(t, err)
+
+    var validationErr *tools.ValidationError
+    require.ErrorAs(t, err, &validationErr)
+    assert.Equal(t, "query", validationErr.Issues()[0].Field)
 }
 ```
+
+Direct executor tests should create a valid `planner.ToolRequest` with the
+generated typed descriptor, then construct a `runtime.ToolCall` from its name
+and canonical payload bytes and assign the execution IDs the runtime would add.
+Assert domain or provider failures through `ToolResult.Failure.Kind`,
+`Failure.Error`, and `Failure.Recovery`. Planner tests that specifically forward
+a validated provider call may use `planner.ToolRequestFromModelCall` to preserve
+its provider correlation ID.
 
 ### Testing Agent Composition
 
@@ -325,7 +332,8 @@ error: policy violation: max consecutive failed tool calls exceeded (3/3)
 **Solutions:**
 
 1. **Fix the underlying tool errors** - check tool executor logs
-2. **Improve retry hints** so the planner can self-correct
+2. **Fix the structured failure contract** so `Failure.Recovery` gives the
+   planner the correct action and exact correction evidence
 3. **Increase the limit** if transient failures are expected:
 ```go
 RunPolicy(func() {
@@ -398,21 +406,25 @@ error: invalid payload: json: cannot unmarshal string into Go struct field Searc
 
 **Solutions:**
 
-1. **Return a RetryHint** from the executor so the planner can self-correct:
+1. **Test the generated codec** so the boundary reports exact field issues:
 ```go
-if err != nil {
-    return runtime.Executed(&planner.ToolResult{
-        Name:  call.Name,
-        Error: planner.NewToolError("invalid payload"),
-        RetryHint: &planner.RetryHint{
-            Reason:       planner.RetryReasonInvalidArguments,
-            Tool:         call.Name,
-            ExampleInput: map[string]any{"query": "example", "limit": 10},
-            Message:      "limit must be an integer",
-        },
-    }), nil
-}
+_, err := specs.SearchTool().Payload.FromJSON(
+    rawjson.Message(`{"query":"example","limit":"ten"}`),
+)
+var validationErr *tools.ValidationError
+require.ErrorAs(t, err, &validationErr)
+assert.Equal(t, "invalid_field_type", validationErr.Issues()[0].Constraint)
 ```
+
+When a provider emits this payload, the validated model client returns
+`model.OutputValidationError`. The planner/runtime surfaces it as
+`planner.OutputContractError` before executor or service code runs. Use
+`errors.As` to assert the structured error at the boundary under test; no
+`ToolFailure` is recorded.
+
+Test `RecoveryCorrectCall` separately with a model-authored call that passes
+schema validation and whose executor or domain boundary returns a recoverable
+`ToolFailure`.
 
 2. **Improve tool descriptions** to clarify expected types.
 

--- a/content/en/docs/2-goa-ai/toolsets.md
+++ b/content/en/docs/2-goa-ai/toolsets.md
@@ -1,7 +1,7 @@
 ---
 title: Toolsets
 weight: 4
-description: "Learn about toolset types, execution models, validation, retry hints, and tool catalogs in Goa-AI."
+description: "Learn about toolset types, execution models, validation, structured failure recovery, and tool catalogs in Goa-AI."
 llm_optimized: true
 aliases:
 ---
@@ -84,11 +84,14 @@ For inline implementations, you write the executor logic directly:
 func (e *Executor) Execute(
     ctx context.Context,
     meta *runtime.ToolCallMeta,
-    call *planner.ToolRequest,
+    call *runtime.ToolCall,
 ) (*runtime.ToolExecutionResult, error) {
     switch call.Name {
     case specs.Summarize:
-        args, _ := specs.UnmarshalSummarizePayload(call.Payload)
+        args, err := specs.SummarizeTool().Payload.FromJSON(call.Payload)
+        if err != nil {
+            return nil, fmt.Errorf("decode admitted %s payload: %w", call.Name, err)
+        }
         // Custom logic: fetch multiple docs, combine, summarize
         summary := e.summarizeDocuments(ctx, args.DocIDs)
         return runtime.Executed(&planner.ToolResult{
@@ -97,8 +100,12 @@ func (e *Executor) Execute(
         }), nil
     }
     return runtime.Executed(&planner.ToolResult{
-        Name:  call.Name,
-        Error: planner.NewToolError("unknown tool"),
+        Name: call.Name,
+        Failure: &planner.ToolFailure{
+            Kind:     planner.FailureInvalidCall,
+            Error:    planner.NewToolError("unknown tool"),
+            Recovery: planner.RecoveryDirective{Action: planner.RecoveryReplan},
+        },
     }), nil
 }
 
@@ -134,6 +141,13 @@ which projection. Dropping the schema-without-root-example or parsed example
 input prevents provider adapters from sending native `input_examples`, even
 though the generated tool spec was correct.
 
+The validated model client still needs an executable input validator. Build
+local generated tools with `model.ToolDefinitionFromSpec`, which retains the
+generated payload decoder. Use `model.AdvertisedToolInputFromSchema` for a
+caller-authored schema. `model.ToolInputFromContract` reconstructs projections
+after a gateway or proxy hop; it does not replace the generated decoder on the
+planner-facing side.
+
 ### Bounded Tool Results
 
 Some tools naturally return large lists, graphs, or time-series windows. You can mark these as **bounded views** so that services remain responsible for trimming while the runtime enforces and surfaces the contract.
@@ -147,6 +161,7 @@ type Bounds struct {
     Returned       int    // Number of items in the bounded view
     Total          *int   // Best-effort total before truncation (optional)
     Truncated      bool   // Whether any caps were applied (length, window, depth)
+    NextCursor     *string // Non-empty opaque cursor for the next page (optional)
     RefinementHint string // Guidance on how to narrow the query when truncated
 }
 ```
@@ -156,6 +171,7 @@ type Bounds struct {
 | `Returned` | Count of items actually present in the result |
 | `Total` | Best-effort count of total items before truncation (nil if unknown) |
 | `Truncated` | True if any caps were applied (pagination, depth limits, size limits) |
+| `NextCursor` | Non-empty opaque cursor for the next page; valid only for a paging-enabled tool when `Truncated` is true |
 | `RefinementHint` | Human-readable guidance for narrowing the query (e.g., "Add a date filter to reduce results") |
 
 #### Service Responsibility for Trimming
@@ -252,19 +268,18 @@ Bounded tools are a hard contract: services implement truncation and populate bo
 **Contract:**
 
 - `Bounds.Returned` and `Bounds.Truncated` must always be set on successful bounded tool results.
-- `Bounds.Total`, `Bounds.NextCursor`, and `Bounds.RefinementHint` are optional and should only be set when known.
-  Provider code sets `Bounds.NextCursor` to the opaque provider cursor.
+- `Bounds.Total` and `Bounds.RefinementHint` are optional and should only be set when known.
+- `Bounds.NextCursor` is optional, but when present it must point to a non-empty
+  string, the generated tool spec must declare paging, and `Bounds.Truncated`
+  must be true. Provider code sets it to the opaque cursor for the next page.
 
 Executors implement truncation and populate bounds metadata:
 
 ```go
-func (e *DeviceExecutor) Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *planner.ToolRequest) (*runtime.ToolExecutionResult, error) {
-    args, err := specs.UnmarshalListDevicesPayload(call.Payload)
+func (e *DeviceExecutor) Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *runtime.ToolCall) (*runtime.ToolExecutionResult, error) {
+    args, err := specs.ListDevicesTool().Payload.FromJSON(call.Payload)
     if err != nil {
-        return runtime.Executed(&planner.ToolResult{
-            Name:  call.Name,
-            Error: planner.NewToolError("invalid payload"),
-        }), nil
+        return nil, fmt.Errorf("decode admitted %s payload: %w", call.Name, err)
     }
 
     devices, total, nextCursor, truncated, err := e.repo.QueryDevices(ctx, args.SiteID, nil)
@@ -477,11 +492,20 @@ Use `Inject` for fields that:
 
 Service-backed toolsets execute via Temporal activities (or equivalent in other engines):
 
-1. Planner returns tool calls in `PlanResult` (payload is `json.RawMessage`)
-2. Runtime schedules `ExecuteToolActivity` for each tool call
-3. Activity decodes payload via generated codec for validation/hints
-4. Calls the toolset registration's `Execute(ctx, planner.ToolRequest)` with canonical JSON
-5. Re-encodes the result with the generated result codec
+1. The validated model client rejects schema-invalid provider calls before
+   planner code receives them. Planner-authored calls use
+   `planner.NewToolRequest`, which returns encoding failures directly.
+2. The planner returns schema-valid `ToolCalls []planner.ToolRequest` with a
+   generated tool name, canonical payload bytes, and an optional provider call
+   ID.
+3. The runtime validates the whole plan, assigns each execution ID, and
+   schedules `ExecuteToolActivity`.
+4. The activity decodes the already admitted payload. A decode failure is an
+   internal invariant error, not correction evidence.
+5. The activity calls the toolset registration's
+   `Execute(ctx, meta, *runtime.ToolCall)` with canonical JSON and the
+   runtime-assigned execution ID.
+6. The activity re-encodes the result with the generated result codec.
 
 ### Inline Execution (Agent-as-Tool)
 
@@ -489,7 +513,8 @@ Agent-as-tool toolsets execute inline from the planner's perspective while the r
 
 1. The runtime detects `Inline=true` on the toolset registration
 2. It injects the `engine.WorkflowContext` into `ctx` so the toolset's `Execute` function can start the provider agent as a child workflow with its own `RunID`
-3. It calls the toolset's `Execute(ctx, call)` with canonical JSON payload and tool metadata (including parent `RunID` and `ToolCallID`)
+3. It calls the toolset's `Execute(ctx, meta, *runtime.ToolCall)` with canonical
+   JSON payload and tool metadata (including parent `RunID` and `ToolCallID`)
 4. The generated agent-tool executor builds nested agent messages (system + user) from the tool payload and runs the provider agent as a child run
 5. The nested agent executes a full plan/execute/resume loop in its own run; its `RunOutput` and tool events are aggregated into a parent `planner.ToolResult` that carries the result payload, aggregated telemetry, child `ChildrenCount`, and a `RunLink` pointing at the child run
 6. Stream subscribers emit both `tool_start` / `tool_end` for the parent tool call and a `child_run_linked` link event so UIs can build nested agent cards while consuming a single session stream
@@ -504,15 +529,21 @@ reg := runtime.ToolsetRegistration{
     Execute: runtime.ToolCallExecutorFunc(func(
         ctx context.Context,
         meta *runtime.ToolCallMeta,
-        call *planner.ToolRequest,
+        call *runtime.ToolCall,
     ) (*runtime.ToolExecutionResult, error) {
         return runtime.Executed(&planner.ToolResult{
-            Name:  call.Name,
-            Error: planner.NewToolError("externally provided"),
+            Name: call.Name,
+            Failure: &planner.ToolFailure{
+                Kind:  planner.FailureUnavailable,
+                Error: planner.NewToolError("externally provided"),
+                Recovery: planner.RecoveryDirective{
+                    Action: planner.RecoveryReplan,
+                },
+            },
         }), nil
     }),
-    Specs: []tools.ToolSpec{specs.SpecAskQuestion},
-    ResultMaterializer: func(ctx context.Context, meta runtime.ToolCallMeta, call *planner.ToolRequest, result *planner.ToolResult) error {
+    Specs: []tools.ToolSpec{specs.SpecAskQuestion()},
+    ResultMaterializer: func(ctx context.Context, meta runtime.ToolCallMeta, call *runtime.ToolCall, result *planner.ToolResult) error {
         // Attach deterministic, server-only sidecars here.
         result.ServerData = buildServerData(call, result)
         return nil
@@ -523,7 +554,9 @@ reg := runtime.ToolsetRegistration{
 Contract:
 
 - `ResultMaterializer` runs on both the **normal execution path** and the **externally provided-result await path**.
-- It receives the original typed `planner.ToolRequest` plus the typed `planner.ToolResult`, before the runtime encodes JSON for hooks, workflow boundaries, or callers.
+- It receives the validated `runtime.ToolCall`, including its runtime-assigned
+  execution ID, plus the typed `planner.ToolResult` before the runtime encodes
+  JSON for hooks, workflow boundaries, or callers.
 - Use it to attach `result.ServerData` or to normalize the semantic result shape in a deterministic way.
 - Keep it pure and deterministic; when it runs inside workflow code it must not perform I/O.
 
@@ -553,27 +586,28 @@ function, registry caller, etc.) and receives explicit per-call metadata via
 **Executor Example:**
 
 ```go
-func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *planner.ToolRequest) (*runtime.ToolExecutionResult, error) {
+func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *runtime.ToolCall) (*runtime.ToolExecutionResult, error) {
     switch call.Name {
     case "orchestrator.profiles.upsert":
-        args, err := profilesspecs.UnmarshalUpsertPayload(call.Payload)
+        args, err := profilesspecs.UpsertTool().Payload.FromJSON(call.Payload)
         if err != nil {
-            return runtime.Executed(&planner.ToolResult{
-                Name: call.Name,
-                Error: planner.NewToolError("invalid payload"),
-            }), nil
+            return nil, fmt.Errorf("decode admitted %s payload: %w", call.Name, err)
         }
         
-        // Optional transforms if emitted by codegen
-        mp, _ := profilesspecs.ToMethodPayload_Upsert(args)
+        // Generated when the tool and bound method use compatible distinct types.
+        mp := profilesspecs.InitUpsertMethodPayload(args)
         methodRes, err := client.Upsert(ctx, mp)
         if err != nil {
             return runtime.Executed(&planner.ToolResult{
-                Name:  call.Name,
-                Error: planner.ToolErrorFromError(err),
+                Name: call.Name,
+                Failure: &planner.ToolFailure{
+                    Kind:     planner.FailureUnavailable,
+                    Error:    planner.ToolErrorFromError(err),
+                    Recovery: planner.RecoveryDirective{Action: planner.RecoveryReplan},
+                },
             }), nil
         }
-        tr, _ := profilesspecs.ToToolReturn_Upsert(methodRes)
+        tr := profilesspecs.InitUpsertToolResult(methodRes)
         return runtime.Executed(&planner.ToolResult{
             Name:   call.Name,
             Result: tr,
@@ -581,8 +615,12 @@ func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *planner.Tool
         
     default:
         return runtime.Executed(&planner.ToolResult{
-            Name:  call.Name,
-            Error: planner.NewToolError("unknown tool"),
+            Name: call.Name,
+            Failure: &planner.ToolFailure{
+                Kind:     planner.FailureInvalidCall,
+                Error:    planner.NewToolError("unknown tool"),
+                Recovery: planner.RecoveryDirective{Action: planner.RecoveryReplan},
+            },
         }), nil
     }
 }
@@ -609,7 +647,7 @@ Tool executors receive explicit per-call metadata via `ToolCallMeta` rather than
 All tool executors receive `ToolCallMeta` as an explicit parameter:
 
 ```go
-func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *planner.ToolRequest) (*runtime.ToolExecutionResult, error) {
+func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *runtime.ToolCall) (*runtime.ToolExecutionResult, error) {
     // Access run context directly from meta
     log.Printf("Executing tool in run %s, session %s, turn %s", 
         meta.RunID, meta.SessionID, meta.TurnID)
@@ -688,10 +726,16 @@ This capability is essential for building robust, production-grade agentic syste
 
 When a tool is bound to a Goa method via `BindTo`, code generation analyzes the tool Arg/Return and the method Payload/Result. If the shapes are compatible, Goa emits type-safe transform helpers:
 
-- `ToMethodPayload_<Tool>(in <ToolArgs>) (<MethodPayload>, error)`
-- `ToToolReturn_<Tool>(in <MethodResult>) (<ToolReturn>, error)`
+- `Init<Tool>MethodPayload(in <ToolPayload>) <MethodPayload>` converts the
+  generated tool payload into the bound Goa method payload.
+- `Init<Tool>ToolResult(in <MethodResult>) <ToolResult>` converts the bound Goa
+  method result into the generated tool result.
 
-Transforms are emitted under the toolset owner package (for example `gen/<service>/toolsets/<toolset>/transforms.go`) and use Goa's GoTransform to safely map fields. If a transform isn't emitted, write an explicit mapper in the executor.
+Transforms are emitted under the toolset owner package (for example
+`gen/<service>/toolsets/<toolset>/transforms.go`) and use Goa's GoTransform to
+safely map fields. Each helper has one return value; generated Go type
+references determine its exact pointer/value signature. If a transform isn't
+emitted, write an explicit mapper in the executor.
 
 ---
 
@@ -711,55 +755,57 @@ For exported toolsets (agent-as-tool), Goa-AI generates export packages under `g
 - Typed tool IDs
 - Alias payload/result types
 - Codecs
-- Helper builders (e.g., `New<Search>Call`)
+- One typed `<Tool>Tool()` descriptor pairing each tool ID with its payload and
+  result codecs; pass it to `planner.NewToolRequest`
 
 ---
 
-## Tool Validation and Retry Hints
+## Tool Validation and Recovery
 
 Goa-AI combines **Goa's design-time validations** with a **structured tool error model** to give LLM planners a powerful way to **repair invalid tool calls automatically**.
 
-### Core Types: ToolError and RetryHint
+### Core Types: ToolError and ToolFailure
 
 **ToolError** (alias to `runtime/agent/toolerrors.ToolError`):
 - `Message string` – human-readable summary
 - `Cause *ToolError` – optional nested cause (preserves chains across retries and agent-as-tool hops)
 - Constructors: `planner.NewToolError(msg)`, `planner.NewToolErrorWithCause(msg, cause)`, `planner.ToolErrorFromError(err)`, `planner.ToolErrorf(format, args...)`
 
-**RetryHint** – typed failure guidance used by the planner, runtime, and policy engine. A hint is not always permission to retry; call `AllowsRetry()`:
+**ToolFailure** keeps failure classification separate from the next legal
+planner transition:
 
 ```go
-type RetryHint struct {
-    Reason             RetryReason
-    Tool               tools.Ident
-    RestrictToTool     bool
-    MissingFields      []string
-    ExampleInput       map[string]any
-    PriorInput         map[string]any
-    ClarifyingQuestion string
-    Message            string
+type ToolFailure struct {
+    Kind     FailureKind
+    Error    *ToolError
+    Recovery RecoveryDirective
+}
+
+type RecoveryDirective struct {
+    Action      RecoveryAction
+    Issues      []*tools.FieldIssue
+    PriorInput  rawjson.Message
+    ExampleJSON rawjson.Message
 }
 ```
 
-Common `RetryReason` values:
-- `invalid_arguments` – payload failed validation (schema/type)
-- `missing_fields` – required fields are missing
-- `malformed_response` – tool returned data that could not be decoded
-- `timeout`, `rate_limited`, `tool_unavailable` – execution/infra issues
+Failure kinds include invalid calls, domain rejection, unavailability, rate
+limits, timeouts, malformed results, and internal errors. Recovery has three
+explicit actions:
 
-`RetryReasonTimeout` is terminal for the current run, so
-`hint.AllowsRetry()` returns false. Every other defined reason returns true.
-This method is the canonical distinction; do not infer retryability from
-`RestrictToTool`, message text, or the mere presence of a hint.
+- `RecoveryCorrectCall` keeps the failed tool available and supplies structured
+  correction evidence.
+- `RecoveryReplan` removes the failed tool from the next planner turn.
+- `RecoveryFinish` allows only finalization from evidence already collected.
 
-**ToolResult** carries errors and hints:
+`ToolResult` carries either a typed result or one structured failure:
 
 ```go
 type ToolResult struct {
     Name          tools.Ident
     Result        any
-    Error         *ToolError
-    RetryHint     *RetryHint
+    ServerData    rawjson.Message
+    Failure       *ToolFailure
     Telemetry     *telemetry.ToolTelemetry
     ToolCallID    string
     ChildrenCount int
@@ -767,36 +813,46 @@ type ToolResult struct {
 }
 ```
 
-### Auto-Repairing Invalid Tool Calls
+### Recovering from Admitted Tool Failures
 
 The recommended pattern:
 
 1. **Design tools with strong payload schemas** (Goa design)
-2. **Let generated codecs and executors surface validation failures** as structured validation errors or `ToolError` + `RetryHint` instead of panicking or hiding errors
-3. **Teach your planner** to inspect `ToolResult.Error` and `ToolResult.RetryHint`, repair the payload when possible, and retry the tool call if appropriate
+2. **Treat executor decode failures as invariant errors** because model-emitted
+   invalid payloads and planner encoding failures stop before execution
+3. **Return `ToolFailure` for domain failures after admission** so a
+   model-authored call may request correction when a valid payload violates a
+   cross-field or business rule
+4. **Teach your planner** to inspect `ToolOutput.Failure`; the runtime uses its
+   `Recovery` action to decide whether the same tool remains available, is
+   removed for replanning, or the run must finish
 
-Generated tool codecs reject closed-object contract violations before executor
-logic runs. Unknown fields become structured `unknown_field` issues with the
-allowed keys for that object path, and JSON type mismatches become
-`invalid_field_type` issues with generated expected/actual JSON type metadata.
-The runtime converts those validation issues into restricted retry hints so the
-next planner turn repairs the same tool call instead of choosing a different
-tool or guessing from a plain decoder string.
+The validated model client uses generated codecs to reject unknown fields, JSON
+type mismatches, and schema constraints before planner or executor code runs.
+Those failures are output-contract errors, not `ToolFailure` values. The example
+below instead starts with an admitted model-authored call whose decoded payload
+violates `validateUpsertRule`, a domain rule that the payload schema cannot
+express. When that failure requests `RecoveryCorrectCall`, the workflow derives
+the prior input and example from the provider call and registered tool
+specification; it ignores executor-authored `PriorInput` and `ExampleJSON`.
 
 **Example Executor:**
 
 ```go
-func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *planner.ToolRequest) (*runtime.ToolExecutionResult, error) {
-    args, err := spec.UnmarshalUpsertPayload(call.Payload)
+func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *runtime.ToolCall) (*runtime.ToolExecutionResult, error) {
+    args, err := spec.UpsertTool().Payload.FromJSON(call.Payload)
     if err != nil {
+        return nil, fmt.Errorf("decode admitted %s payload: %w", call.Name, err)
+    }
+    if err := validateUpsertRule(args); err != nil {
         return runtime.Executed(&planner.ToolResult{
             Name: call.Name,
-            Error: planner.NewToolError("invalid payload"),
-            RetryHint: &planner.RetryHint{
-                Reason:        planner.RetryReasonInvalidArguments,
-                Tool:          call.Name,
-                RestrictToTool: true,
-                Message:       "Payload did not match the expected schema.",
+            Failure: &planner.ToolFailure{
+                Kind:  planner.FailureInvalidCall,
+                Error: planner.ToolErrorFromError(err),
+                Recovery: planner.RecoveryDirective{
+                    Action: planner.RecoveryCorrectCall,
+                },
             },
         }), nil
     }
@@ -804,8 +860,14 @@ func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *planner.Tool
     res, err := client.Upsert(ctx, args)
     if err != nil {
         return runtime.Executed(&planner.ToolResult{
-            Name:  call.Name,
-            Error: planner.ToolErrorFromError(err),
+            Name: call.Name,
+            Failure: &planner.ToolFailure{
+                Kind:  planner.FailureUnavailable,
+                Error: planner.ToolErrorFromError(err),
+                Recovery: planner.RecoveryDirective{
+                    Action: planner.RecoveryReplan,
+                },
+            },
         }), nil
     }
 
@@ -813,38 +875,15 @@ func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *planner.Tool
 }
 ```
 
-**Example Planner Logic:**
-
-```go
-func (p *MyPlanner) PlanResume(ctx context.Context, in *planner.PlanResumeInput) (*planner.PlanResult, error) {
-    if len(in.ToolOutputs) == 0 {
-        return &planner.PlanResult{}, nil
-    }
-
-    last := in.ToolOutputs[len(in.ToolOutputs)-1]
-    if last.Error != nil && last.RetryHint.AllowsRetry() {
-        hint := last.RetryHint
-
-        switch hint.Reason {
-        case planner.RetryReasonMissingFields, planner.RetryReasonInvalidArguments:
-            return &planner.PlanResult{
-                Await: &planner.Await{
-                    Clarification: &planner.AwaitClarification{
-                        ID:               "fix-" + string(hint.Tool),
-                        Question:         hint.ClarifyingQuestion,
-                        MissingFields:    hint.MissingFields,
-                        RestrictToTool:   hint.Tool,
-                        ExampleInput:     hint.ExampleInput,
-                        ClarifyingPrompt: hint.Message,
-                    },
-                },
-            }, nil
-        }
-    }
-
-    return &planner.PlanResult{/* FinalResponse, next ToolCalls, ... */}, nil
-}
-```
+`PlanResumeInput.ToolOutputs` contains the workflow-safe form of each call:
+canonical payload/result bytes plus `Failure`. For `RecoveryCorrectCall`, field
+issues, prior input, and example JSON let the next planner turn correct the
+call. `RecoveryReplan` removes the failed tool from that next turn.
+`RecoveryFinish` permits only finalization. The runtime enforces these
+transitions; planners do not infer them from error text. Only provider-authored
+calls can use `RecoveryCorrectCall`. Runtime-created continuations have no
+model-authored input and must replan or finish instead of exposing their
+execution payload.
 
 ---
 
@@ -867,6 +906,25 @@ For each agent, Goa-AI emits a **specs package** and a **JSON catalog**:
   payload/result schemas, hints, plus one typed `tools.TypedTool` descriptor
   per tool (for example `SummarizeDocTool`) pairing the tool identifier with
   its typed payload and result codecs
+
+Generated spec accessors return fresh copies. Application mutation of one
+returned schema, example, or codec wrapper cannot alter later model requests.
+Use `<Tool>Tool().Payload.FromJSON(...)` for ordinary payloads and the generated
+`Decode<Tool>(payload, meta, labels)` helper for tools with injected fields.
+Do not retain or mutate spec internals as shared runtime state.
+
+### No-Result Tools
+
+A method-backed tool whose Goa service method has no result generates an empty
+result `TypeSpec`: no schema and no result codec. Its executor reports success
+without inventing a payload:
+
+```go
+return runtime.Executed(&planner.ToolResult{Name: call.Name}), nil
+```
+
+The generated typed descriptor uses an empty `tools.JSONCodec[any]` for that
+result. `PlanResume` observes successful completion with empty result bytes.
 
 **JSON catalog (`tool_schemas.json`):**
 
@@ -977,16 +1035,23 @@ decode canonical JSON bytes without sending those bytes to model providers.
 func (e *Executor) Execute(
     ctx context.Context,
     meta *runtime.ToolCallMeta,
-    call *planner.ToolRequest,
+    call *runtime.ToolCall,
 ) (*runtime.ToolExecutionResult, error) {
-    args, _ := specs.UnmarshalGetTimeSeriesPayload(call.Payload)
+    args, err := specs.GetTimeSeriesTool().Payload.FromJSON(call.Payload)
+    if err != nil {
+        return nil, fmt.Errorf("decode admitted %s payload: %w", call.Name, err)
+    }
     
     // Fetch full data
     fullData, err := e.dataService.GetTimeSeries(ctx, args.DeviceID, args.StartTime, args.EndTime)
     if err != nil {
         return runtime.Executed(&planner.ToolResult{
-            Name:  call.Name,
-            Error: planner.ToolErrorFromError(err),
+            Name: call.Name,
+            Failure: &planner.ToolFailure{
+                Kind:     planner.FailureUnavailable,
+                Error:    planner.ToolErrorFromError(err),
+                Recovery: planner.RecoveryDirective{Action: planner.RecoveryReplan},
+            },
         }), nil
     }
     
@@ -1021,8 +1086,8 @@ execution and externally provided-result await paths:
 ```go
 reg := runtime.ToolsetRegistration{
     Name:  "orchestrator.metrics",
-    Specs: []tools.ToolSpec{specs.SpecGetTimeSeries},
-    ResultMaterializer: func(ctx context.Context, meta runtime.ToolCallMeta, call *planner.ToolRequest, result *planner.ToolResult) error {
+    Specs: []tools.ToolSpec{specs.SpecGetTimeSeries()},
+    ResultMaterializer: func(ctx context.Context, meta runtime.ToolCallMeta, call *runtime.ToolCall, result *planner.ToolResult) error {
         if len(result.ServerData) != 0 {
             return nil
         }
@@ -1067,9 +1132,12 @@ Avoid server-data when:
 ## Best Practices
 
 - **Put validations in the design, not in planners** – Use Goa's attribute DSL (`Required`, `MinLength`, `Enum`, etc.)
-- **Return ToolError + RetryHint from executors** – Prefer structured errors over panics or plain `error` returns
-- **Keep hints concise but actionable** – Focus on which fields are missing/invalid, a short clarifying question, and a small `ExampleInput` map
-- **Teach planners to read hints** – Make `RetryHint` handling a first-class part of your planner
+- **Return `ToolFailure` from executors** – Preserve the error cause and choose
+  the exact recovery action instead of returning a plain error or panic
+- **Keep correction evidence exact** – Use generated field issues, canonical
+  prior input, and a schema-compliant JSON example
+- **Teach planners to read failures** – Make `ToolOutput.Failure` handling a
+  first-class part of the planner
 - **Avoid re-validating inside services** – Goa-AI assumes validation happens at the tool boundary
 
 ---


### PR DESCRIPTION
## Why these docs changed

The Goa-AI guide still mixed older handwritten executor patterns with the contracts released in v0.77.3. In particular, it could lead readers to treat schema-invalid model output as a recoverable tool execution, reuse provider tool-call identity as runtime execution identity, or author correction payloads inside executors even though the workflow now derives them from the admitted call.

A framework user following those examples could build a planner that retries output the runtime considers terminal, correlate correction evidence with the wrong provider call, or persist a suspension that cannot be resumed safely.

## Documented contract

The Goa-AI section now explains the current DSL, generated code, and runtime as one path:

- generated tool specifications and codecs validate model-authored calls before executor code runs;
- invalid model, planner, or typed tool output surfaces as structured `*planner.OutputContractError`, detected with `errors.As`;
- `ToolFailure` recovery applies only after a schema-valid call is admitted and execution or a domain rule fails;
- planners emit `planner.ToolRequest`, the runtime creates `runtime.ToolCall`, `ModelToolCallID` correlates provider transcript evidence, and `ToolCallID` identifies durable execution;
- the workflow owns correction input and generated examples rather than trusting executor-authored bytes;
- typed completion streams validate the whole response and expose suppression/termination behavior explicitly;
- `RunSuspension` v4, replay identity, nested agent runs, terminal finalization labels, bounded results, evaluations, MCP integration, and production rollout guidance use the released public names and behavior.

Examples now return direct encoding or invariant errors for impossible decode failures. `RecoveryCorrectCall` appears only after an admitted model-authored call passes schema validation and then violates an executor-owned domain rule.

## Compatibility and publication

This pull request changes documentation only. It requires no data migration, deployment order, runtime rollback, or generated-code update. It documents Goa-AI v0.77.3, which has already been published.

English remains the source of truth. No translated pages are changed in this pull request.

## Verification performed

- `npm test` — 5 files and 70 tests passed
- `make build` — Hugo production build completed successfully
- `git diff --check`
- Independent contract review against Goa-AI v0.77.3 found no remaining high-, medium-, or low-severity factual issues

The Hugo build emitted existing upstream deprecation warnings from Docsy, Bootstrap, and Sass; it completed successfully and produced no documentation error.

## Review guide

Read `_index.md` and `quickstart.md` first for the user journey. `runtime.md` and `toolsets.md` define execution, failure, identity, and suspension behavior. `production.md`, `testing.md`, and `evaluations.md` cover operational and verification consequences; `agent-composition.md`, `memory-sessions.md`, and `mcp-integration.md` cover adjacent runtime integrations.