### PR TITLE
Document Goa-AI runtime storage and completion contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,16 @@ We provide a translation helper script backed by DeepL:
 cp .env.example .env
 ${EDITOR:-vi} .env
 
-# 2) Translate changed English docs to all supported languages
-./scripts/translate content/en/docs/
+# 2) Translate changed English docs to every language supported by DeepL
+./scripts/translate --lang IT --lang FR --lang ES content/en/docs/
 ```
 
 Notes:
 
 - The full workflow is documented in `scripts/TRANSLATION.md`.
 - The script uses a cache file (`.translation-cache.json`, gitignored) so only changed English files are reprocessed.
-- **Japanese (`JA`) is not auto-translated**: `./scripts/translate --lang JA ...` will print which files need a **manual update** and record the English hash so only future changes are re-flagged.
+- **Japanese (`JA`) is updated manually**: first run
+  `./scripts/translate --dry-run --lang JA ...`, update the listed files, then
+  run `./scripts/translate --lang JA ...` to record the English revision you
+  translated.
 - UI strings live under `i18n/*.yaml` and are maintained manually.

--- a/content/en/docs/2-goa-ai/memory-sessions.md
+++ b/content/en/docs/2-goa-ai/memory-sessions.md
@@ -256,9 +256,11 @@ state in one operation:
 
 - `StartRootRun` stores root-run metadata and its first record.
 - `StartChildRun` stores the parent link, child metadata, and first child record.
+  A new child requires a running parent; an exact accepted retry remains valid
+  after the parent stops.
 - `StartOneShotRun` stores a sessionless run and its first record.
 - `StartOneShotChildRun` stores a sessionless parent link and child start in one
-  operation.
+  operation. It applies the same running-parent and exact-retry rule.
 - `RecordRunCancellation` stores the first cancellation reason and its record.
 - `RecordRunSuspension` stores the private checkpoint, suspended status, and
   suspension record.
@@ -288,6 +290,38 @@ store must not guess which value is newer or overwrite the first value.
 Cancellation follows the same rule: the first reason is permanent, an exact
 repeat succeeds, and a different reason fails.
 
+### Durable event JSON
+
+The runtime decodes `RunStarted`, `RunSuspended`, `RunCompleted`, and
+`ChildRunLinked` payloads as exactly one typed JSON value. Unknown fields and
+extra JSON values after that value are rejected. Existing records must match
+these exact shapes before the runtime can replay or deliver them; it never
+ignores incompatible stored data.
+
+### Cancellation provenance {#cancellation-provenance}
+
+The runtime store distinguishes a cancellation request from the reason a run
+ended:
+
+- When a running workflow accepts an explicit `CancelRun` request, it stores
+  the first reason in run metadata and a matching record whose type is
+  `storage.CancellationRecordType` (`runtime.cancellation_intent`) in one
+  operation before it stops. The later canceled `RunCompleted` record must
+  contain that same reason.
+- If `StartRootRun` or `StartChildRun` finds that its session already ended,
+  the start operation stores `session_ended` in run metadata together with
+  `RunStarted` and the canceled `RunCompleted` record. It does not store a
+  `storage.CancellationRecordType` record because no separate cancellation was
+  requested.
+- If the workflow engine cancels a run without a previously recorded request,
+  the cancellation reason in run metadata remains empty and there is no
+  `storage.CancellationRecordType` record. The canceled `RunCompleted` record
+  contains `engine_canceled`. In this case, the empty metadata field has a
+  precise meaning; it is not missing data.
+
+These are the three valid pairings between run metadata and cancellation
+records. A durable store must preserve each pairing exactly.
+
 ### Continuation starts
 
 A continuation start requires an existing predecessor run in `suspended`
@@ -316,7 +350,10 @@ Child workflows use `StartChildRun`. The store records `ChildRunLinked` on the
 parent followed by `RunStarted` on the child. If the session has ended, it also
 records the child's canceled `RunCompleted`. Every workflow accepted by the
 engine therefore has one `RunStarted` record, including work stopped because
-its session ended.
+its session ended. A new child requires a running parent. An exact retry of a
+child start that the store already accepted remains valid after the parent
+stops; a changed retry or a new child is rejected. Temporal terminates a child
+workflow if its parent workflow closes first.
 
 Sessionless root work uses `StartOneShotRun`; it receives normal run metadata
 and `RunStarted`, but it does not create or join a session. An agent called as a
@@ -375,8 +412,8 @@ removed:
   and `PurgeSession`
 - the built-in `features/session/mongo` and `features/runlog/mongo` packages
 
-Replace the two stores with one implementation of
-`runtime/agent/storage.Store`, then pass it as the first argument to
+Replace the two stores with one implementation of `storage.Store` from
+`goa.design/goa-ai/runtime/agent/storage`, then pass it as the first argument to
 `runtime.New`. Move session creation, ending, and deletion into the host service
 that owns the runtime data. If agent workers run in separate services, make them
 call that owner through a typed API instead of importing its database adapter.
@@ -387,6 +424,21 @@ the lifecycle operations above, and old split-store writers must not overlap
 with new writers. The host chooses the conversion and recovery procedure for
 its database and deployment environment, then deploys the owner and all workers
 that use it as one coordinated change.
+
+The completion-delivery commands do not add a database schema migration or
+change a public wire format. They do change the Go source contract. Upgrade the
+runtime and its store implementation together:
+
+- replace each `Runtime.RepairRunCompletion` call with
+  `Runtime.EnsureRunCompletion`;
+- implement `LoadSessionStatus` in every custom `storage.Store`;
+- configure `Runtime.WithStream` before calling either ensure command for an
+  active Session; and
+- expect a new child start to fail after its parent stops. An exact retry of a
+  child start already accepted by the store remains valid.
+
+Existing durable lifecycle records must also satisfy the exact JSON contract
+above.
 
 ---
 

--- a/content/en/docs/2-goa-ai/production.md
+++ b/content/en/docs/2-goa-ai/production.md
@@ -405,25 +405,14 @@ Product data remains with the product service. For example, a chat service keeps
 its transcript, ratings, and search fields even when another service owns the
 Goa-AI runtime store.
 
-The store must commit each lifecycle change with its matching record. An
-identical storage-activity retry returns the first result. A retry that changes the run
-identity, payload, checkpoint, status, or cancellation reason fails as a
-conflict. See [Memory & Sessions](../memory-sessions/#store-lifecycle-changes-and-records-together)
-for the full contract.
-
-Every workflow accepted by the engine has a durable `RunStarted` record. If a
-session ended before an accepted root or child may begin work, the same start
-operation stores `RunStarted` followed by a canceled `RunCompleted`; the
-workflow does no planner or tool work. Sessionless child starts store the
-parent link and child start together. Their first call requires a running
-sessionless parent, while an exact retry remains valid after that parent
-finishes.
-
-A continuation start requires an existing suspended predecessor with the same
-session, agent, and parent run identity. The storage transaction rejects a
-mismatch before it writes the successor start or a parent link. The successor's
-`RunStarted` record stores `PredecessorRunID`; `RunMeta` does not duplicate that
-relationship.
+[Memory & Sessions](../memory-sessions/#store-lifecycle-changes-and-records-together)
+defines the complete storage contract: lifecycle changes and records are stored
+together, exact retries return the accepted result, new children require a
+running parent, stored event JSON is strict, and cancellation provenance is
+preserved. [Runtime](../runtime/#ensuring-a-final-record-and-its-delivery)
+defines how hosts validate and deliver final run events after engine history
+closes. Keep these rules in the owning runtime store rather than reproducing
+them in each worker.
 
 The move from `session.Store` plus `runlog.Store` is a coordinated storage
 change. Before the new runtime writes, existing run metadata, checkpoints, and

--- a/content/en/docs/2-goa-ai/runtime.md
+++ b/content/en/docs/2-goa-ai/runtime.md
@@ -272,6 +272,8 @@ if err := rt.Seal(ctx); err != nil {
    sessionful run proceeds only when its session is active; when the session has
    ended, the store follows `RunStarted` with a canceled `RunCompleted` and the
    workflow does no planner or tool work.
+   [Memory & Sessions](../memory-sessions/#cancellation-provenance) defines the
+   three valid ways cancellation reasons and intent records are stored.
 3. The runtime calls your planner's `PlanStart` with the current messages and a
    `run.Context` containing `RunID`, `SessionID`, `TurnID`, labels, and policy
    caps.
@@ -787,9 +789,10 @@ activity's Start-to-Close timeout and requires a value greater than zero.
 
 `Engine.QueryRunCompletion` returns the current run `Status`. Once the run is
 closed, the same result also contains its stable `CompletedAt` time and final
-`Output` or `WorkflowError`. Completion repair uses that time so every retry
-submits the same record timestamp. The method's separate error means the engine
-could not retrieve those facts. There is no separate status query.
+`Output` or `WorkflowError`. `EnsureRunCompletion` uses `CompletedAt` as the
+record timestamp, so every retry submits the same value. The method's separate
+error means the engine could not retrieve those facts. There is no separate
+status query.
 
 Child prompt preparation returns exactly one `Success` or `Failure`. Success
 contains only the messages and rendered prompt facts. The workflow derives the
@@ -817,34 +820,58 @@ applies the same retry policy as Temporal.
 - Root, child, sessionless root, and sessionless child starts are separate
   storage calls. Child starts store the parent link with the child start;
   sessionless starts store full run metadata without a session
-- A new sessionless child requires an existing running sessionless parent.
-  `StartOneShotChildRun` stores the parent link and child start together. An
-  exact retry remains valid after the parent finishes, while a changed retry or
-  a new child after the parent finishes is rejected
+- Temporal terminates a child workflow if its parent workflow closes first
+- New children require a running parent. `StartChildRun` and
+  `StartOneShotChildRun` each store the parent link and child start together.
+  An exact retry of an accepted start remains valid after the parent stops,
+  while a changed retry or a new child is rejected
 - Cancellation reasons are write-once. An exact retry succeeds; a different reason for the same run is a conflict
 - Suspension and terminal changes store the new status with the matching record,
   which cannot later be changed
+- Durable `RunStarted`, `RunSuspended`, `RunCompleted`, and `ChildRunLinked`
+  payloads must contain exactly one matching JSON value. Unknown fields and
+  trailing JSON values are rejected
 - Agents must be registered before the first run. The runtime rejects registration after the first run submission with `ErrRegistrationClosed` to keep engine workers deterministic
 - Tool executors receive explicit per-call metadata (`ToolCallMeta`) rather than fishing values from `context.Context`. Its labels contain cloned run and policy labels plus `runtime.FinalizationReasonLabel` only when that call is executing terminal finalization
 - Do not rely on implicit fallbacks; all domain identifiers (run, session, turn, correlation) must be passed explicitly
 
-### Repairing a missing final record
+### Ensuring a final record and its delivery {#ensuring-a-final-record-and-its-delivery}
 
 Normal workflows retry suspension and terminal writes until the runtime store
-accepts them. If engine history is already closed while the stored run still
-appears active, an operator can call
-`Runtime.RepairRunCompletion(ctx, runID)`. The command verifies the final engine
-status and submits the missing suspension or terminal record through a
-repair-only store method: `RepairRunSuspension` or `RepairRunTerminal`. The
-store writes it only if the run is still active;
-if the workflow stored another final record first, that record remains
-authoritative.
+accepts them. A host can use two explicit commands after engine history closes:
 
-Run listing and snapshot methods are read-only and never perform this repair.
-The engine returns the workflow output and workflow error separately from an
-error retrieving that result. Retrieval errors return to the operator and are
-never saved as the workflow's final failure. Repeating a successful repair does
-not change the stored result.
+- `Runtime.EnsureRunCompletion(ctx, runID)` stores a missing suspension or
+  terminal result for a run that is still active in storage. If the run is
+  already closed, or another final result wins while the command runs, it
+  validates and delivers the exact stored result instead.
+- `Runtime.EnsureChildRunLink(ctx, runID)` validates and delivers only a
+  session-backed child's exact stored parent link. Hosts can call it in
+  parent-first order before they deliver the final results of nested children.
+
+`EnsureRunCompletion` delivers the parent link before a child's final event.
+Stable event keys make repeated stream delivery safe, and an already stored
+result does not produce another local lifecycle notification. Neither ensure
+command changes the result that storage already accepted.
+
+Both commands require `Runtime.WithStream` when the Session status used for
+delivery is active. `EnsureChildRunLink` reads the current status through
+`LoadSessionStatus`. `EnsureRunCompletion` instead uses the `SessionStatus`
+returned with the final-record write or exact retry. A newly checked ended
+Session keeps its stored records and suppresses delivery. If storage accepted
+the event while the Session was active, that event remains due: ending the
+Session while the same delivery call retries does not cancel it.
+
+`EnsureRunCompletion` returns `ErrRunCompletionNotReady` when the engine still
+reports a running workflow. It returns `ErrRunCompletionCorrupt` when engine
+history or stored lifecycle data cannot form one valid result. An error loading
+engine history is returned to the caller and is never stored as the workflow's
+failure.
+
+Run listing and snapshot methods are read-only and never call either command.
+These commands add no database schema migration and do not change a public wire
+format. They do change the Go source interface for custom stores, and existing
+durable lifecycle records must match the strict typed JSON shapes documented in
+[Memory & Sessions](../memory-sessions/#durable-event-json).
 
 ---
 

--- a/content/en/docs/2-goa-ai/testing.md
+++ b/content/en/docs/2-goa-ai/testing.md
@@ -235,14 +235,25 @@ production implementation against the same contract, including these cases:
 
 - root, child, and sessionless one-shot starts store their metadata and first
   records together;
-- a child start stores its parent link in the same operation as the child start;
+- new `StartChildRun` and `StartOneShotChildRun` calls require a running parent
+  and store the parent link in the same operation as the child start;
+- an exact retry of either accepted child start remains valid after the parent
+  stops, while a changed retry and a new child are rejected;
 - an identical retry returns the original record identifier and reports that no
   new record was inserted;
 - repeating a lifecycle change with a different record conflicts even when the
   requested status and other lifecycle fields are unchanged;
 - changing any value fixed by the first write returns a conflict;
-- the first cancellation reason is permanent and a different later reason is a
-  conflict;
+- cancellation accepted by a running workflow stores the first reason and
+  matching `storage.CancellationRecordType` record together; its serialized
+  type is `runtime.cancellation_intent`. An exact retry succeeds and a different
+  later reason conflicts;
+- a sessionful start against an already-ended session stores `session_ended`
+  with the canceled terminal record and no `storage.CancellationRecordType`
+  record;
+- engine-originated cancellation leaves the stored reason empty and has no
+  `storage.CancellationRecordType` record, while its terminal record contains
+  `engine_canceled`;
 - suspension stores the checkpoint, suspended status, and matching record
   together;
 - terminal completion stores the final status and matching record together;
@@ -256,9 +267,32 @@ production implementation against the same contract, including these cases:
 - purge fails while a run is active, then removes the ended session's run
   metadata, checkpoints, and records after all runs finish.
 
-These tests should exercise the real database transaction behavior. A mock that
-only checks method calls cannot prove that state and records become visible
+These store tests must exercise the real database transaction behavior. A mock
+that only checks method calls cannot prove that state and records become visible
 together.
+
+Test the Temporal adapter separately: closing a Temporal parent must terminate
+its child workflow.
+
+Test the runtime's explicit completion-delivery commands separately:
+
+- `EnsureRunCompletion` writes a result missing from an active stored run and
+  validates and redelivers an already stored result without changing it;
+- a child link is delivered before its final event, while
+  `EnsureChildRunLink` delivers only the exact stored link;
+- an active Session without `Runtime.WithStream` fails, while a newly checked
+  ended Session keeps the stored result and suppresses delivery;
+- `LoadSessionStatus` returns the Session's current status, while
+  `EnsureRunCompletion` uses the `SessionStatus` returned with the final-record
+  write or exact retry and retains that status through stream retries;
+- an event accepted while its Session is active remains due if the Session ends
+  during that delivery call;
+- an open engine workflow returns `ErrRunCompletionNotReady`, and malformed or
+  contradictory engine or stored data returns `ErrRunCompletionCorrupt`.
+
+Test the hook codec separately: decoders for `RunStarted`, `RunSuspended`,
+`RunCompleted`, and `ChildRunLinked` must reject `null`, unknown fields, and a
+second trailing JSON value.
 
 Continuation tests should accept `goa-ai.run-suspension.v7` and reject every
 earlier checkpoint version before restoring payloads or calling a planner.

--- a/content/es/docs/2-goa-ai/memory-sessions.md
+++ b/content/es/docs/2-goa-ai/memory-sessions.md
@@ -189,9 +189,9 @@ En una aplicación de un solo proceso, `store` puede ser un adaptador de base de
 Cada método de ciclo de vida guarda el estado y el registro que lo demuestra en la misma operación:
 
 - `StartRootRun` guarda los metadatos de una ejecución raíz y su primer registro.
-- `StartChildRun` guarda el vínculo con el padre, los metadatos del hijo y su primer registro.
+- `StartChildRun` guarda el vínculo con el padre, los metadatos del hijo y su primer registro. Un hijo nuevo requiere un padre activo; un reintento exacto ya aceptado sigue siendo válido después de que el padre se detenga.
 - `StartOneShotRun` guarda una ejecución sin sesión y su primer registro.
-- `StartOneShotChildRun` guarda juntos el vínculo con el padre sin sesión y el inicio del hijo.
+- `StartOneShotChildRun` guarda juntos el vínculo con el padre sin sesión y el inicio del hijo. Aplica la misma regla de padre activo y reintento exacto.
 - `RecordRunCancellation` guarda el primer motivo de cancelación y su registro.
 - `RecordRunSuspension` guarda el checkpoint privado, el estado suspendido y su registro.
 - `RecordRunTerminal` guarda el estado final y su registro.
@@ -210,6 +210,41 @@ el cambio de ciclo de vida con otro registro produce un conflicto, aunque
 coincidan el estado y los demás campos del ciclo de vida.
 
 Si cambia cualquier valor fijado por la primera escritura, el almacén devuelve un conflicto. No adivina qué valor es más reciente ni sobrescribe el primero. El primer motivo de cancelación también es permanente: una repetición exacta tiene éxito y un motivo diferente produce un conflicto.
+
+### JSON de eventos duraderos {#durable-event-json}
+
+El runtime decodifica los payloads de `RunStarted`, `RunSuspended`,
+`RunCompleted` y `ChildRunLinked` como un único valor JSON tipado. Rechaza los
+campos desconocidos y cualquier valor JSON adicional. Los registros existentes
+deben ajustarse exactamente a estas formas para que el runtime pueda
+reproducirlos o entregarlos; los datos guardados que no sean compatibles nunca
+se ignoran.
+
+### Procedencia de la cancelación {#cancellation-provenance}
+
+El almacén del runtime distingue una solicitud de cancelación del motivo por
+el que terminó una ejecución:
+
+- Cuando un workflow activo acepta una llamada explícita a `CancelRun`, guarda
+  en una sola operación el primer motivo en los metadatos de la ejecución y un
+  registro del tipo `storage.CancellationRecordType`
+  (`runtime.cancellation_intent`) con el mismo motivo. El registro
+  `RunCompleted` cancelado que se escriba después debe contener ese mismo
+  motivo.
+- Si `StartRootRun` o `StartChildRun` encuentra que la sesión ya terminó, la
+  operación de inicio guarda `session_ended` en los metadatos junto con
+  `RunStarted` y el `RunCompleted` cancelado. No guarda un registro
+  `storage.CancellationRecordType` porque no hubo una solicitud de cancelación
+  separada.
+- Si el motor de workflows cancela una ejecución sin una solicitud registrada
+  previamente, el motivo de cancelación de los metadatos queda vacío y no hay
+  ningún registro `storage.CancellationRecordType`. El `RunCompleted` cancelado
+  contiene `engine_canceled`. En este caso, el campo vacío tiene un significado
+  preciso; no indica que falten datos.
+
+Estas son las tres combinaciones válidas entre los metadatos de la ejecución y
+los registros de cancelación. Un almacén duradero debe conservar cada una sin
+cambios.
 
 ### Inicio de una continuación
 
@@ -241,7 +276,11 @@ Los workflows hijos usan `StartChildRun`. El almacén escribe `ChildRunLinked`
 en el padre y después `RunStarted` en el hijo. Si la sesión ha terminado,
 también escribe el `RunCompleted` cancelado del hijo. Por tanto, cada workflow
 aceptado por el motor tiene un registro `RunStarted`, incluso si se detuvo
-porque su sesión había terminado.
+porque su sesión había terminado. Un hijo nuevo requiere un padre activo. Un
+reintento exacto de un inicio de hijo que el almacén ya aceptó sigue siendo
+válido después de que el padre se detenga; un reintento modificado o un hijo
+nuevo se rechazan. Temporal termina un workflow hijo si su workflow padre se
+cierra primero.
 
 El trabajo raíz sin sesión usa `StartOneShotRun`: recibe los metadatos normales
 de la ejecución y `RunStarted`, pero no crea ni se une a una sesión. Un agente
@@ -286,7 +325,12 @@ Este contrato rompe la API anterior. Se eliminan:
 - los métodos de administración de sesiones del runtime, como `CreateSession`, `EndSession` y `PurgeSession`
 - los paquetes integrados `features/session/mongo` y `features/runlog/mongo`
 
-Implementa un único `runtime/agent/storage.Store` y pásalo como primer argumento de `runtime.New`. Mueve la creación, finalización y eliminación de sesiones al servicio host propietario de los datos. Si los workers viven en otros servicios, deben llamar al propietario mediante una API tipada y no importar su adaptador de base de datos.
+Implementa un único `storage.Store` del paquete
+`goa.design/goa-ai/runtime/agent/storage` y pásalo como primer argumento de
+`runtime.New`. Mueve la creación, finalización y eliminación de sesiones al
+servicio host propietario de los datos. Si los workers viven en otros
+servicios, deben llamar al propietario mediante una API tipada y no importar
+su adaptador de base de datos.
 
 Antes de que el nuevo runtime escriba, los datos existentes deben cumplir el
 contrato del almacenamiento integrado. Los metadatos, checkpoints y registros
@@ -294,6 +338,22 @@ deben admitir las operaciones de ciclo de vida anteriores, y los escritores
 antiguos de almacenes separados no deben solaparse con los nuevos. La aplicación
 host elige el procedimiento de conversión y recuperación para su base de datos y
 su entorno, y despliega juntos al propietario y a todos sus workers.
+
+Los comandos de entrega de finalización no requieren una migración del esquema
+de la base de datos ni cambian un formato público. Sí cambian el contrato de
+código Go. Actualiza el runtime y su implementación del almacén a la vez:
+
+- sustituye cada llamada a `Runtime.RepairRunCompletion` por
+  `Runtime.EnsureRunCompletion`;
+- implementa `LoadSessionStatus` en cada `storage.Store` personalizado;
+- configura `Runtime.WithStream` antes de llamar a cualquiera de los comandos
+  de garantía para una sesión activa; y
+- espera que el inicio de un hijo nuevo falle después de que su padre se
+  detenga. Un reintento exacto de un inicio que el almacén ya aceptó sigue
+  siendo válido.
+
+Además, los registros duraderos existentes deben cumplir el contrato JSON
+exacto descrito arriba.
 
 ## Patrones comunes
 

--- a/content/es/docs/2-goa-ai/production.md
+++ b/content/es/docs/2-goa-ai/production.md
@@ -393,13 +393,15 @@ rt := runtime.New(runtimeStore, runtime.WithEngine(temporalEng))
 
 Los datos del producto siguen perteneciendo al servicio del producto. Por ejemplo, un servicio de chat conserva sus transcripciones, valoraciones y campos de búsqueda aunque otro servicio sea propietario del almacén del runtime de Goa-AI.
 
-El almacén debe confirmar cada cambio de ciclo de vida junto con su registro correspondiente. Un reintento idéntico de la activity de almacenamiento devuelve el primer resultado. Un reintento que cambie la identidad de la ejecución, el payload, el checkpoint, el estado o el motivo de cancelación falla con un conflicto. Consulta [Memoria y sesiones](../memory-sessions/#store-lifecycle-changes-and-records-together) para ver el contrato completo.
-
-El inicio de una continuación exige un predecesor suspendido existente con la
-misma sesión, el mismo agente y la misma ejecución padre. La transacción rechaza
-cualquier diferencia antes de escribir el inicio del sucesor o un vínculo
-padre. El registro `RunStarted` del sucesor guarda `PredecessorRunID`; `RunMeta`
-no duplica esa relación.
+[Memoria y sesiones](../memory-sessions/#store-lifecycle-changes-and-records-together)
+define el contrato completo del almacenamiento: los cambios de ciclo de vida y
+sus registros se guardan juntos, los reintentos exactos devuelven el resultado
+aceptado, los hijos nuevos requieren un padre activo, el JSON de eventos
+guardados es estricto y se conserva la procedencia de la cancelación.
+[Runtime](../runtime/#ensuring-a-final-record-and-its-delivery) define cómo los
+hosts validan y entregan los eventos finales después de que se cierre el
+historial del motor. Mantén estas reglas en el almacén del runtime que las
+posee, en lugar de reproducirlas en cada worker.
 
 El cambio desde `session.Store` y `runlog.Store` es un cambio coordinado del
 almacenamiento. Antes de que el nuevo runtime escriba, los metadatos, checkpoints

--- a/content/es/docs/2-goa-ai/runtime.md
+++ b/content/es/docs/2-goa-ai/runtime.md
@@ -273,6 +273,9 @@ if err := rt.Seal(ctx); err != nil {
 2. La primera actividad guarda la identidad y el primer registro permanente
    mediante `StartRootRun`, `StartChildRun`, `StartOneShotRun` o
    `StartOneShotChildRun`. Todo workflow aceptado guarda `RunStarted`.
+   [Memoria y sesiones](../memory-sessions/#cancellation-provenance) define las
+   tres formas válidas de guardar los motivos y los registros de intención de
+   cancelación.
 3. El runtime llama a `PlanStart` con los mensajes y un `run.Context` que
    contiene `RunID`, `SessionID`, `TurnID`, etiquetas y límites de política.
 4. Programa las llamadas a herramientas devueltas por el planificador usando
@@ -758,10 +761,11 @@ Start-to-Close de la activity y exige un valor mayor que cero.
 
 `Engine.QueryRunCompletion` devuelve el `Status` actual de la ejecución. Cuando
 la ejecución ya está cerrada, el mismo resultado también contiene su instante
-estable `CompletedAt` y su `Output` final o `WorkflowError`. La reparación usa
-ese instante para que cada reintento envíe la misma marca de tiempo. El error
-separado del método indica que el motor no pudo recuperar esos datos. No existe
-otra consulta separada para el estado.
+estable `CompletedAt` y su `Output` final o `WorkflowError`.
+`EnsureRunCompletion` usa `CompletedAt` como marca de tiempo del registro, por
+lo que cada reintento envía el mismo valor. El error separado del método indica
+que el motor no pudo recuperar esos datos. No existe otra consulta separada
+para el estado.
 
 La preparación del prompt de un hijo devuelve exactamente un `Success` o un
 `Failure`. El éxito solo contiene los mensajes y los datos de los prompts
@@ -783,30 +787,58 @@ reintentos que Temporal.
   historial consultable. Reusar el ID con otra entrada se rechaza. Después de
   la retención del historial, la identidad permanente del comando pertenece al
   servicio del producto, no a Goa-AI
-- Los inicios raíz, hijo y one-shot usan operaciones de almacenamiento distintas. El inicio hijo guarda el vínculo con el padre; el inicio one-shot guarda metadatos completos sin sesión
+- Los inicios raíz, hijo y one-shot usan operaciones de almacenamiento distintas. Los inicios de hijos guardan juntos el vínculo con el padre y el inicio del hijo; los inicios one-shot guardan metadatos completos sin sesión
+- Temporal termina un workflow hijo si su workflow padre se cierra primero
+- Un hijo nuevo requiere un padre activo. Tanto `StartChildRun` como `StartOneShotChildRun` guardan juntos el vínculo con el padre y el inicio del hijo. Un reintento exacto ya aceptado sigue siendo válido después de que el padre se detenga; un reintento modificado o un hijo nuevo se rechazan
 - El primer motivo de cancelación no cambia. Un reintento exacto tiene éxito y otro motivo para la misma ejecución produce un conflicto
 - La suspensión y la finalización guardan el nuevo estado junto con el registro correspondiente, que no puede modificarse después
+- Los payloads duraderos de `RunStarted`, `RunSuspended`, `RunCompleted` y `ChildRunLinked` deben contener exactamente un valor JSON del tipo correspondiente. Se rechazan los campos desconocidos y los valores JSON adicionales
 - Los agentes deben registrarse antes de la primera ejecución. El runtime rechaza el registro después del envío de la primera ejecución con `ErrRegistrationClosed` para mantener deterministas a los workers del motor
 - Los ejecutores de herramientas reciben metadatos explícitos por llamada (`ToolCallMeta`) en lugar de extraer valores de `context.Context`
 - No confíes en fallbacks implícitos; todos los identificadores de dominio (ejecución, sesión, turno, correlación) deben pasarse explícitamente
 
-### Reparar un registro final ausente
+### Garantizar el registro final y su entrega {#ensuring-a-final-record-and-its-delivery}
 
 Los workflows normales reintentan las escrituras de suspensión y finalización
-hasta que el almacenamiento del runtime las acepta. Si el historial del motor
-ya está cerrado pero la ejecución guardada sigue activa, un operador puede
-llamar a `Runtime.RepairRunCompletion(ctx, runID)`. El comando comprueba el
-estado final del motor y envía la suspensión o el registro final ausente a un
-método de reparación: `RepairRunSuspension` o `RepairRunTerminal`. El almacén
-lo escribe solo si la ejecución sigue activa;
-si el workflow guardó antes otro registro final, ese registro conserva la
-autoridad.
+hasta que el almacenamiento del runtime las acepta. Un host puede usar dos
+comandos explícitos después de que se cierre el historial del motor:
 
-Los métodos de listado e instantánea son de solo lectura y nunca realizan esta
-reparación. El motor devuelve la salida y el error del workflow separados de un
-error al recuperar ese resultado. Un error de recuperación se devuelve al
-operador y nunca se guarda como fallo final del workflow. Repetir una reparación
-que ya tuvo éxito no cambia el resultado guardado.
+- `Runtime.EnsureRunCompletion(ctx, runID)` guarda una suspensión o un
+  resultado final ausente cuando la ejecución todavía está activa en el
+  almacenamiento. Si ya está cerrada, o si otro resultado final gana mientras
+  se ejecuta el comando, valida y entrega exactamente el resultado guardado.
+- `Runtime.EnsureChildRunLink(ctx, runID)` valida y entrega únicamente el
+  vínculo exacto con el padre de una ejecución hija asociada a una sesión. Los
+  hosts pueden llamarlo en orden de padres a hijos antes de entregar los
+  resultados finales de hijos anidados.
+
+`EnsureRunCompletion` entrega el vínculo con el padre antes del evento final de
+un hijo. Las claves de evento estables hacen que repetir la entrega al stream
+sea seguro, y un resultado ya guardado no produce otra notificación local del
+ciclo de vida. Ninguno de los dos comandos cambia el resultado aceptado por el
+almacenamiento.
+
+Ambos comandos requieren `Runtime.WithStream` cuando el estado de la sesión
+usado para la entrega es activo. `EnsureChildRunLink` obtiene el estado actual
+mediante `LoadSessionStatus`. En cambio, `EnsureRunCompletion` usa el
+`SessionStatus` devuelto junto con la escritura del registro final o su
+reintento exacto. Una sesión recién comprobada como terminada conserva sus
+registros y suprime la entrega. Si el almacenamiento aceptó el evento mientras
+la sesión estaba activa, el evento sigue pendiente: terminar la sesión durante
+los reintentos de esa misma llamada de entrega no lo cancela.
+
+`EnsureRunCompletion` devuelve `ErrRunCompletionNotReady` si el motor aún
+informa de un workflow activo. Devuelve `ErrRunCompletionCorrupt` si el
+historial del motor o los datos de ciclo de vida guardados no pueden formar un
+único resultado válido. Los errores al cargar el historial del motor se
+devuelven al código que llamó al comando y nunca se guardan como fallo del
+workflow.
+
+Los métodos de listado e instantánea son de solo lectura y nunca llaman a estos
+comandos. Los comandos no requieren una migración del esquema de la base de
+datos ni cambian un formato público. Sí cambian la interfaz Go de los almacenes
+personalizados, y los registros duraderos existentes deben respetar las formas
+JSON tipadas y estrictas descritas en [Memoria y sesiones](../memory-sessions/#durable-event-json).
 
 ---
 

--- a/content/es/docs/2-goa-ai/testing.md
+++ b/content/es/docs/2-goa-ai/testing.md
@@ -237,11 +237,22 @@ func TestAgentComposition(t *testing.T) {
 Usa `runtime/agent/storage/inmem` para probar planificadores y workflows. Comprueba una implementación duradera de producción con el mismo contrato, incluidos estos casos:
 
 - los inicios raíz, hijo y one-shot sin sesión guardan juntos sus metadatos y primeros registros;
-- el inicio de un hijo guarda el vínculo con su padre en la misma operación;
+- las llamadas nuevas a `StartChildRun` y `StartOneShotChildRun` requieren un padre activo y guardan el vínculo con el padre en la misma operación que el inicio del hijo;
+- un reintento exacto de cualquiera de estos inicios ya aceptados sigue siendo válido después de que el padre se detenga, mientras que se rechazan un reintento modificado y un hijo nuevo;
 - un reintento idéntico devuelve el identificador del registro original e indica que no se insertó otro;
 - repetir un cambio de ciclo de vida con otro registro produce un conflicto, aunque no cambien el estado solicitado ni los demás campos;
 - cambiar cualquier valor fijado por la primera escritura devuelve un conflicto;
-- el primer motivo de cancelación es permanente y un motivo posterior diferente produce un conflicto;
+- una llamada explícita a `CancelRun` aceptada por un workflow activo guarda
+  juntos el primer motivo y el registro `storage.CancellationRecordType`
+  correspondiente; su tipo serializado es `runtime.cancellation_intent`. Un
+  reintento exacto tiene éxito y un motivo posterior diferente produce un
+  conflicto;
+- un inicio con sesión contra una sesión ya terminada guarda `session_ended`
+  con el registro terminal cancelado y sin ningún registro
+  `storage.CancellationRecordType`;
+- una cancelación iniciada por el motor deja vacío el motivo almacenado y no
+  tiene registro `storage.CancellationRecordType`, mientras que su registro
+  terminal contiene `engine_canceled`;
 - la suspensión guarda juntos el checkpoint, el estado suspendido y el registro correspondiente;
 - la finalización guarda juntos el estado final y el registro correspondiente;
 - el inicio de una continuación exige un predecesor suspendido existente con la
@@ -252,7 +263,36 @@ Usa `runtime/agent/storage/inmem` para probar planificadores y workflows. Compru
 - una sesión terminada impide el trabajo del planificador y las herramientas, pero registra como cancelado un workflow ya aceptado;
 - la purga falla mientras haya una ejecución activa y, una vez terminadas todas, elimina los metadatos, checkpoints y registros de la sesión terminada.
 
-Estas pruebas deben ejercer las transacciones reales de la base de datos. Un mock que solo comprueba llamadas a métodos no demuestra que el estado y los registros se hagan visibles juntos.
+Estas pruebas del almacén deben ejecutar las transacciones reales de la base de
+datos. Un mock que solo comprueba llamadas a métodos no demuestra que el estado
+y los registros se hagan visibles juntos.
+
+Prueba por separado el adaptador de Temporal: cerrar un workflow padre debe
+terminar su workflow hijo.
+
+Prueba por separado los comandos explícitos del runtime para entregar la
+finalización:
+
+- `EnsureRunCompletion` guarda el resultado ausente de una ejecución activa y
+  valida y vuelve a entregar un resultado ya guardado sin cambiarlo;
+- el vínculo de un hijo se entrega antes de su evento final, mientras que
+  `EnsureChildRunLink` entrega únicamente el vínculo exacto guardado;
+- una sesión activa sin `Runtime.WithStream` falla, mientras que una sesión
+  recién comprobada como terminada conserva el resultado guardado y suprime la
+  entrega;
+- `LoadSessionStatus` devuelve el estado actual de la sesión, mientras que
+  `EnsureRunCompletion` usa el `SessionStatus` devuelto junto con la escritura
+  del registro final o su reintento exacto y conserva ese estado durante los
+  reintentos de entrega al stream;
+- un evento aceptado mientras su sesión está activa sigue pendiente si la sesión
+  termina durante esa llamada de entrega;
+- un workflow activo en el motor devuelve `ErrRunCompletionNotReady`, y los
+  datos mal formados o contradictorios del motor o del almacenamiento devuelven
+  `ErrRunCompletionCorrupt`.
+
+Prueba por separado el codec de hooks: los decodificadores de `RunStarted`,
+`RunSuspended`, `RunCompleted` y `ChildRunLinked` deben rechazar `null`, campos
+desconocidos y un segundo valor JSON al final.
 
 Las pruebas de continuación deben aceptar `goa-ai.run-suspension.v7` y rechazar
 todas las versiones anteriores antes de restaurar payloads o llamar al

--- a/content/fr/docs/2-goa-ai/memory-sessions.md
+++ b/content/fr/docs/2-goa-ai/memory-sessions.md
@@ -221,9 +221,9 @@ déduisez pas de l'ordre d'exécution.
 Chaque méthode de cycle de vie enregistre l’état et l’enregistrement correspondant dans la même opération :
 
 - `StartRootRun` enregistre les métadonnées d’une exécution racine et son premier enregistrement.
-- `StartChildRun` enregistre le lien parent, les métadonnées de l’enfant et son premier enregistrement.
+- `StartChildRun` enregistre le lien parent, les métadonnées de l’enfant et son premier enregistrement. Un nouvel enfant exige un parent actif ; une nouvelle tentative identique déjà acceptée reste valide après l'arrêt du parent.
 - `StartOneShotRun` enregistre une exécution sans session et son premier enregistrement.
-- `StartOneShotChildRun` enregistre ensemble le lien vers le parent sans session et le démarrage de l'enfant.
+- `StartOneShotChildRun` enregistre ensemble le lien vers le parent sans session et le démarrage de l'enfant. Il applique la même règle de parent actif et de nouvelle tentative identique.
 - `RecordRunCancellation` enregistre le premier motif d’annulation et son enregistrement.
 - `RecordRunSuspension` enregistre le point de reprise privé, l’état suspendu et son enregistrement.
 - `RecordRunTerminal` enregistre l’état final et son enregistrement.
@@ -242,6 +242,40 @@ changement de cycle de vie avec un autre enregistrement produit un conflit,
 même si l’état et les autres champs du cycle de vie sont identiques.
 
 Toute valeur différente de la première écriture produit un conflit. Le stockage ne choisit pas la valeur la plus récente et n’écrase pas la première. Le premier motif d’annulation est permanent : une répétition exacte réussit, un motif différent échoue.
+
+### JSON des événements durables {#durable-event-json}
+
+Le runtime décode les payloads `RunStarted`, `RunSuspended`, `RunCompleted` et
+`ChildRunLinked` comme une seule valeur JSON typée. Les champs inconnus et les
+valeurs JSON supplémentaires sont rejetés. Les enregistrements existants
+doivent respecter exactement ces formes avant que le runtime puisse les
+rejouer ou les livrer ; il n'ignore jamais des données enregistrées
+incompatibles.
+
+### Origine de l'annulation {#cancellation-provenance}
+
+Le stockage du runtime distingue une demande d'annulation de la raison pour
+laquelle une exécution s'est terminée :
+
+- Lorsqu'un workflow actif accepte un appel explicite à `CancelRun`, il
+  enregistre en une seule opération le premier motif dans les métadonnées de
+  l'exécution et un enregistrement de type `storage.CancellationRecordType`
+  (`runtime.cancellation_intent`) portant le même motif. L'enregistrement
+  `RunCompleted` annulé écrit ensuite doit contenir ce même motif.
+- Si `StartRootRun` ou `StartChildRun` constate que sa session est déjà
+  terminée, l'opération de démarrage enregistre `session_ended` dans les
+  métadonnées avec `RunStarted` et l'enregistrement `RunCompleted` annulé. Elle
+  n'enregistre pas de `storage.CancellationRecordType`, car aucune demande
+  d'annulation distincte n'a eu lieu.
+- Si le moteur de workflows annule une exécution sans demande enregistrée au
+  préalable, le motif d'annulation reste vide dans les métadonnées et aucun
+  enregistrement `storage.CancellationRecordType` n'existe. L'enregistrement
+  `RunCompleted` annulé contient `engine_canceled`. Dans ce cas, le champ vide a
+  un sens précis ; il ne signale pas une donnée manquante.
+
+Ce sont les trois combinaisons valides entre les métadonnées d'exécution et les
+enregistrements d'annulation. Un stockage durable doit les conserver
+exactement.
 
 ### Démarrage d'une continuation
 
@@ -273,7 +307,11 @@ Les workflows enfants utilisent `StartChildRun`. Le stockage écrit
 `ChildRunLinked` sur le parent, puis `RunStarted` sur l'enfant. Si la session est
 terminée, il écrit aussi le `RunCompleted` annulé de l'enfant. Chaque workflow
 accepté par le moteur possède donc un enregistrement `RunStarted`, y compris un
-travail arrêté parce que sa session était terminée.
+travail arrêté parce que sa session était terminée. Un nouvel enfant exige un
+parent actif. Une nouvelle tentative identique d'un démarrage déjà accepté
+reste valide après l'arrêt du parent ; une tentative modifiée ou un nouvel
+enfant est rejeté. Temporal termine un workflow enfant si son workflow parent
+se ferme en premier.
 
 Un travail racine sans session utilise `StartOneShotRun` : il reçoit les
 métadonnées normales de l'exécution et `RunStarted`, mais ne crée ni ne rejoint
@@ -319,7 +357,12 @@ Ce contrat rompt l’API précédente. Sont supprimés :
 - les méthodes d’administration de session du runtime, comme `CreateSession`, `EndSession` et `PurgeSession`
 - les packages intégrés `features/session/mongo` et `features/runlog/mongo`
 
-Implémentez un seul `runtime/agent/storage.Store` et passez-le en premier argument de `runtime.New`. Déplacez la création, la fin et la suppression des sessions dans le service hôte propriétaire des données. Les workers situés dans d’autres services appellent ce propriétaire par une API typée au lieu d’importer son adaptateur de base de données.
+Implémentez un seul `storage.Store` du package
+`goa.design/goa-ai/runtime/agent/storage` et passez-le en premier argument de
+`runtime.New`. Déplacez la création, la fin et la suppression des sessions dans
+le service hôte propriétaire des données. Les workers situés dans d’autres
+services appellent ce propriétaire par une API typée au lieu d’importer son
+adaptateur de base de données.
 
 Avant que le nouveau runtime écrive, les données existantes doivent respecter
 le contrat du stockage intégré. Les métadonnées, points de reprise et
@@ -328,6 +371,23 @@ ci-dessus, et les anciens writers des stockages séparés ne doivent pas se
 chevaucher avec les nouveaux. L’application hôte choisit la procédure de
 conversion et de récupération adaptée à sa base de données et à son
 environnement, puis déploie ensemble le propriétaire et tous ses workers.
+
+Les commandes de livraison de fin n'ajoutent aucune migration de schéma de
+base de données et ne modifient aucun format public. Elles changent toutefois
+le contrat du code Go. Mettez à jour ensemble le runtime et son implémentation
+du stockage :
+
+- remplacez chaque appel à `Runtime.RepairRunCompletion` par
+  `Runtime.EnsureRunCompletion` ;
+- implémentez `LoadSessionStatus` dans chaque `storage.Store` personnalisé ;
+- configurez `Runtime.WithStream` avant d'appeler l'une des deux commandes de
+  garantie pour une session active ; et
+- attendez-vous à ce que le démarrage d'un nouvel enfant échoue après l'arrêt
+  de son parent. Une nouvelle tentative identique d'un démarrage déjà accepté
+  par le stockage reste valide.
+
+Les enregistrements durables existants doivent également respecter le contrat
+JSON exact décrit ci-dessus.
 
 ## Modèles communs
 

--- a/content/fr/docs/2-goa-ai/production.md
+++ b/content/fr/docs/2-goa-ai/production.md
@@ -393,13 +393,15 @@ rt := runtime.New(runtimeStore, runtime.WithEngine(temporalEng))
 
 Les données du produit restent la propriété du service produit. Par exemple, un service de chat conserve ses transcriptions, évaluations et champs de recherche même si un autre service possède le stockage du runtime Goa-AI.
 
-Le stockage doit valider chaque changement de cycle de vie avec l’enregistrement correspondant. Une nouvelle tentative identique de l’activité de stockage renvoie le premier résultat. Une tentative qui modifie l’identité de l’exécution, le payload, le point de reprise, l’état ou le motif d’annulation échoue avec un conflit. Consultez [Mémoire et sessions](../memory-sessions/#store-lifecycle-changes-and-records-together) pour le contrat complet.
-
-Le démarrage d'une continuation exige une exécution précédente suspendue qui
-existe et possède la même session, le même agent et la même exécution parente.
-La transaction rejette toute différence avant d'écrire le démarrage du
-successeur ou un lien parent. L'enregistrement `RunStarted` du successeur
-conserve `PredecessorRunID` ; `RunMeta` ne duplique pas cette relation.
+[Mémoire et sessions](../memory-sessions/#store-lifecycle-changes-and-records-together)
+définit le contrat complet du stockage : les changements de cycle de vie et
+leurs enregistrements sont sauvegardés ensemble, les nouvelles tentatives
+identiques renvoient le résultat accepté, tout nouvel enfant exige un parent
+actif, le JSON des événements enregistrés est strict et l'origine de
+l'annulation est préservée. [Runtime](../runtime/#ensuring-a-final-record-and-its-delivery)
+explique comment les hôtes valident et livrent les événements finaux après la
+fermeture de l'historique du moteur. Conservez ces règles dans le stockage du
+runtime qui en est responsable au lieu de les reproduire dans chaque worker.
 
 Le remplacement de `session.Store` et `runlog.Store` est une modification
 coordonnée du stockage. Avant que le nouveau runtime écrive, les métadonnées,

--- a/content/fr/docs/2-goa-ai/runtime.md
+++ b/content/fr/docs/2-goa-ai/runtime.md
@@ -276,6 +276,9 @@ if err := rt.Seal(ctx); err != nil {
 2. La première activité enregistre l'identité et le premier enregistrement
    permanent avec `StartRootRun`, `StartChildRun`, `StartOneShotRun` ou
    `StartOneShotChildRun`. Chaque workflow accepté enregistre `RunStarted`.
+   [Mémoire et sessions](../memory-sessions/#cancellation-provenance) définit
+   les trois façons valides d'enregistrer les motifs et les demandes
+   d'annulation.
 3. Le runtime appelle `PlanStart` avec les messages et un `run.Context`
    contenant `RunID`, `SessionID`, `TurnID`, les libellés et les limites.
 4. Il planifie les appels d'outils avec les codecs générés.
@@ -770,10 +773,11 @@ zéro.
 
 `Engine.QueryRunCompletion` renvoie le `Status` actuel de l’exécution. Une fois
 l’exécution fermée, le même résultat contient aussi son instant stable
-`CompletedAt` et son `Output` final ou son `WorkflowError`. La réparation utilise
-cet instant afin que chaque nouvelle tentative envoie le même horodatage.
-L’erreur distincte de la méthode indique que le moteur n’a pas pu récupérer ces
-informations. Il n’existe pas de requête de statut séparée.
+`CompletedAt` et son `Output` final ou son `WorkflowError`.
+`EnsureRunCompletion` utilise `CompletedAt` comme horodatage de l’enregistrement,
+afin que chaque nouvelle tentative envoie la même valeur. L’erreur distincte de
+la méthode indique que le moteur n’a pas pu récupérer ces informations. Il
+n’existe pas de requête de statut séparée.
 
 La préparation du prompt d’un enfant renvoie exactement un `Success` ou un
 `Failure`. Le succès contient uniquement les messages et les informations sur
@@ -795,9 +799,12 @@ applique la même politique de nouvelle tentative que Temporal.
   interrogeable. Réutiliser l’ID avec une autre entrée est refusé. Après la
   durée de conservation de l’historique, l’identité permanente de la commande
   appartient au service produit, pas à Goa-AI
-- Les démarrages racine, enfant et ponctuel utilisent des opérations distinctes. Le démarrage enfant enregistre le lien parent ; le démarrage ponctuel enregistre les métadonnées complètes sans session
+- Les démarrages racine, enfant et ponctuel utilisent des opérations distinctes. Les démarrages d'enfants enregistrent ensemble le lien parent et le démarrage de l'enfant ; les démarrages ponctuels enregistrent les métadonnées complètes sans session
+- Temporal termine un workflow enfant si son workflow parent se ferme en premier
+- Tout nouvel enfant exige un parent actif. `StartChildRun` et `StartOneShotChildRun` enregistrent chacun le lien parent et le démarrage de l'enfant ensemble. Une nouvelle tentative identique déjà acceptée reste valide après l'arrêt du parent ; une tentative modifiée ou un nouvel enfant est rejeté
 - Le premier motif d’annulation ne change pas. Une répétition exacte réussit et un autre motif pour la même exécution produit un conflit
 - La suspension et la fin enregistrent le nouvel état avec l’enregistrement correspondant, qui ne peut plus être modifié
+- Les payloads durables `RunStarted`, `RunSuspended`, `RunCompleted` et `ChildRunLinked` doivent contenir exactement une valeur JSON du type correspondant. Les champs inconnus et les valeurs JSON supplémentaires sont rejetés
 - Les agents doivent être enregistrés avant la première exécution. Le moteur d'exécution rejette l'enregistrement après la première soumission d'exécution avec `ErrRegistrationClosed` pour que les opérateurs du moteur restent déterministes.
 - Les exécuteurs d'outils reçoivent des métadonnées explicites par appel
   (`ToolCallMeta`) plutôt que d'extraire des valeurs de `context.Context`.
@@ -806,23 +813,51 @@ applique la même politique de nouvelle tentative que Temporal.
   finalisation terminale
 - Ne comptez pas sur des solutions de repli implicites ; tous les identifiants de domaine (exécution, session, tour, corrélation) doivent être transmis explicitement
 
-### Réparer un enregistrement final manquant
+### Garantir l’enregistrement final et sa livraison {#ensuring-a-final-record-and-its-delivery}
 
 Les workflows normaux relancent les écritures de suspension et de fin jusqu’à
-ce que le stockage du runtime les accepte. Si l’historique du moteur est déjà
-fermé alors que l’exécution enregistrée est encore active, un opérateur peut
-appeler `Runtime.RepairRunCompletion(ctx, runID)`. La commande vérifie l’état
-final du moteur et soumet la suspension ou le résultat final manquant à une
-opération de réparation : `RepairRunSuspension` ou `RepairRunTerminal`. Le
-stockage ne l’écrit que si l’exécution est encore
-active ; si le workflow a déjà enregistré un autre résultat final, celui-ci
-reste la référence.
+ce que le stockage du runtime les accepte. Un hôte peut utiliser deux commandes
+explicites après la fermeture de l'historique du moteur :
 
-Les méthodes de liste et d’instantané sont en lecture seule et n’effectuent
-jamais cette réparation. Le moteur renvoie le résultat et l’erreur du workflow
-séparément d’une erreur survenue pendant leur récupération. Une erreur de
-récupération est renvoyée à l’opérateur et n’est jamais enregistrée comme échec
-final du workflow. Répéter une réparation réussie ne modifie pas le résultat.
+- `Runtime.EnsureRunCompletion(ctx, runID)` enregistre une suspension ou un
+  résultat final manquant tant que l'exécution reste active dans le stockage.
+  Si elle est déjà terminée, ou si un autre résultat final l'emporte pendant
+  l'exécution de la commande, celle-ci valide et livre exactement le résultat
+  enregistré.
+- `Runtime.EnsureChildRunLink(ctx, runID)` valide et livre uniquement le lien
+  parent exact d'une exécution enfant associée à une session. Les hôtes peuvent
+  l'appeler dans l'ordre des parents vers les enfants avant de livrer les
+  résultats finaux des enfants imbriqués.
+
+`EnsureRunCompletion` livre le lien parent avant l'événement final d'un enfant.
+Les clés d'événement stables permettent de répéter sans risque la livraison au
+flux, et un résultat déjà enregistré ne produit pas une nouvelle notification
+locale du cycle de vie. Aucune des deux commandes ne modifie le résultat accepté
+par le stockage.
+
+Les deux commandes exigent `Runtime.WithStream` lorsque le statut de la session
+utilisé pour la livraison est actif. `EnsureChildRunLink` lit le statut actuel
+avec `LoadSessionStatus`. `EnsureRunCompletion` utilise plutôt le
+`SessionStatus` renvoyé avec l’écriture de l’enregistrement final ou sa nouvelle
+tentative identique. Une session nouvellement constatée comme terminée conserve
+ses enregistrements et n’émet rien sur le flux. Si le stockage a accepté
+l’événement pendant que la session était active, cet événement reste à livrer :
+terminer la session pendant les nouvelles tentatives de ce même appel de
+livraison ne l’annule pas.
+
+`EnsureRunCompletion` renvoie `ErrRunCompletionNotReady` lorsque le moteur
+signale encore un workflow actif. Il renvoie `ErrRunCompletionCorrupt` lorsque
+l'historique du moteur ou les données de cycle de vie enregistrées ne peuvent
+pas former un résultat valide unique. Une erreur de lecture de l'historique du
+moteur est renvoyée au code appelant et n'est jamais enregistrée comme échec
+du workflow.
+
+Les méthodes de liste et d'instantané sont en lecture seule et n'appellent
+jamais ces commandes. Ces commandes n'ajoutent aucune migration du schéma de la
+base de données et ne changent aucun format public. Elles modifient toutefois
+l'interface Go des stockages personnalisés, et les enregistrements durables
+existants doivent respecter les formes JSON typées et strictes décrites dans
+[Mémoire et sessions](../memory-sessions/#durable-event-json).
 
 ---
 

--- a/content/fr/docs/2-goa-ai/testing.md
+++ b/content/fr/docs/2-goa-ai/testing.md
@@ -240,11 +240,22 @@ func TestAgentComposition(t *testing.T) {
 Utilisez `runtime/agent/storage/inmem` pour les tests de planificateurs et de workflows. Testez une implémentation de production durable avec le même contrat, notamment les cas suivants :
 
 - les démarrages racine, enfant et ponctuel sans session enregistrent ensemble leurs métadonnées et leurs premiers enregistrements ;
-- le démarrage d’un enfant enregistre le lien vers son parent dans la même opération ;
+- les nouveaux appels à `StartChildRun` et `StartOneShotChildRun` exigent un parent actif et enregistrent le lien parent dans la même opération que le démarrage de l'enfant ;
+- une nouvelle tentative identique de l'un de ces démarrages déjà acceptés reste valide après l'arrêt du parent, tandis qu'une tentative modifiée ou un nouvel enfant est rejeté ;
 - une nouvelle tentative identique renvoie l’identifiant d’origine et indique qu’aucun nouvel enregistrement n’a été inséré ;
 - répéter un changement de cycle de vie avec un autre enregistrement produit un conflit, même si l’état demandé et les autres champs sont inchangés ;
 - toute modification d’une valeur fixée par la première écriture renvoie un conflit ;
-- le premier motif d’annulation est permanent et un motif ultérieur différent produit un conflit ;
+- un appel explicite à `CancelRun` accepté par un workflow actif enregistre
+  ensemble le premier motif et l'enregistrement
+  `storage.CancellationRecordType` correspondant ; son type sérialisé est
+  `runtime.cancellation_intent`. Une répétition exacte réussit et un motif
+  ultérieur différent produit un conflit ;
+- le démarrage d'une exécution avec une session déjà terminée enregistre
+  `session_ended` avec l'enregistrement terminal annulé et sans enregistrement
+  `storage.CancellationRecordType` ;
+- une annulation venant du moteur laisse vide le motif enregistré et ne crée
+  aucun enregistrement `storage.CancellationRecordType`, tandis que son
+  enregistrement terminal contient `engine_canceled` ;
 - la suspension enregistre ensemble le point de reprise, l’état suspendu et l’enregistrement correspondant ;
 - la fin enregistre ensemble l’état final et l’enregistrement correspondant ;
 - le démarrage d'une continuation exige une exécution précédente suspendue qui
@@ -255,7 +266,35 @@ Utilisez `runtime/agent/storage/inmem` pour les tests de planificateurs et de wo
 - une session terminée empêche le planificateur et les outils de travailler, mais enregistre comme annulé un workflow déjà accepté ;
 - la purge échoue tant qu’une exécution est active, puis supprime les métadonnées, points de reprise et enregistrements de la session terminée une fois toutes les exécutions achevées.
 
-Ces tests doivent exercer les vraies transactions de la base de données. Un mock qui vérifie seulement les appels de méthodes ne peut pas prouver que l’état et les enregistrements deviennent visibles ensemble.
+Ces tests du stockage doivent exécuter les vraies transactions de la base de
+données. Un mock qui vérifie seulement les appels de méthodes ne peut pas
+prouver que l’état et les enregistrements deviennent visibles ensemble.
+
+Testez séparément l'adaptateur Temporal : la fermeture d'un workflow parent
+doit terminer son workflow enfant.
+
+Testez séparément les commandes explicites du runtime pour livrer la fin :
+
+- `EnsureRunCompletion` enregistre le résultat manquant d'une exécution active,
+  puis valide et livre à nouveau un résultat déjà enregistré sans le modifier ;
+- le lien d'un enfant est livré avant son événement final, tandis que
+  `EnsureChildRunLink` livre uniquement le lien exact enregistré ;
+- une session active sans `Runtime.WithStream` échoue, tandis qu’une session
+  nouvellement constatée comme terminée conserve le résultat enregistré et
+  supprime sa livraison ;
+- `LoadSessionStatus` renvoie le statut actuel de la session, tandis que
+  `EnsureRunCompletion` utilise le `SessionStatus` renvoyé avec l’écriture de
+  l’enregistrement final ou sa nouvelle tentative identique et conserve ce
+  statut pendant les nouvelles tentatives de livraison au flux ;
+- un événement accepté pendant que sa session est active reste à livrer si la
+  session se termine pendant cet appel de livraison ;
+- un workflow encore actif dans le moteur renvoie `ErrRunCompletionNotReady`,
+  et des données mal formées ou contradictoires du moteur ou du stockage
+  renvoient `ErrRunCompletionCorrupt`.
+
+Testez séparément le codec des hooks : les décodeurs de `RunStarted`,
+`RunSuspended`, `RunCompleted` et `ChildRunLinked` doivent rejeter `null`, les
+champs inconnus et une seconde valeur JSON finale.
 
 Les tests de continuation doivent accepter `goa-ai.run-suspension.v7` et rejeter
 toutes les versions précédentes avant de restaurer les payloads ou d’appeler le

--- a/content/it/docs/2-goa-ai/memory-sessions.md
+++ b/content/it/docs/2-goa-ai/memory-sessions.md
@@ -204,9 +204,9 @@ In un’applicazione a processo singolo, `store` può essere un adattatore local
 Ogni metodo salva stato e record corrispondente nella stessa operazione:
 
 - `StartRootRun` salva metadati radice e primo record.
-- `StartChildRun` salva collegamento al padre, metadati del figlio e primo record.
+- `StartChildRun` salva collegamento al padre, metadati del figlio e primo record. Un nuovo figlio richiede un padre attivo; un retry identico già accettato resta valido dopo l'arresto del padre.
 - `StartOneShotRun` salva un’esecuzione senza sessione e il primo record.
-- `StartOneShotChildRun` salva insieme il collegamento al padre senza sessione e l'avvio del figlio.
+- `StartOneShotChildRun` salva insieme il collegamento al padre senza sessione e l'avvio del figlio. Applica la stessa regola del padre attivo e del retry identico.
 - `RecordRunCancellation` salva il primo motivo di annullamento e il record.
 - `RecordRunSuspension` salva checkpoint privato, stato sospeso e record.
 - `RecordRunTerminal` salva stato finale e record.
@@ -221,6 +221,38 @@ Per ogni avvio, annullamento, sospensione e completamento, lo storage ricorda
 anche il record esatto scelto dalla prima scrittura riuscita. Ripetere il
 cambiamento del ciclo di vita con un record diverso produce un conflitto, anche
 quando lo stato e gli altri campi del ciclo di vita coincidono.
+
+### JSON degli eventi persistenti {#durable-event-json}
+
+Il runtime decodifica i payload di `RunStarted`, `RunSuspended`, `RunCompleted`
+e `ChildRunLinked` come un unico valore JSON tipizzato. I campi sconosciuti e
+gli ulteriori valori JSON vengono rifiutati. I record esistenti devono
+rispettare esattamente queste forme prima che il runtime possa riprodurli o
+consegnarli; i dati salvati non compatibili non vengono mai ignorati.
+
+### Origine dell'annullamento {#cancellation-provenance}
+
+Lo storage del runtime distingue una richiesta di annullamento dal motivo per
+cui termina un'esecuzione:
+
+- Quando un workflow attivo accetta una chiamata esplicita a `CancelRun`, salva
+  in un'unica operazione il primo motivo nei metadati dell'esecuzione e un
+  record di tipo `storage.CancellationRecordType`
+  (`runtime.cancellation_intent`) con lo stesso motivo. Il successivo record
+  `RunCompleted` annullato deve contenere quel medesimo motivo.
+- Se `StartRootRun` o `StartChildRun` rileva che la sessione è già terminata,
+  l'operazione di avvio salva `session_ended` nei metadati insieme a
+  `RunStarted` e al record `RunCompleted` annullato. Non salva un record
+  `storage.CancellationRecordType`, perché non è stata fatta una richiesta di
+  annullamento separata.
+- Se il motore dei workflow annulla un'esecuzione senza una richiesta già
+  registrata, il motivo di annullamento nei metadati rimane vuoto e non esiste
+  alcun record `storage.CancellationRecordType`. Il record `RunCompleted`
+  annullato contiene `engine_canceled`. In questo caso, il campo vuoto ha un
+  significato preciso e non indica dati mancanti.
+
+Queste sono le tre combinazioni valide tra i metadati dell'esecuzione e i
+record di annullamento. Uno storage persistente deve conservarle esattamente.
 
 ### Avvio di una continuazione
 
@@ -252,7 +284,10 @@ I workflow figli usano `StartChildRun`. Lo storage scrive `ChildRunLinked` sul
 padre e poi `RunStarted` sul figlio. Se la sessione è terminata, scrive anche il
 `RunCompleted` annullato del figlio. Ogni workflow accettato dal motore ha quindi
 un record `RunStarted`, compreso il lavoro fermato perché la sessione era
-terminata.
+terminata. Un nuovo figlio richiede un padre attivo. Un retry identico di un
+avvio figlio già accettato resta valido dopo l'arresto del padre; un retry
+modificato o un nuovo figlio vengono rifiutati. Temporal termina un workflow
+figlio se il workflow padre si chiude per primo.
 
 Il lavoro radice senza sessione usa `StartOneShotRun`: riceve i normali
 metadati dell'esecuzione e `RunStarted`, ma non crea né usa una sessione. Un
@@ -289,7 +324,11 @@ L’applicazione host crea, termina e rimuove le sessioni; i worker non lo fanno
 
 Sono rimossi `session.Store`, `runlog.Store`, `runtime.WithSessionStore`, `runtime.WithRunEventStore`, i metodi runtime `CreateSession`, `EndSession` e `PurgeSession`, e i package `features/session/mongo` e `features/runlog/mongo`.
 
-Implementa un unico `runtime/agent/storage.Store` e passalo come primo argomento di `runtime.New`. Sposta l’amministrazione delle sessioni nel servizio host proprietario dei dati. I worker remoti lo chiamano tramite API tipizzata, senza importarne l’adattatore database.
+Implementa un unico `storage.Store` del package
+`goa.design/goa-ai/runtime/agent/storage` e passalo come primo argomento di
+`runtime.New`. Sposta l’amministrazione delle sessioni nel servizio host
+proprietario dei dati. I worker remoti lo chiamano tramite API tipizzata, senza
+importarne l’adattatore database.
 
 Prima che il nuovo runtime scriva, i dati esistenti devono rispettare il
 contratto dello storage integrato. Metadati, checkpoint e record devono
@@ -297,6 +336,22 @@ supportare le operazioni del ciclo di vita descritte sopra, e i vecchi writer
 degli storage separati non devono sovrapporsi ai nuovi. L’applicazione host
 sceglie la procedura di conversione e ripristino per il proprio database e
 ambiente, quindi distribuisce insieme il proprietario e tutti i worker.
+
+I comandi di consegna del completamento non aggiungono una migrazione dello
+schema del database e non cambiano alcun formato pubblico. Cambiano però il
+contratto del codice Go. Aggiorna insieme il runtime e la relativa
+implementazione dello storage:
+
+- sostituisci ogni chiamata a `Runtime.RepairRunCompletion` con
+  `Runtime.EnsureRunCompletion`;
+- implementa `LoadSessionStatus` in ogni `storage.Store` personalizzato;
+- configura `Runtime.WithStream` prima di chiamare uno dei comandi di garanzia
+  per una sessione attiva; e
+- prevedi che l'avvio di un nuovo figlio fallisca dopo l'arresto del padre. Un
+  retry identico di un avvio già accettato dallo storage resta valido.
+
+Anche i record persistenti esistenti devono rispettare il contratto JSON esatto
+descritto sopra.
 
 ## Modelli comuni
 

--- a/content/it/docs/2-goa-ai/production.md
+++ b/content/it/docs/2-goa-ai/production.md
@@ -393,13 +393,15 @@ rt := runtime.New(runtimeStore, runtime.WithEngine(temporalEng))
 
 I dati del prodotto restano di proprietà del servizio del prodotto. Per esempio, un servizio chat conserva trascrizioni, valutazioni e campi di ricerca anche quando un altro servizio possiede l’archivio del runtime Goa-AI.
 
-L’archivio deve salvare ogni cambiamento del ciclo di vita insieme al record corrispondente. Un retry identico dell’activity di storage restituisce il primo risultato. Un tentativo che cambia identità dell’esecuzione, payload, checkpoint, stato o motivo di annullamento fallisce con un conflitto. Consulta [Memoria e sessioni](../memory-sessions/#store-lifecycle-changes-and-records-together) per il contratto completo.
-
-L'avvio di una continuazione richiede un'esecuzione precedente sospesa che
-esista e abbia la stessa sessione, lo stesso agente e la stessa esecuzione padre.
-La transazione rifiuta una differenza prima di scrivere l'avvio del successore o
-un collegamento al padre. Il record `RunStarted` del successore conserva
-`PredecessorRunID`; `RunMeta` non duplica questa relazione.
+[Memoria e sessioni](../memory-sessions/#store-lifecycle-changes-and-records-together)
+definisce il contratto completo dello storage: i cambiamenti del ciclo di vita
+e i record vengono salvati insieme, i retry identici restituiscono il risultato
+accettato, i nuovi figli richiedono un padre attivo, il JSON degli eventi
+salvati è rigoroso e l'origine dell'annullamento viene preservata.
+[Runtime](../runtime/#ensuring-a-final-record-and-its-delivery) descrive come
+gli host convalidano e consegnano gli eventi finali dopo la chiusura della
+cronologia del motore. Mantieni queste regole nello storage del runtime che ne
+è responsabile invece di ripeterle in ogni worker.
 
 Il passaggio da `session.Store` e `runlog.Store` è una modifica coordinata dello
 storage. Prima che il nuovo runtime scriva, metadati, checkpoint e record

--- a/content/it/docs/2-goa-ai/runtime.md
+++ b/content/it/docs/2-goa-ai/runtime.md
@@ -265,6 +265,8 @@ if err := rt.Seal(ctx); err != nil {
 2. La prima activity salva l'identità e il primo record permanente tramite
    `StartRootRun`, `StartChildRun`, `StartOneShotRun` o
    `StartOneShotChildRun`. Ogni workflow accettato salva `RunStarted`.
+   [Memoria e sessioni](../memory-sessions/#cancellation-provenance) descrive i
+   tre modi validi di salvare i motivi e i record di richiesta di annullamento.
 3. Il runtime chiama `PlanStart` con i messaggi e un `run.Context` contenente
    `RunID`, `SessionID`, `TurnID`, etichette e limiti di policy.
 4. Pianifica le chiamate agli strumenti usando i codec generati.
@@ -668,10 +670,11 @@ dell’activity e richiede un valore maggiore di zero.
 
 `Engine.QueryRunCompletion` restituisce lo `Status` corrente dell’esecuzione.
 Dopo la chiusura dell’esecuzione, lo stesso risultato contiene anche l’istante
-stabile `CompletedAt` e l’`Output` finale o il `WorkflowError`. La riparazione
-usa quell’istante, quindi ogni nuovo tentativo invia lo stesso timestamp.
-L’errore separato del metodo indica che il motore non ha potuto recuperare
-queste informazioni. Non esiste una query separata per lo stato.
+stabile `CompletedAt` e l’`Output` finale o il `WorkflowError`.
+`EnsureRunCompletion` usa `CompletedAt` come timestamp del record, quindi ogni
+nuovo tentativo invia lo stesso valore. L’errore separato del metodo indica che
+il motore non ha potuto recuperare queste informazioni. Non esiste una query
+separata per lo stato.
 
 La preparazione del prompt di un figlio restituisce esattamente un `Success` o
 un `Failure`. Il successo contiene soltanto i messaggi e i dati dei prompt
@@ -693,30 +696,58 @@ stessa politica di retry di Temporal.
   interrogabile. Riutilizzare l’ID con input diverso viene rifiutato. Dopo la
   conservazione della cronologia, l’identità permanente del comando appartiene
   al servizio del prodotto, non a Goa-AI
-- Gli avvii radice, figlio e one-shot usano operazioni distinte. L’avvio figlio salva il collegamento al padre; l’avvio one-shot salva metadati completi senza sessione
+- Gli avvii radice, figlio e one-shot usano operazioni distinte. Gli avvii dei figli salvano insieme il collegamento al padre e l'avvio del figlio; gli avvii one-shot salvano metadati completi senza sessione
+- Temporal termina un workflow figlio se il workflow padre si chiude per primo
+- Un nuovo figlio richiede un padre attivo. `StartChildRun` e `StartOneShotChildRun` salvano ciascuno il collegamento al padre e l'avvio del figlio insieme. Un retry identico già accettato resta valido dopo l'arresto del padre; un retry modificato o un nuovo figlio vengono rifiutati
 - Il primo motivo di annullamento non cambia. Un retry esatto riesce e un motivo diverso per la stessa esecuzione produce un conflitto
 - La sospensione e il completamento salvano il nuovo stato insieme al record corrispondente, che non può più essere modificato
+- I payload persistenti di `RunStarted`, `RunSuspended`, `RunCompleted` e `ChildRunLinked` devono contenere esattamente un valore JSON del tipo corrispondente. I campi sconosciuti e gli ulteriori valori JSON vengono rifiutati
 - Gli agenti devono essere registrati prima della prima esecuzione. Il runtime rifiuta la registrazione dopo l'invio della prima esecuzione con `ErrRegistrationClosed` per mantenere i lavoratori del motore deterministici
 - Gli esecutori degli strumenti ricevono metadati espliciti per chiamata (`ToolCallMeta`) piuttosto che pescare valori da `context.Context`
 - Non fare affidamento su fallback impliciti; tutti gli identificatori di dominio (esecuzione, sessione, turno, correlazione) devono essere passati esplicitamente
 
-### Riparare un record finale mancante
+### Garantire il record finale e la sua consegna {#ensuring-a-final-record-and-its-delivery}
 
 I workflow normali ritentano le scritture di sospensione e completamento finché
-lo storage del runtime non le accetta. Se la cronologia del motore è già chiusa
-ma l’esecuzione salvata risulta ancora attiva, un operatore può chiamare
-`Runtime.RepairRunCompletion(ctx, runID)`. Il comando verifica lo stato finale
-del motore e invia la sospensione o il record finale mancante a un’operazione
-di riparazione: `RepairRunSuspension` o `RepairRunTerminal`. Lo storage lo
-scrive solo se l’esecuzione è ancora attiva; se
-il workflow ha già salvato un altro record finale, quel record resta
-autorevole.
+lo storage del runtime non le accetta. Un host può usare due comandi espliciti
+dopo la chiusura della cronologia del motore:
 
-I metodi di elenco e snapshot sono di sola lettura e non eseguono mai questa
-riparazione. Il motore restituisce output ed errore del workflow separatamente
-da un errore nel recupero del risultato. Gli errori di recupero vengono
-restituiti all’operatore e non vengono mai salvati come errore finale del
-workflow. Ripetere una riparazione già riuscita non modifica il risultato.
+- `Runtime.EnsureRunCompletion(ctx, runID)` salva una sospensione o un
+  risultato finale mancante mentre l'esecuzione è ancora attiva nello storage.
+  Se è già terminata, o se un altro risultato finale prevale durante il
+  comando, convalida e consegna esattamente il risultato salvato.
+- `Runtime.EnsureChildRunLink(ctx, runID)` convalida e consegna soltanto
+  l'esatto collegamento al padre di un'esecuzione figlia associata a una
+  sessione. Gli host possono chiamarlo dal padre verso i figli prima di
+  consegnare i risultati finali dei figli annidati.
+
+`EnsureRunCompletion` consegna il collegamento al padre prima dell'evento finale
+di un figlio. Le chiavi evento stabili rendono sicura la consegna ripetuta allo
+stream e un risultato già salvato non produce un'altra notifica locale del
+ciclo di vita. Nessuno dei due comandi cambia il risultato accettato dallo
+storage.
+
+Entrambi i comandi richiedono `Runtime.WithStream` quando lo stato della sessione
+usato per la consegna è attivo. `EnsureChildRunLink` legge lo stato corrente con
+`LoadSessionStatus`. `EnsureRunCompletion` usa invece il `SessionStatus`
+restituito insieme alla scrittura del record finale o al suo tentativo identico.
+Una sessione appena rilevata come terminata conserva i propri record e sopprime
+la consegna allo stream. Se lo storage ha accettato l’evento mentre la sessione
+era attiva, l’evento resta da consegnare: terminare la sessione durante i
+tentativi di quella stessa chiamata di consegna non lo annulla.
+
+`EnsureRunCompletion` restituisce `ErrRunCompletionNotReady` quando il motore
+segnala ancora un workflow attivo. Restituisce `ErrRunCompletionCorrupt` quando
+la cronologia del motore o i dati del ciclo di vita salvati non possono formare
+un unico risultato valido. Un errore nel caricamento della cronologia del
+motore viene restituito al chiamante e non viene mai salvato come errore del
+workflow.
+
+I metodi di elenco e snapshot sono di sola lettura e non chiamano mai questi
+comandi. I comandi non aggiungono una migrazione dello schema del database e non
+cambiano alcun formato pubblico. Cambiano però l'interfaccia Go degli storage
+personalizzati, e i record persistenti esistenti devono rispettare le forme JSON
+tipizzate e rigorose descritte in [Memoria e sessioni](../memory-sessions/#durable-event-json).
 
 ---
 

--- a/content/it/docs/2-goa-ai/testing.md
+++ b/content/it/docs/2-goa-ai/testing.md
@@ -227,11 +227,21 @@ func TestAgentComposition(t *testing.T) {
 Usa `runtime/agent/storage/inmem` per i test di pianificatori e workflow. Verifica un’implementazione di produzione duratura rispetto allo stesso contratto, inclusi questi casi:
 
 - gli avvii radice, figlio e one-shot senza sessione salvano insieme i metadati e i primi record;
-- l’avvio di un figlio salva il collegamento al padre nella stessa operazione;
+- le nuove chiamate a `StartChildRun` e `StartOneShotChildRun` richiedono un padre attivo e salvano il collegamento al padre nella stessa operazione dell'avvio del figlio;
+- un retry identico di uno di questi avvii già accettati resta valido dopo l'arresto del padre, mentre un retry modificato o un nuovo figlio vengono rifiutati;
 - un nuovo tentativo identico restituisce l’identificatore del record originale e segnala che non è stato inserito un nuovo record;
 - ripetere un cambiamento del ciclo di vita con un record diverso produce un conflitto, anche quando stato e altri campi non cambiano;
 - cambiare un valore fissato dalla prima scrittura restituisce un conflitto;
-- il primo motivo di annullamento è permanente e un motivo successivo diverso produce un conflitto;
+- una chiamata esplicita a `CancelRun` accettata da un workflow attivo salva
+  insieme il primo motivo e il record `storage.CancellationRecordType`
+  corrispondente; il suo tipo serializzato è `runtime.cancellation_intent`. Un
+  retry identico riesce e un motivo successivo diverso produce un conflitto;
+- l'avvio di un'esecuzione con una sessione già terminata salva
+  `session_ended` con il record terminale annullato e senza alcun record
+  `storage.CancellationRecordType`;
+- un annullamento avviato dal motore lascia vuoto il motivo salvato e non ha un
+  record `storage.CancellationRecordType`, mentre il record terminale contiene
+  `engine_canceled`;
 - la sospensione salva insieme checkpoint, stato sospeso e record corrispondente;
 - il completamento salva insieme stato finale e record corrispondente;
 - l'avvio di una continuazione richiede un'esecuzione precedente sospesa che
@@ -242,7 +252,36 @@ Usa `runtime/agent/storage/inmem` per i test di pianificatori e workflow. Verifi
 - una sessione terminata impedisce il lavoro di pianificatore e strumenti, ma registra come annullato un workflow già accettato;
 - l’eliminazione fallisce mentre è attiva un’esecuzione e, al termine di tutte le esecuzioni, rimuove metadati, checkpoint e record della sessione terminata.
 
-Questi test devono esercitare le transazioni reali del database. Un mock che controlla solo le chiamate ai metodi non può dimostrare che stato e record diventino visibili insieme.
+Questi test dello storage devono eseguire le transazioni reali del database. Un
+mock che controlla solo le chiamate ai metodi non può dimostrare che stato e
+record diventino visibili insieme.
+
+Verifica separatamente l'adattatore Temporal: la chiusura di un workflow padre
+deve terminare il workflow figlio.
+
+Verifica separatamente i comandi espliciti del runtime per consegnare il
+completamento:
+
+- `EnsureRunCompletion` salva il risultato mancante di un'esecuzione attiva e
+  convalida e riconsegna un risultato già salvato senza cambiarlo;
+- il collegamento di un figlio viene consegnato prima del suo evento finale,
+  mentre `EnsureChildRunLink` consegna soltanto l'esatto collegamento salvato;
+- una sessione attiva senza `Runtime.WithStream` non riesce, mentre una sessione
+  appena rilevata come terminata conserva il risultato salvato e ne sopprime la
+  consegna;
+- `LoadSessionStatus` restituisce lo stato corrente della sessione, mentre
+  `EnsureRunCompletion` usa il `SessionStatus` restituito insieme alla scrittura
+  del record finale o al suo tentativo identico e conserva quello stato durante
+  i tentativi di consegna allo stream;
+- un evento accettato mentre la sessione è attiva resta da consegnare se la
+  sessione termina durante quella chiamata di consegna;
+- un workflow ancora attivo nel motore restituisce `ErrRunCompletionNotReady`,
+  mentre dati malformati o contraddittori del motore o dello storage
+  restituiscono `ErrRunCompletionCorrupt`.
+
+Verifica separatamente il codec degli hook: i decoder di `RunStarted`,
+`RunSuspended`, `RunCompleted` e `ChildRunLinked` devono rifiutare `null`, i
+campi sconosciuti e un secondo valore JSON finale.
 
 I test delle continuazioni devono accettare `goa-ai.run-suspension.v7` e
 rifiutare tutte le versioni precedenti prima di ripristinare i payload o

--- a/content/ja/docs/2-goa-ai/memory-sessions.md
+++ b/content/ja/docs/2-goa-ai/memory-sessions.md
@@ -187,9 +187,9 @@ rt := runtime.New(store, runtime.WithEngine(eng))
 各メソッドは状態と、それを示す記録を一つの操作で保存します。
 
 - `StartRootRun` はルートランのメタデータと最初の記録を保存します。
-- `StartChildRun` は親リンク、子のメタデータ、最初の記録を保存します。
+- `StartChildRun` は親リンク、子のメタデータ、最初の記録を保存します。新しい child には running の parent が必要です。すでに受理された完全に同じ retry は、parent の停止後も有効です。
 - `StartOneShotRun` はセッションなしランと最初の記録を保存します。
-- `StartOneShotChildRun` はセッションなし親へのリンクと子の開始をまとめて保存します。
+- `StartOneShotChildRun` はセッションなし親へのリンクと子の開始をまとめて保存します。同じ running-parent と完全一致 retry のルールが適用されます。
 - `RecordRunCancellation` は最初のキャンセル理由と記録を保存します。
 - `RecordRunSuspension` は非公開チェックポイント、一時停止状態、記録を保存します。
 - `RecordRunTerminal` は最終状態と記録を保存します。
@@ -205,6 +205,36 @@ workflow activity は複数回実行されることがあります。完全に�
 record を使って同じ変更を繰り返すと conflict になります。
 
 最初の書き込みで確定した値を変えると conflict になります。store は新旧を推測せず、最初の値を上書きしません。最初の cancellation reason も変更不可です。
+
+### 永続イベントの JSON {#durable-event-json}
+
+runtime は `RunStarted`、`RunSuspended`、`RunCompleted`、`ChildRunLinked` の
+payload を、型が決まった単一の JSON 値として decode します。未知の field や、
+その値の後に続く別の JSON 値は拒否します。runtime が既存の record を replay
+または配信するには、record がこれらの形式に正確に一致する必要があります。
+互換性のない保存済み data を無視することはありません。
+
+### キャンセル理由の記録 {#cancellation-provenance}
+
+runtime store は、キャンセル要求と run が終了した理由を区別して保存します。
+
+- running workflow が明示的な `CancelRun` request を受理した場合、最初の reason を
+  run metadata に保存し、同じ reason を持つ
+  `storage.CancellationRecordType` (`runtime.cancellation_intent`) record も
+  1 回の操作で保存します。後から保存する canceled の `RunCompleted` record にも
+  同じ reason が必要です。
+- `StartRootRun` または `StartChildRun` が、すでに終了した session を検出した場合、
+  start operation は `session_ended` を run metadata に保存し、`RunStarted` と
+  canceled の `RunCompleted` record も同時に保存します。独立したキャンセル要求は
+  なかったため、`storage.CancellationRecordType` record は保存しません。
+- 事前に記録されたキャンセル要求がないまま workflow engine が run をキャンセル
+  した場合、run metadata の cancellation reason は空のままで、
+  `storage.CancellationRecordType` record もありません。canceled の
+  `RunCompleted` record は `engine_canceled` を含みます。この空の metadata field
+  には明確な意味があり、data の欠落ではありません。
+
+run metadata とキャンセル record の組み合わせとして有効なのは、この 3 通りです。
+永続 store は各組み合わせをそのまま保存する必要があります。
 
 ### Continuation の開始
 
@@ -233,7 +263,10 @@ child workflow は `StartChildRun` を使います。store は parent に
 `ChildRunLinked`、child に `RunStarted` の順で書きます。session が終了している
 場合は、child の canceled `RunCompleted` も書きます。そのため、engine が受理した
 すべての workflow には、session 終了によって停止したものも含めて `RunStarted`
-record が 1 つあります。
+record が 1 つあります。新しい child には running の parent が必要です。store が
+すでに受理した child start の完全に同じ retry は、parent の停止後も有効です。
+内容を変えた retry や新しい child は拒否します。親 workflow が先に終了すると、
+Temporal は child workflow を終了します。
 
 sessionless root work は `StartOneShotRun` を使います。通常の run metadata と
 `RunStarted` を持ちますが、session を作成せず、session にも参加しません。その
@@ -268,13 +301,31 @@ session 管理は host application の責任であり、agent worker の責任�
 
 `session.Store`、`runlog.Store`、`runtime.WithSessionStore`、`runtime.WithRunEventStore`、runtime の `CreateSession`、`EndSession`、`PurgeSession`、`features/session/mongo`、`features/runlog/mongo` は削除されます。
 
-一つの `runtime/agent/storage.Store` を実装し、`runtime.New` の第一引数に渡します。session 管理は runtime data を所有する host service に移します。別サービスの worker は typed API で owner を呼び、DB adapter を import しません。
+`goa.design/goa-ai/runtime/agent/storage` package の `storage.Store` を一つ実装し、
+`runtime.New` の第一引数に渡します。session 管理は runtime data を所有する host
+service に移します。別サービスの worker は typed API で owner を呼び、DB
+adapter を import しません。
 
 新 runtime が書き込む前に、既存データが integrated store contract を満たして
 いなければなりません。run metadata、checkpoint、record は上記 lifecycle
 operation を支え、旧 split-store writer と新 writer は重ならないようにします。
 host application は自身の database と environment に合う conversion と recovery
 の手順を選び、owner と全 worker をまとめて deploy します。
+
+完了結果の配信 command は database schema migration を追加せず、公開 wire format
+も変更しません。ただし Go source contract は変わります。runtime と store
+implementation は同時に更新してください。
+
+- `Runtime.RepairRunCompletion` の各呼び出しを
+  `Runtime.EnsureRunCompletion` に置き換えます。
+- すべての custom `storage.Store` に `LoadSessionStatus` を実装します。
+- active な Session にどちらかの ensure command を使う前に
+  `Runtime.WithStream` を設定します。
+- parent が停止した後は、新しい child start が失敗することを前提にします。store が
+  すでに受理した child start の完全に同じ retry は引き続き有効です。
+
+また、既存の durable lifecycle record も上記の厳密な JSON contract を満たす必要が
+あります。
 
 ## よくあるパターン
 

--- a/content/ja/docs/2-goa-ai/production.md
+++ b/content/ja/docs/2-goa-ai/production.md
@@ -381,12 +381,14 @@ rt := runtime.New(runtimeStore, runtime.WithEngine(temporalEng))
 
 プロダクトデータはプロダクトサービスが引き続き所有します。たとえば、別のサービスが Goa-AI のランタイムストアを所有していても、チャットサービスはトランスクリプト、評価、検索用フィールドを保持します。
 
-ストアは各ライフサイクル変更と対応する記録をまとめて確定しなければなりません。storage activity の完全に同じ再試行は最初の結果を返します。ランの識別情報、payload、checkpoint、状態、キャンセル理由のいずれかを変更した再試行は競合として失敗します。完全な契約は [Memory & Sessions](../memory-sessions/#store-lifecycle-changes-and-records-together) を参照してください。
-
-continuation の開始には、存在し、同じ session、agent、parent run identity を持つ
-suspended predecessor が必要です。transaction は identity の不一致を、successor
-の開始や親リンクを書く前に拒否します。successor の `RunStarted` record が
-`PredecessorRunID` を保存し、`RunMeta` はこの関係を重複して持ちません。
+[Memory & Sessions](../memory-sessions/#store-lifecycle-changes-and-records-together)
+は storage contract 全体を定義しています。lifecycle change と record はまとめて
+保存し、完全に同じ retry には受理済みの結果を返します。新しい child には running
+の parent が必要です。保存済み event の JSON は厳密に検証し、キャンセル理由の
+由来も正確に保ちます。[Runtime](../runtime/#ensuring-a-final-record-and-its-delivery)
+は engine history が閉じた後に host が最終 run event を検証して配信する方法を
+定義します。各 worker で同じ規則を作り直さず、規則を所有する runtime store に
+実装してください。
 
 `session.Store` と `runlog.Store` からの変更は、storage 全体を協調して
 切り替える必要があります。新 runtime が書き込む前に、既存の run metadata、

--- a/content/ja/docs/2-goa-ai/runtime.md
+++ b/content/ja/docs/2-goa-ai/runtime.md
@@ -271,6 +271,8 @@ if err := rt.Seal(ctx); err != nil {
 2. 最初の activity が `StartRootRun`、`StartChildRun`、`StartOneShotRun`、
    `StartOneShotChildRun` のいずれかで run identity と最初の変更不可 record を
    保存します。受理されたすべての workflow が `RunStarted` を保存します。
+   キャンセル理由と要求 record の有効な 3 通りの保存方法は、
+   [メモリとセッション](../memory-sessions/#cancellation-provenance)で定義します。
 3. runtime が messages と、`RunID`、`SessionID`、`TurnID`、labels、policy caps
    を持つ `run.Context` を `PlanStart` に渡します。
 4. planner が返した tool calls を generated codecs で実行します。
@@ -685,9 +687,10 @@ runtime は `runtime.store` という型付き activity を 1 つだけ登録し
 
 `Engine.QueryRunCompletion` は現在の run `Status` を返します。run が閉じた後は、
 同じ結果に安定した完了時刻 `CompletedAt` と、最終 `Output` または
-`WorkflowError` も含まれます。completion repair はこの時刻を使うため、再試行でも
-同じ record timestamp が送られます。method が別に返す error は、engine がそれらの
-情報を取得できなかったことを示します。status 専用の別 query はありません。
+`WorkflowError` も含まれます。`EnsureRunCompletion` は `CompletedAt` を
+record timestamp として使うため、再試行でも同じ値が送られます。method が別に
+返す error は、engine がそれらの情報を取得できなかったことを示します。status
+専用の別 query はありません。
 
 child prompt の準備は `Success` または `Failure` のどちらか一方だけを返します。
 成功には message と描画済み prompt の情報だけが含まれます。workflow は、記録済み
@@ -707,27 +710,54 @@ retry policy を使います。
   できる間は受理済み workflow が返ります。異なる input で ID を再利用すると拒否されます。
   history retention 後の permanent command identity は product service が所有し、
   Goa-AI は保証しません。
-- root、child、one-shot の開始には別々の storage operation を使います。child は親への link を保存し、one-shot は session なしで完全な metadata を保存します。
+- root、child、one-shot の開始には別々の storage operation を使います。child start は親 link と child start をまとめて保存し、one-shot start は session なしで完全な metadata を保存します。
+- 親 workflow が先に終了すると、Temporal は child workflow を終了します。
+- 新しい child には running の parent が必要です。`StartChildRun` と `StartOneShotChildRun` は、親 link と child start をそれぞれまとめて保存します。受理済みの完全に同じ retry は parent の停止後も有効ですが、内容を変えた retry や新しい child は拒否します。
 - 最初の cancellation reason は変更できません。完全に同じ再試行は成功し、同じ run に別の reason を指定すると conflict になります。
 - suspension と終了は、新しい status と対応する変更不可の record をまとめて保存します。
+- 永続化された `RunStarted`、`RunSuspended`、`RunCompleted`、`ChildRunLinked` の payload は、対応する型の JSON 値を正確に一つだけ含む必要があります。未知の field や末尾の追加 JSON 値は拒否します。
 - エージェントは最初の run の前に登録されなければなりません。ランタイムは、エンジンワーカーの決定性を保つため、最初の run 送信後の登録を `ErrRegistrationClosed` で拒否します。
 - tool executor は `context.Context` から値を“釣る”のではなく、call ごとの明示 metadata（`ToolCallMeta`）を受け取ります。その label には clone された run／policy label が入り、call が terminal finalization を実行する場合だけ `runtime.FinalizationReasonLabel` も入ります。
 - 暗黙のフォールバックには依存しません。すべてのドメイン識別子（run / session / turn / correlation）は明示的に渡します。
 
-### 欠けた最終記録を修復する
+### 最終記録とその配信を保証する {#ensuring-a-final-record-and-its-delivery}
 
 通常の workflow は、runtime storage が受理するまで suspension と terminal の
-書き込みを再試行します。engine history がすでに閉じているのに保存済み run が
-active のままの場合、operator は `Runtime.RepairRunCompletion(ctx, runID)` を
-呼べます。この command は engine の最終状態を確認し、修復専用の store operation に
-欠けた suspension または terminal record を渡します。この operation は
-`RepairRunSuspension` または `RepairRunTerminal` です。store は run がまだ active な場合だけ
-それを保存します。workflow が先に別の最終記録を保存していれば、その記録が優先されます。
+書き込みを再試行します。engine history が閉じた後、host は二つの明示的な command
+を使えます。
 
-run の一覧や snapshot の method は読み取り専用で、この修復を行いません。
-engine は workflow output と workflow error を、最終結果を取得できなかった
-error とは分けて返します。取得 error は operator に返され、workflow の最終
-failure として保存されません。成功済みの修復を繰り返しても保存結果は変わりません。
+- `Runtime.EnsureRunCompletion(ctx, runID)` は、storage 上でまだ active の run に
+  欠けている suspension または terminal result を保存します。run がすでに終了して
+  いる場合や、command の実行中に別の final result が先に確定した場合は、保存済みの
+  正確な result を検証して配信します。
+- `Runtime.EnsureChildRunLink(ctx, runID)` は、session に属する child run の保存済み
+  parent link だけを検証して配信します。host は nested child の final result を配信
+  する前に、parent から child の順でこの command を呼べます。
+
+`EnsureRunCompletion` は child の final event より先に parent link を配信します。
+安定した event key により stream への再配信は安全です。すでに保存済みの result から
+local lifecycle notification をもう一度発行することはありません。どちらの command
+も storage が受理済みの result を変更しません。
+
+配信に使う Session status が active な場合、どちらの command にも
+`Runtime.WithStream` が必要です。`EnsureChildRunLink` は
+`LoadSessionStatus` で現在の status を読みます。一方、`EnsureRunCompletion` は
+final record の書き込みまたは完全に同じ再試行と一緒に返された `SessionStatus`
+を使います。新たに確認した Session が終了済みなら、保存済み record は保持して
+stream 配信を抑止します。Session が active な間に storage が event を受理した場合、
+その event は配信対象のままです。同じ配信 call の再試行中に Session が終了しても
+取り消されません。
+
+engine が workflow を running と報告している場合、`EnsureRunCompletion` は
+`ErrRunCompletionNotReady` を返します。engine history または保存済み lifecycle data
+から一つの有効な result を構成できない場合は `ErrRunCompletionCorrupt` を返します。
+engine history の読み込み error は caller に返し、workflow failure として保存しません。
+
+run の一覧や snapshot の method は読み取り専用で、どちらの command も呼びません。
+これらの command は database schema migration を追加せず、公開 wire format も
+変更しません。ただし custom store の Go interface は変わり、既存の durable
+lifecycle record は [Memory & Sessions](../memory-sessions/#durable-event-json) に記載した
+厳密な typed JSON 形式を満たす必要があります。
 
 ---
 

--- a/content/ja/docs/2-goa-ai/testing.md
+++ b/content/ja/docs/2-goa-ai/testing.md
@@ -239,11 +239,20 @@ func TestAgentComposition(t *testing.T) {
 プランナーとワークフローのテストには `runtime/agent/storage/inmem` を使います。プロダクション用の永続実装も同じ契約に対してテストし、次のケースを含めます。
 
 - ルート、子、セッションなし one-shot の各開始が、メタデータと最初の記録をまとめて保存する
-- 子の開始が、親へのリンクと子の開始を同じ操作で保存する
+- 新しい `StartChildRun` と `StartOneShotChildRun` は running の parent を必須とし、親 link と child start を同じ操作で保存する
+- 受理済みのどちらの child start も、完全に同じ retry なら parent の停止後も有効だが、内容を変えた retry と新しい child は拒否する
 - まったく同じ再試行が元の記録 ID を返し、新しい記録を追加していないことを報告する
 - status と他の lifecycle field が同じでも、別の record で同じ変更を繰り返すと conflict になる
 - 最初の書き込みで確定した値を変更すると競合になる
-- 最初のキャンセル理由は変更できず、異なる理由を後から書くと競合になる
+- running workflow が受理した明示的な `CancelRun` は、最初の reason と対応する
+  `storage.CancellationRecordType` record をまとめて保存する。この record の
+  serialized type は `runtime.cancellation_intent` である。完全に同じ retry は成功するが、
+  後から異なる reason を指定すると conflict になる
+- sessionful run の開始時に session がすでに終了していた場合、`session_ended` と
+  canceled の terminal record を保存し、`storage.CancellationRecordType` record は保存しない
+- engine が始めたキャンセルでは、保存された reason は空のままで
+  `storage.CancellationRecordType` record もなく、terminal record に
+  `engine_canceled` が入る
 - 一時停止がチェックポイント、一時停止状態、対応する記録をまとめて保存する
 - 終了が最終状態と対応する記録をまとめて保存する
 - continuation の開始には、存在し、同じ session、agent、parent run identity を持つ
@@ -254,7 +263,31 @@ func TestAgentComposition(t *testing.T) {
 - 終了済みセッションではプランナーやツールを実行せず、すでに受理されたワークフローはキャンセルとして記録する
 - 実行中のランがある間は purge が失敗し、すべて終了した後に終了済みセッションのメタデータ、チェックポイント、記録を削除する
 
-これらのテストでは、実際のデータベーストランザクションを動かしてください。メソッド呼び出しだけを確認する mock では、状態と記録が同時に見えることを証明できません。
+これらの store test では、実際の database transaction を動かしてください。method
+call だけを確認する mock では、state と record が同時に見えることを証明できません。
+
+Temporal adapter は別に test します。親 workflow を終了すると child workflow も
+終了する必要があります。
+
+runtime の明示的な完了結果配信 command は別に test し、次を確認します。
+
+- `EnsureRunCompletion` は active な保存済み run に欠けている result を保存し、
+  すでに保存済みの result は変更せず、検証して再配信する
+- child link は final event より先に配信し、`EnsureChildRunLink` は保存済みの正確な
+  link だけを配信する
+- active な Session で `Runtime.WithStream` がない場合は失敗し、新たに確認した
+  Session が終了済みなら、保存済み result を保持して配信を抑止する
+- `LoadSessionStatus` は Session の現在の status を返すが、`EnsureRunCompletion` は
+  final record の書き込みまたは完全に同じ再試行と一緒に返された
+  `SessionStatus` を使い、stream 配信の再試行中もその status を保つ
+- Session が active な間に受理された event は、その配信 call 中に Session が
+  終了しても配信対象のままである
+- engine workflow が open なら `ErrRunCompletionNotReady` を返し、engine または
+  storage の data が不正、または矛盾していれば `ErrRunCompletionCorrupt` を返す
+
+hook codec は別に test します。`RunStarted`、`RunSuspended`、`RunCompleted`、
+`ChildRunLinked` の decoder は、`null`、未知の field、末尾の二つ目の JSON 値を
+拒否する必要があります。
 
 continuation test は `goa-ai.run-suspension.v7` を受理し、それ以前の version は
 payload の復元や planner 呼び出しの前に拒否することを確認します。

--- a/scripts/TRANSLATION.md
+++ b/scripts/TRANSLATION.md
@@ -19,14 +19,14 @@ Get a DeepL API key at: https://www.deepl.com/pro-api
 ## Quick Start
 
 ```bash
-# Translate all English docs to all languages (IT, JA, FR)
-./scripts/translate content/en/docs/
+# Translate all English docs supported by DeepL
+./scripts/translate --lang IT --lang FR --lang ES content/en/docs/
 
 # Translate a single file to French only
 ./scripts/translate --lang FR content/en/docs/1-goa/quickstart.md
 
-# Translate a directory to Japanese only
-./scripts/translate --lang JA content/en/docs/1-goa/
+# Check which Japanese files need a manual update without changing the cache
+./scripts/translate --dry-run --lang JA content/en/docs/1-goa/
 
 # See what would be translated (dry run)
 ./scripts/translate --dry-run content/en/docs/
@@ -36,17 +36,24 @@ Get a DeepL API key at: https://www.deepl.com/pro-api
 
 1. **Source files** live in `content/en/docs/`
 2. **Translated files** are placed in `content/{lang}/docs/` with the same structure
-3. A **cache file** (`.translation-cache.json`) tracks which files have been translated
-4. Only **changed files** are re-translated (unless `--force` is used)
+3. DeepL translates Italian, French, and Spanish; Japanese is updated manually
+4. A **cache file** (`.translation-cache.json`) tracks which files have been translated
+5. Only **changed files** are re-translated (unless `--force` is used)
+
+For Japanese, inspect pending files with `--dry-run` before editing them. A
+normal Japanese run does not update the translated file: it prints a reminder
+and records the current English hash in the cache. Run it only after the manual
+Japanese update, so the cache is not advanced before the translation is ready.
 
 ## Supported Languages
 
-| Code | Language | Directory |
-|------|----------|-----------|
-| EN   | English  | content/en |
-| IT   | Italian  | content/it |
-| JA   | Japanese | content/ja |
-| FR   | French   | content/fr |
+| Code | Language | Directory | Method |
+|------|----------|-----------|--------|
+| EN   | English  | content/en | Source |
+| IT   | Italian  | content/it | DeepL |
+| FR   | French   | content/fr | DeepL |
+| ES   | Spanish  | content/es | DeepL |
+| JA   | Japanese | content/ja | Manual |
 
 ## What Gets Translated
 
@@ -58,18 +65,28 @@ Get a DeepL API key at: https://www.deepl.com/pro-api
 ### After editing English docs
 
 ```bash
-# Re-translate changed files
-./scripts/translate content/en/docs/
+# Re-translate changed files supported by DeepL
+./scripts/translate --lang IT --lang FR --lang ES content/en/docs/
 
-# Force re-translate everything
-./scripts/translate --force content/en/docs/
+# Force DeepL to re-translate everything it supports
+./scripts/translate --force --lang IT --lang FR --lang ES content/en/docs/
+
+# List Japanese files whose English source changed
+./scripts/translate --dry-run --lang JA content/en/docs/
+
+# After manually updating those Japanese files, record their English revision
+./scripts/translate --lang JA content/en/docs/
 ```
 
 ### Adding a new page
 
 ```bash
-# Translate the new page to all languages
-./scripts/translate content/en/docs/1-goa/new-page.md
+# Translate the new page with DeepL
+./scripts/translate --lang IT --lang FR --lang ES content/en/docs/1-goa/new-page.md
+
+# Then inspect and manually update its Japanese translation
+./scripts/translate --dry-run --lang JA content/en/docs/1-goa/new-page.md
+./scripts/translate --lang JA content/en/docs/1-goa/new-page.md
 ```
 
 ### Translate only to one language
@@ -84,7 +101,7 @@ Usage is displayed after each run. The free tier includes 500,000 chars/month.
 
 You can also pass a different API key directly:
 ```bash
-./scripts/translate --api-key "your-key-here" content/en/docs/
+./scripts/translate --api-key "your-key-here" --lang IT --lang FR --lang ES content/en/docs/
 ```
 
 ## Troubleshooting
@@ -103,7 +120,7 @@ rm -rf .venv
 If a file is corrupted or you want to re-translate:
 
 ```bash
-./scripts/translate --force content/en/docs/1-goa/quickstart.md
+./scripts/translate --force --lang IT --lang FR --lang ES content/en/docs/1-goa/quickstart.md
 ```
 
 ### Clear translation cache
@@ -112,8 +129,13 @@ To re-translate everything:
 
 ```bash
 rm .translation-cache.json
-./scripts/translate content/en/docs/
+./scripts/translate --lang IT --lang FR --lang ES content/en/docs/
+./scripts/translate --dry-run --lang JA content/en/docs/
 ```
+
+After manually checking every Japanese file reported by the dry run, run
+`./scripts/translate --lang JA content/en/docs/` once to record the reviewed
+English revisions.
 
 ## Files
 
@@ -122,4 +144,3 @@ rm .translation-cache.json
 - `.translation-cache.json` - Tracks translated files (gitignored)
 - `.venv/` - Python virtual environment (gitignored)
 - `i18n/*.yaml` - UI string translations (manually maintained)
-


### PR DESCRIPTION
Goa-AI users can now follow the website documentation to implement the current runtime storage contract without depending on removed store packages or guessing how retries, cancellation, and final event delivery behave.

## Why the documentation needed correction

The published pages still described `Runtime.RepairRunCompletion` and repair-only store methods that no longer match Goa-AI. They also left several correctness rules implicit:

- whether a run state change and the record proving that change must appear together;
- what an exact retry may return and when a changed retry must fail;
- whether a child may start after its parent stops;
- how a cancellation request differs from a run canceled by session or engine state;
- which stored JSON values the runtime accepts; and
- when final results are delivered to a Session stream.

That gap could lead a custom store to compile against old names, save lifecycle state and records separately, accept an invalid retry, or persist data that the current runtime rejects when it reads it back. The translated pages repeated the same incomplete contract.

## The documented contract

`storage.Store` is the one interface for Goa-AI run metadata, checkpoints, and immutable lifecycle records. A lifecycle record is the stored event that proves a run started, suspended, completed, or became linked to its parent. The store writes each state change and its matching record in one operation.

The updated Memory & Sessions, Runtime, Production, and Testing pages now explain that:

- exact retries return the result already accepted, while a retry that changes fixed input fails with a conflict;
- `StartChildRun` and `StartOneShotChildRun` require a running parent for a new child, but the exact retry of an already accepted start remains valid after the parent stops;
- Temporal terminates a child workflow if its parent workflow closes first;
- `RunStarted`, `RunSuspended`, `RunCompleted`, and `ChildRunLinked` payloads must each contain exactly one JSON object of the matching type; `null`, unknown fields, and trailing JSON values are rejected;
- an explicit `CancelRun` stores the first reason with a `storage.CancellationRecordType` record, serialized as `runtime.cancellation_intent`;
- a run rejected because its Session ended stores `session_ended` without a separate cancellation-intent record; and
- cancellation initiated by the workflow engine leaves the stored request reason empty and records `engine_canceled` in the terminal event.

The Production pages now point to the owning Memory & Sessions and Runtime contracts instead of repeating a shorter version that could drift. Store tests own database transaction checks. Temporal behavior, runtime completion delivery, and hook JSON decoding each have separate test responsibilities.

## Upgrade actions and observable errors

Callers upgrading custom runtime integrations need to make these source changes together:

- replace `Runtime.RepairRunCompletion` with `Runtime.EnsureRunCompletion`;
- implement `LoadSessionStatus` on each custom `storage.Store`;
- configure `Runtime.WithStream` before either ensure command delivers to an active Session; and
- treat a new child start after its parent stops as invalid while continuing to accept an exact retry that the store already recorded.

`EnsureRunCompletion` stores a final result missing from an active run, or validates and delivers the exact final result already present. `EnsureChildRunLink` validates and delivers only the stored parent link for a Session-backed child. Active workflows return `ErrRunCompletionNotReady`. Engine history or stored lifecycle data that cannot form one valid result returns `ErrRunCompletionCorrupt`.

The ensure commands do not require a database schema change and do not alter a public wire format. Moving from the removed split `session.Store` and `runlog.Store` APIs to the integrated store is a coordinated application change: existing run data must satisfy the documented contract before the new runtime writes, old and new writers must not overlap, and the host runtime plus its custom store should be deployed together. This pull request changes documentation only, so it can be reverted without changing a running service or stored data.

## Translation safety

The automatic translation examples now explicitly select Italian, French, and Spanish, the languages handled by DeepL in this repository. Japanese uses a separate sequence:

1. run a Japanese dry-run to list changed English sources without changing the cache;
2. update the Japanese files manually; and
3. run the Japanese command once to record the reviewed English revision.

This prevents the cache from marking Japanese current before its content has actually been updated. All contract changes in this pull request are present in English, Spanish, French, Italian, and Japanese, and existing page anchors remain intact.

## Validation performed

- `git diff --check`
- `npm test` (5 files, 70 tests)
- `go test ./...` in `go-app`
- `make build` in an isolated checkout with this exact diff applied
- cross-language checks for the renamed API, required store method, stream requirement, cancellation record type, and serialized value
- comparison of all pre-existing explicit anchors against `main`

The production Hugo build completed for all five languages. It emitted existing Hugo and Sass deprecation warnings; those warnings are unrelated to this documentation change.

## Reviewer focus

The highest-value review path is:

1. the lifecycle, retry, cancellation, and upgrade rules in Memory & Sessions;
2. the `EnsureRunCompletion` and `EnsureChildRunLink` behavior and errors in Runtime;
3. the separation of store, Temporal, runtime, and hook tests in Testing; and
4. the Japanese cache workflow in `README.md` and `scripts/TRANSLATION.md`.

The localized pages should express the same contract and keep the shared English anchor names used by cross-language links.
