### PR TITLE
Document durable workflow continuation handoff

### DIFF
--- a/content/en/docs/2-goa-ai/memory-sessions.md
+++ b/content/en/docs/2-goa-ai/memory-sessions.md
@@ -405,8 +405,9 @@ that use it as one coordinated change.
 - When a run requests external input, its workflow ends; the answer starts a new
   run in the same session using the saved checkpoint
 - When accepting the answer must be combined with an application write, use
-  `PrepareContinuation`, atomically accept the answer in application storage,
-  then pass that exact prepared value to `StartContinuation`. See
+  `PrepareContinuation`, call `MarshalBinary`, and atomically store those bytes
+  with the accepted answer. A submitting process loads the bytes, calls
+  `ParsePreparedRun`, and passes the restored value to `StartPrepared`. See
   [External Input and Workflow Continuations](../runtime/#external-input-and-workflow-continuations).
 - Use `SessionID` to group related runs (e.g., per ticket or incident)
 - Rely on `run.Phase` and `RunCompleted` events for status tracking

--- a/content/en/docs/2-goa-ai/runtime.md
+++ b/content/en/docs/2-goa-ai/runtime.md
@@ -722,6 +722,16 @@ activities when their contracts allow it, but it never restarts an entire agent
 workflow after failure. A whole-workflow retry could repeat tool side effects or
 conflict with the final lifecycle record already saved by the first attempt.
 
+Custom engines use `engine/contract.NormalizeRootRequest` and
+`NormalizeChildRequest` to validate and privately retain accepted requests.
+Before every initial or retry attempt, they call `CopyRunInput` so the workflow
+handler receives a fresh input. After success they retain one private
+`CopyRunOutput` result and copy it again for every wait, query, or other
+caller-facing read. Goa-AI also converts search fields to values that every
+supported engine can store and computes the identity used to recognize an exact
+retry. Each engine adapter still translates and submits those values through
+its own backend.
+
 ### Semantic timing vs Temporal liveness
 
 Goa-AI keeps the public runtime contract engine-agnostic:
@@ -846,19 +856,23 @@ suspension. Nested agents still run as linked child workflows.
 
 Clarifications, structured questions, external tool results, and confirmations
 end the current workflow successfully. The returned `RunOutput.Suspension`
-contains the request that the UI or external system must answer. No Temporal
-workflow remains open while a person is deciding.
+contains visible `Pending` requests and a private `Checkpoint`. The application
+keeps the complete suspension in trusted server storage and sends only
+`Suspension.Pending` to the UI or external system that must answer it. No
+Temporal workflow remains open while a person is deciding.
 
 Before the workflow completes, Goa-AI stores its private checkpoint under the
 completed run ID. When the application must record acceptance of the answer in
-its own storage, continuation has two explicit phases:
+its own storage, continuation has three explicit steps:
 
 1. `PrepareContinuation` loads the saved checkpoint, validates the typed answer
-   and the current generated `AgentDefinition`, and returns an immutable copy
-   of the complete successor input. It does not write runtime state or call the
-   workflow engine.
-2. The application atomically accepts that answer in its own storage, then
-   passes the exact prepared value to `StartContinuation`.
+   and the current generated `AgentDefinition`, and returns a `PreparedRun`
+   containing an immutable copy of the complete successor request. It does not
+   write runtime state or call the workflow engine.
+2. The application calls `MarshalBinary` and atomically stores those bytes with
+   its accepted answer.
+3. Any process can load those bytes, call `ParsePreparedRun`, and pass the
+   restored value to `StartPrepared`.
 
 This lets concurrent requests compete for one application-owned obligation
 without starting two workflows. If the engine response is uncertain, the
@@ -878,14 +892,31 @@ prepared, err := client.PrepareContinuation(
             Answer: "Device ID is ABC-123",
         },
     },
-    nil, // optional workflow settings for the new run
+    runtime.WorkflowOptions{},
 )
 if err != nil {
     return err
 }
 
-// Atomically accept this answer in application storage here.
-handle, err := client.StartContinuation(ctx, prepared)
+preparedBytes, err := prepared.MarshalBinary()
+if err != nil {
+    return err
+}
+// This application-owned method uses one database transaction to accept the
+// answer and store the prepared workflow ID with preparedBytes.
+if err := workflowStarts.AcceptContinuation(ctx, previous.RunID, prepared.RunID(), preparedBytes); err != nil {
+    return err
+}
+
+preparedBytes, err = workflowStarts.Load(ctx, "run-124")
+if err != nil {
+    return err
+}
+stored, err := runtime.ParsePreparedRun(preparedBytes)
+if err != nil {
+    return err
+}
+handle, err := client.StartPrepared(ctx, stored)
 if err != nil {
     return err
 }
@@ -894,7 +925,10 @@ next, err := handle.Wait(ctx)
 
 When no application write is needed between validation and engine submission,
 `Continue` is the convenience method that prepares, starts, and waits. In both
-forms the checkpoint remains private to the runtime store. Goa-AI validates its
+forms the runtime store keeps the authoritative checkpoint. The complete
+suspension and prepared bytes may also contain that checkpoint and the complete
+transcript, so keep them in trusted, access-controlled application storage and
+never send them to an untrusted client. Goa-AI validates the checkpoint's
 version and pending request, restores saved payloads through the current
 generated codecs, and resumes planning.
 

--- a/content/es/docs/2-goa-ai/runtime.md
+++ b/content/es/docs/2-goa-ai/runtime.md
@@ -817,16 +817,22 @@ con un resultado final o con un `api.RunSuspension` que contiene las solicitudes
 pendientes visibles y un checkpoint privado. Ningún workflow permanece abierto
 mientras una persona o un sistema externo prepara la respuesta.
 
+La aplicación conserva el `RunSuspension` completo en almacenamiento de servidor
+confiable y envía únicamente `RunSuspension.Pending` a la interfaz o al sistema
+externo que debe responder. Nunca envía el checkpoint privado a un cliente no
+confiable.
+
 El servicio propietario debe aceptar una sola respuesta de forma atómica. A
 continuación inicia un nuevo workflow con el ID de la ejecución completada, un
 nuevo ID de ejecución, un nuevo ID de turno y una
 `api.PendingInputResponse` que satisface el primer elemento pendiente:
 
 Si la aceptación de la respuesta debe guardarse junto con datos del producto,
-llama primero a `PrepareContinuation`, confirma ambos cambios de forma atómica
-y pasa exactamente el valor preparado a `StartContinuation`. Usa `Continue`
-solo cuando no haya una escritura de la aplicación entre la validación y el
-envío al motor.
+llama a `PrepareContinuation`, después a `MarshalBinary`, y guarda esos bytes
+con la respuesta en una sola transacción. El proceso que inicia el workflow
+carga los bytes, llama a `ParsePreparedRun` y pasa el valor restaurado a
+`StartPrepared`. Usa `Continue` solo cuando no haya una escritura de la
+aplicación entre la validación y el envío al motor.
 
 ```go
 next, err := client.Continue(
@@ -836,7 +842,7 @@ next, err := client.Continue(
     "run-124",
     "turn-2",
     response,
-    nil, // opciones opcionales del nuevo workflow
+    runtime.WorkflowOptions{},
 )
 ```
 
@@ -867,10 +873,13 @@ response := &api.PendingInputResponse{
 }
 ```
 
-La aplicación solo pasa el ID de la ejecución completada y la respuesta tipada.
-Goa-AI carga el checkpoint, valida su versión y la solicitud pendiente, restaura
-los payloads guardados con los codecs generados actuales y reanuda la
-planificación. El checkpoint permanece privado en el almacén del runtime.
+Al preparar la continuación, la aplicación solo pasa el ID de la ejecución
+completada y la respuesta tipada. Goa-AI carga el checkpoint, valida su versión
+y la solicitud pendiente, restaura los payloads guardados con los codecs
+generados actuales y reanuda la planificación. Los bytes de `PreparedRun`
+pueden contener una copia de ese checkpoint y la transcripción completa.
+Guárdalos únicamente en almacenamiento de aplicación confiable y con acceso
+controlado; nunca los envíes a un cliente no confiable.
 
 El único formato aceptado es `goa-ai.run-suspension.v7`. Goa-AI rechaza todas
 las versiones anteriores en lugar de adivinar cómo traducirlas. Antes de

--- a/content/fr/docs/2-goa-ai/runtime.md
+++ b/content/fr/docs/2-goa-ai/runtime.md
@@ -835,9 +835,12 @@ continuent à s'exécuter dans des workflows enfants liés.
 
 Les clarifications, questions structurées, résultats d'outils externes et
 confirmations terminent correctement le workflow courant. Le
-`RunOutput.Suspension` renvoyé contient la demande à laquelle l'interface ou le
-système externe doit répondre. Aucun workflow Temporal ne reste ouvert pendant
-la décision d'une personne.
+`RunOutput.Suspension` renvoyé contient des demandes `Pending` visibles et un
+point de reprise `Checkpoint` privé. L’application conserve la suspension complète
+dans un stockage serveur fiable et transmet uniquement `Suspension.Pending` à
+l’interface ou au système externe qui doit répondre. Elle ne transmet jamais le
+point de reprise privé à un client non fiable. Aucun workflow Temporal ne reste
+ouvert pendant la décision d'une personne.
 
 Avant de se terminer, Goa-AI enregistre son point de reprise privé sous l'ID de
 l'exécution achevée. L'application doit accepter atomiquement une seule réponse
@@ -846,10 +849,11 @@ Elle démarre ensuite un nouveau workflow avec l'ID de l'exécution précédente
 un nouvel ID d'exécution, un nouvel ID de tour et une réponse typée :
 
 Si l'acceptation de la réponse doit être enregistrée avec des données produit,
-appelez d'abord `PrepareContinuation`, validez les deux modifications de façon
-atomique, puis passez exactement la valeur préparée à `StartContinuation`.
-Utilisez `Continue` uniquement lorsqu'aucune écriture applicative ne sépare la
-validation de la soumission au moteur.
+appelez `PrepareContinuation`, puis `MarshalBinary`, et enregistrez ces octets
+avec la réponse dans une seule transaction. Le processus qui lance le workflow
+charge ces octets, appelle `ParsePreparedRun`, puis transmet la valeur restaurée
+à `StartPrepared`. Utilisez `Continue` uniquement lorsqu'aucune écriture
+applicative ne sépare la validation de la soumission au moteur.
 
 ```go
 next, err := client.Continue(
@@ -864,15 +868,17 @@ next, err := client.Continue(
             Answer: "Device ID is ABC-123",
         },
     },
-    nil, // paramètres de workflow facultatifs pour la nouvelle exécution
+    runtime.WorkflowOptions{},
 )
 ```
 
-L’application transmet uniquement l’ID de l’exécution terminée et la réponse
-typée. Goa-AI charge le point de reprise, valide sa version et la demande en
-attente, restaure les payloads enregistrés avec les codecs générés actuels et
-reprend la planification. Le point de reprise reste privé dans le stockage du
-runtime.
+Lors de la préparation de la continuation, l’application transmet uniquement
+l’ID de l’exécution terminée et la réponse typée. Goa-AI charge le point de
+reprise, valide sa version et la demande en attente, restaure les payloads
+enregistrés avec les codecs générés actuels et reprend la planification. Les
+octets de `PreparedRun` peuvent contenir une copie de ce point de reprise et la
+transcription complète. Conservez-les uniquement dans un stockage applicatif
+fiable avec un accès contrôlé ; ne les envoyez jamais à un client non fiable.
 
 Le seul format accepté est `goa-ai.run-suspension.v7`. Goa-AI rejette toutes les
 versions précédentes au lieu de deviner comment les traduire. Avant d’accepter

--- a/content/it/docs/2-goa-ai/runtime.md
+++ b/content/it/docs/2-goa-ai/runtime.md
@@ -729,8 +729,11 @@ workflow figli collegati.
 
 Chiarimenti, domande strutturate, risultati di strumenti esterni e conferme
 concludono con successo il workflow corrente. Il `RunOutput.Suspension`
-restituito contiene la richiesta cui deve rispondere la UI o il sistema
-esterno. Nessun workflow Temporal resta aperto mentre una persona decide.
+restituito contiene richieste `Pending` visibili e un `Checkpoint` privato.
+L'applicazione conserva la sospensione completa in uno storage server affidabile
+e invia solo `Suspension.Pending` alla UI o al sistema esterno che deve
+rispondere. Non invia mai il checkpoint privato a un client non attendibile.
+Nessun workflow Temporal resta aperto mentre una persona decide.
 
 Prima di terminare, Goa-AI salva il checkpoint privato sotto l'ID del run
 completato. L'applicazione deve accettare atomicamente una sola risposta, quindi
@@ -738,10 +741,11 @@ avvia un nuovo workflow con l'ID del run precedente, un nuovo run ID, un nuovo
 turn ID e una sola risposta tipizzata:
 
 Se l'accettazione della risposta deve essere salvata insieme a dati del
-prodotto, chiamare prima `PrepareContinuation`, confermare atomicamente entrambe
-le modifiche e passare esattamente il valore preparato a `StartContinuation`.
-Usare `Continue` solo quando non vi è una scrittura applicativa tra convalida e
-invio al motore.
+prodotto, chiamare `PrepareContinuation`, quindi `MarshalBinary`, e salvare quei
+byte con la risposta in un'unica transazione. Il processo che avvia il workflow
+carica i byte, chiama `ParsePreparedRun` e passa il valore ripristinato a
+`StartPrepared`. Usare `Continue` solo quando non vi è una scrittura
+applicativa tra convalida e invio al motore.
 
 ```go
 next, err := client.Continue(
@@ -756,14 +760,17 @@ next, err := client.Continue(
             Answer: "Device ID is ABC-123",
         },
     },
-    nil, // impostazioni workflow facoltative per la nuova esecuzione
+    runtime.WorkflowOptions{},
 )
 ```
 
-L’applicazione passa soltanto l’ID dell’esecuzione completata e la risposta
-tipizzata. Goa-AI carica il checkpoint, ne convalida la versione e la richiesta
-in attesa, ripristina i payload salvati con i codec generati correnti e riprende
-la pianificazione. Il checkpoint resta privato nello storage del runtime.
+Durante la preparazione della continuazione, l’applicazione passa soltanto l’ID
+dell’esecuzione completata e la risposta tipizzata. Goa-AI carica il checkpoint,
+ne convalida la versione e la richiesta in attesa, ripristina i payload salvati
+con i codec generati correnti e riprende la pianificazione. I byte di
+`PreparedRun` possono contenere una copia del checkpoint e la trascrizione
+completa. Salvali solo in uno storage applicativo affidabile e con accesso
+controllato; non inviarli mai a un client non attendibile.
 
 L’unico formato accettato è `goa-ai.run-suspension.v7`. Goa-AI rifiuta tutte le
 versioni precedenti invece di tentare di tradurle. Prima di accettare

--- a/content/ja/docs/2-goa-ai/runtime.md
+++ b/content/ja/docs/2-goa-ai/runtime.md
@@ -735,14 +735,15 @@ failure として保存されません。成功済みの修復を繰り返して
 
 受理された各 user input は、その turn の top-level workflow を 1 つ開始します。workflow は、その turn の final result または external-input suspension のどちらかで終了します。nested agent は引き続き linked child workflow として動きます。
 
-clarification、structured question、external tool result、confirmation は、現在の workflow を正常終了させます。返される `RunOutput.Suspension` には UI または external system が回答すべき request が入ります。人が判断している間、Temporal workflow は開いたままになりません。
+clarification、structured question、external tool result、confirmation は、現在の workflow を正常終了させます。返される `RunOutput.Suspension` には、UI または external system が回答する公開可能な `Pending` requests と、非公開の `Checkpoint` が入ります。application は suspension 全体を信頼できる server storage に保存し、回答する相手には `Suspension.Pending` だけを送ります。非公開 checkpoint を信頼できない client に送ってはいけません。人が判断している間、Temporal workflow は開いたままになりません。
 
 workflow が完了する前に、Goa-AI は completed run ID の下に非公開 checkpoint を保存します。application は 1 つの answer を原子的に受理し、2 つの concurrent request が同じ state を続行できないようにしなければなりません。その後、predecessor run ID、新しい run ID、新しい turn ID、1 つの型付き response を使って新 workflow を開始します。
 
 answer の受理と product data を同じ transaction で保存する必要がある場合は、まず
-`PrepareContinuation` を呼び、両方の変更を atomic に確定し、exact prepared value
-を `StartContinuation` に渡します。validation と engine submission の間に
-application write がない場合だけ `Continue` を使います。
+`PrepareContinuation`、続いて `MarshalBinary` を呼び、その bytes と answer を同じ
+transaction で保存します。workflow を開始する process は bytes を読み込み、
+`ParsePreparedRun` を呼び、復元した値を `StartPrepared` に渡します。validation と
+engine submission の間に application write がない場合だけ `Continue` を使います。
 
 ```go
 next, err := client.Continue(
@@ -757,14 +758,16 @@ next, err := client.Continue(
             Answer: "Device ID is ABC-123",
         },
     },
-    nil, // 新しい run の任意 workflow 設定
+    runtime.WorkflowOptions{},
 )
 ```
 
-application が渡すのは、完了した run ID と型付き回答だけです。Goa-AI は
-checkpoint を読み、その version と保留中 request を検証し、現在の generated
-codec で保存済み payload を復元して planning を再開します。checkpoint は
-runtime store 内で非公開のままです。
+continuation の準備時に application が渡すのは、完了した run ID と型付き回答
+だけです。Goa-AI は checkpoint を読み、その version と保留中 request を検証し、
+現在の generated codec で保存済み payload を復元して planning を再開します。
+`PreparedRun` の bytes には、その checkpoint のコピーと完全な transcript が含まれる
+場合があります。信頼できる access-controlled な application storage にだけ保存し、
+信頼できない client には決して送信しないでください。
 
 受理される形式は `goa-ai.run-suspension.v7` だけです。Goa-AI は以前の version を
 推測で変換せず、すべて拒否します。新しい runtime で continuation traffic を


### PR DESCRIPTION
Goa-AI applications can now save a prepared continuation with their own product write and submit that exact workflow later or from another process. These pages document the complete handoff and the data that must remain on the server.

## Why this needed clarification

The previous guide stopped at `PrepareContinuation` followed by `StartContinuation`. That example assumed the same process would submit immediately and did not show how an application could atomically accept an answer in its own database before starting the successor workflow.

The old wording could also be read as permission to send the complete `RunOutput.Suspension` to a browser. That value contains visible pending requests, but its private checkpoint may also contain the transcript and execution state.

## Documented contract

When accepting an answer must be combined with an application-owned database write, the application now:

1. Calls `PrepareContinuation` to build the complete successor request without starting it.
2. Calls `MarshalBinary` and stores those exact bytes in the same transaction as the accepted answer.
3. Loads the bytes in the submitting process.
4. Calls `ParsePreparedRun` and passes the restored value to `StartPrepared`.

An uncertain submission is retried with the same stored bytes. The application does not prepare a replacement with different fields.

The security boundary is explicit in all five languages:

- The runtime store keeps the authoritative checkpoint.
- The application keeps the complete suspension and prepared bytes in trusted, access-controlled server storage.
- Only `Suspension.Pending`, the list of typed requests that need answers, is sent to a UI or external system.
- The private checkpoint and prepared bytes are never sent to an untrusted client.

`Continue` remains the simpler method when no application write separates validation from engine submission.

The custom-engine section also replaces internal shorthand with the concrete requirements: copy accepted inputs and completed outputs, convert search fields to values supported by every engine, and compute the identity used to recognize an exact retry.

## Compatibility and rollout

This is documentation for the current Goa-AI API. It changes no Go types, generated code, wire data, or runtime behavior. There is no migration or deployment order.

## Validation

- Hugo production build passed for English, Spanish, French, Italian, and Japanese.
- `git diff --check` passed.
- The examples and ownership claims were checked against Goa-AI `main` at `2500f36e5bbf`.
- An independent documentation review found and verified the corrected suspension security boundary and prepared-run sequence.
