### PR TITLE
Document pagination recovery after parallel failures

### DIFF
--- a/content/en/docs/2-goa-ai/toolsets.md
+++ b/content/en/docs/2-goa-ai/toolsets.md
@@ -315,9 +315,13 @@ When a bounded tool executes:
    and retained query fields before execution. Exact cursor lineage advances
    sequential pages. Parallel source invocations remain valid; multiple live
    heads make the no-argument continuation unavailable
-4. For direct `Cursor`, the runtime projects the opaque cursor into
+4. If another tool in the same parallel batch requires `finish` recovery, the
+   failed tool cannot run again and no new domain work can start. Continuation
+   actions remain available for successful queries that already returned a
+   next-page cursor. Without such an action, finalization starts immediately
+5. For direct `Cursor`, the runtime projects the opaque cursor into
    `next_cursor` and the model supplies it on the next call
-5. Stream subscribers and finalizers access bounds for UI display, logging, or
+6. Stream subscribers and finalizers access bounds for UI display, logging, or
    policy decisions
 
 ```go

--- a/content/es/docs/2-goa-ai/toolsets.md
+++ b/content/es/docs/2-goa-ai/toolsets.md
@@ -281,8 +281,9 @@ Cuando se ejecuta una herramienta acotada:
 1. El runtime valida que una herramienta acotada exitosa haya devuelto `planner.ToolResult.Bounds`
 2. El runtime fusiona esos bounds en el JSON emitido usando los nombres JSON visibles para el modelo generados desde `BoundedResult(...)`
 3. Con `ContinueWith`, el runtime ofrece la acción vacía solo cuando una única cabeza activa de la cadena puede continuar y enlaza el cursor antes de ejecutar
-4. Con `Cursor` directo, el runtime emite el cursor opaco en `next_cursor` para la siguiente llamada del modelo
-5. Los suscriptores de streams y los finalizadores acceden a los bounds para su visualización en la UI, logging o decisiones de políticas
+4. Si otra herramienta del mismo lote paralelo requiere recuperación `finish`, la herramienta fallida no puede volver a ejecutarse y no puede iniciarse nuevo trabajo de dominio. Las acciones de continuación siguen disponibles para las consultas exitosas que ya devolvieron un cursor de página siguiente. Sin una acción de ese tipo, la finalización comienza inmediatamente
+5. Con `Cursor` directo, el runtime emite el cursor opaco en `next_cursor` para la siguiente llamada del modelo
+6. Los suscriptores de streams y los finalizadores acceden a los bounds para su visualización en la UI, logging o decisiones de políticas
 
 ```go
 // En un suscriptor de stream

--- a/content/fr/docs/2-goa-ai/toolsets.md
+++ b/content/fr/docs/2-goa-ai/toolsets.md
@@ -280,8 +280,9 @@ Lorsqu'un outil limité s'exécute :
 1. Le runtime valide qu'un outil limité réussi a renvoyé `planner.ToolResult.Bounds`
 2. Le moteur d'exécution fusionne ces limites dans le JSON émis en utilisant les noms de champs de `BoundedResult(...)`.
 3. Avec `ContinueWith`, le runtime propose l'action vide uniquement pour une tête de chaîne active non ambiguë et associe le curseur avant l'exécution
-4. Avec `Cursor` direct, le runtime émet le curseur opaque dans `next_cursor` pour l'appel suivant du modèle
-5. Les abonnés au flux et les finaliseurs accèdent aux limites pour l'affichage UI, la journalisation ou les décisions de politique
+4. Si un autre outil du même lot parallèle nécessite une récupération `finish`, l'outil en échec ne peut pas être relancé et aucun nouveau travail métier ne peut commencer. Les actions de continuation restent disponibles pour les requêtes réussies qui ont déjà renvoyé un curseur de page suivante. Sans une telle action, la finalisation commence immédiatement
+5. Avec `Cursor` direct, le runtime émet le curseur opaque dans `next_cursor` pour l'appel suivant du modèle
+6. Les abonnés au flux et les finaliseurs accèdent aux limites pour l'affichage UI, la journalisation ou les décisions de politique
 
 ```go
 // In a stream subscriber

--- a/content/it/docs/2-goa-ai/toolsets.md
+++ b/content/it/docs/2-goa-ai/toolsets.md
@@ -289,8 +289,9 @@ When a bounded tool executes:
 1. The runtime validates that a successful bounded tool returned `planner.ToolResult.Bounds`
 2. The runtime merges those bounds into emitted JSON using the model-facing JSON field names generated from `BoundedResult(...)`
 3. Con `ContinueWith`, il runtime offre l'azione vuota solo per una singola testa di catena attiva non ambigua e associa il cursor prima dell'esecuzione
-4. Con `Cursor` diretto, il runtime emette il cursor opaco in `next_cursor` per la chiamata successiva del modello
-5. I sottoscrittori dello stream e i finalizer accedono ai bounds per UI, log e decisioni di policy
+4. Se un altro strumento nello stesso batch parallelo richiede il recovery `finish`, lo strumento fallito non può essere eseguito di nuovo e non può iniziare nuovo lavoro di dominio. Le azioni di continuazione restano disponibili per le query riuscite che hanno già restituito un cursor della pagina successiva. Senza tale azione, la finalizzazione inizia immediatamente
+5. Con `Cursor` diretto, il runtime emette il cursor opaco in `next_cursor` per la chiamata successiva del modello
+6. I sottoscrittori dello stream e i finalizer accedono ai bounds per UI, log e decisioni di policy
 
 ```go
 // In un sottoscrittore di flusso

--- a/content/ja/docs/2-goa-ai/toolsets.md
+++ b/content/ja/docs/2-goa-ai/toolsets.md
@@ -269,8 +269,9 @@ bounded tool が実行されると:
 1. runtime は successful bounded tool が `planner.ToolResult.Bounds` を返したことを検証します
 2. runtime は `BoundedResult(...)` の field name を使い、emitted JSON に bounds を merge します
 3. `ContinueWith` では、runtime は一意な live chain head に対してのみ空の action を公開し、実行前に cursor を bind します
-4. direct `Cursor` では、runtime は opaque cursor を `next_cursor` に出力し、model が次の call で指定します
-5. stream subscriber と finalizer は bounds を UI display、logging、policy decision に使えます
+4. 同じ parallel batch の別の tool が `finish` recovery を要求した場合、failed tool は再実行できず、新しい domain work も開始できません。next-page cursor を既に返した successful query の continuation action は引き続き利用できます。そのような action がない場合は、直ちに finalization が始まります
+5. direct `Cursor` では、runtime は opaque cursor を `next_cursor` に出力し、model が次の call で指定します
+6. stream subscriber と finalizer は bounds を UI display、logging、policy decision に使えます
 
 ```go
 // In a stream subscriber


### PR DESCRIPTION
## Outcome

The public Goa-AI toolset documentation now explains how an unfinished paginated query behaves when a different tool in the same parallel batch fails terminally.

Previously, the `BoundedResult` page described generated continuation actions but did not state whether a sibling `finish` recovery failure discarded them. That omission made it unclear whether applications could finish pages already requested or whether every tool action stopped immediately.

After [goadesign/goa-ai#260](https://github.com/goadesign/goa-ai/pull/260), the contract is explicit:

- the failed tool cannot run again;
- no new domain work can start;
- continuation actions remain available for successful queries that already returned a next-page cursor; and
- finalization begins immediately when no such continuation exists.

## Documentation scope

The new runtime-behavior item appears in the English source page and the Spanish, French, Italian, and Japanese mirrors. The wording stays beside `BoundedResult` and `ContinueWith`, where users declare and implement this behavior. No navigation, code sample, diagram, generated asset, dependency, or site configuration changes.

## Compatibility and publication

This PR changes documentation only. It has no API, wire-format, migration, regeneration, deployment-order, mixed-version, or rollback requirement. The site may publish before or after the runtime PR; until the runtime release lands, the linked implementation PR is the authoritative pending change. Reverting this PR removes only the explanatory text.

## Validation

- `git diff --check`
- `npm ci`
- `make build` — Hugo built all five languages successfully; existing Hugo and Sass deprecation warnings remain unchanged