### PR TITLE
Clarify what partial tool results can support

### DIFF
--- a/content/en/docs/2-goa-ai/toolsets.md
+++ b/content/en/docs/2-goa-ai/toolsets.md
@@ -324,6 +324,15 @@ When a bounded tool executes:
 6. Stream subscribers and finalizers access bounds for UI display, logging, or
    policy decisions
 
+When a truncated result has no next-page cursor, the runtime reminder asks the
+model to state the view's limits. Partial results can still support useful
+answers about the returned items when that scope is clear. Disclosing truncation
+or fetching another still-partial page does not establish facts about items
+still omitted. Provider-established full-query totals retain their full-query
+scope; later, independently complete evidence supports conclusions within its
+own scope. Extra pagination is not required when the available evidence already
+answers the question.
+
 ```go
 // In a stream subscriber
 func handleToolEnd(event *stream.ToolEndEvent) {

--- a/content/es/docs/2-goa-ai/toolsets.md
+++ b/content/es/docs/2-goa-ai/toolsets.md
@@ -309,6 +309,17 @@ Cuando se ejecuta una herramienta acotada:
 5. Con `Cursor` directo, el runtime emite el cursor opaco en `next_cursor` para la siguiente llamada del modelo
 6. Los suscriptores de streams y los finalizadores acceden a los bounds para su visualización en la UI, logging o decisiones de políticas
 
+Cuando un resultado truncado no tiene un cursor de página siguiente, el
+recordatorio del runtime pide al modelo que indique los límites de la vista.
+Los resultados parciales pueden sustentar respuestas útiles sobre los elementos
+devueltos si ese alcance queda claro. Advertir del truncado u obtener otra
+página que siga siendo parcial no permite establecer hechos sobre los elementos
+que siguen omitidos. Los totales que el proveedor establece para la consulta
+completa conservan ese alcance; las pruebas posteriores que sean completas por
+sí mismas pueden sustentar conclusiones dentro de su propio alcance. No es
+necesario obtener más páginas si las pruebas disponibles ya responden a la
+pregunta.
+
 ```go
 // En un suscriptor de stream
 func handleToolEnd(event *stream.ToolEndEvent) {

--- a/content/fr/docs/2-goa-ai/toolsets.md
+++ b/content/fr/docs/2-goa-ai/toolsets.md
@@ -307,6 +307,17 @@ Lorsqu'un outil limité s'exécute :
 5. Avec `Cursor` direct, le runtime émet le curseur opaque dans `next_cursor` pour l'appel suivant du modèle
 6. Les abonnés au flux et les finaliseurs accèdent aux limites pour l'affichage UI, la journalisation ou les décisions de politique
 
+Lorsqu'un résultat tronqué n'a pas de curseur de page suivante, le rappel du
+runtime demande au modèle de préciser les limites de la vue. Des résultats
+partiels peuvent étayer des réponses utiles sur les éléments renvoyés, à
+condition que cette portée soit claire. Signaler la troncature ou récupérer une
+autre page encore partielle ne permet pas d'établir des faits sur les éléments
+qui restent omis. Les totaux établis par le fournisseur pour l'ensemble de la
+requête conservent cette portée ; des éléments de preuve ultérieurs, complets
+par eux-mêmes, peuvent étayer des conclusions dans leur propre périmètre. Il
+n'est pas nécessaire de récupérer d'autres pages si les éléments disponibles
+répondent déjà à la question.
+
 ```go
 // In a stream subscriber
 func handleToolEnd(event *stream.ToolEndEvent) {

--- a/content/it/docs/2-goa-ai/toolsets.md
+++ b/content/it/docs/2-goa-ai/toolsets.md
@@ -308,6 +308,16 @@ When a bounded tool executes:
 5. Con `Cursor` diretto, il runtime emette il cursor opaco in `next_cursor` per la chiamata successiva del modello
 6. I sottoscrittori dello stream e i finalizer accedono ai bounds per UI, log e decisioni di policy
 
+Quando un risultato troncato non ha un cursor per la pagina successiva, il
+promemoria del runtime chiede al modello di indicare i limiti della vista.
+I risultati parziali possono comunque sostenere risposte utili sugli elementi
+restituiti, purché tale ambito sia chiaro. Segnalare il troncamento o recuperare
+un'altra pagina ancora parziale non permette di stabilire fatti sugli elementi
+ancora omessi. I totali stabiliti dal provider per l'intera query mantengono tale
+ambito; dati successivi, completi di per sé, possono sostenere conclusioni nel
+proprio ambito. Non occorre recuperare altre pagine se i dati disponibili
+rispondono già alla domanda.
+
 ```go
 // In un sottoscrittore di flusso
 func handleToolEnd(event *stream.ToolEnd) {

--- a/content/ja/docs/2-goa-ai/toolsets.md
+++ b/content/ja/docs/2-goa-ai/toolsets.md
@@ -296,6 +296,8 @@ bounded tool が実行されると:
 5. direct `Cursor` では、runtime は opaque cursor を `next_cursor` に出力し、model が次の call で指定します
 6. stream subscriber と finalizer は bounds を UI display、logging、policy decision に使えます
 
+truncated result に次ページの cursor がない場合、runtime の reminder は model に view の限界を明示するよう求めます。partial result でも、返された item についての回答であることを明確にすれば、有用な回答の根拠になります。truncation を明記したり、別のまだ不完全な page を取得したりするだけでは、依然として省略されている item についての事実は確立できません。provider が query 全体について確立した total はその範囲を保ち、後から得られた、それ自体で完全な証拠は、その証拠が対象とする範囲内の結論の根拠になります。利用可能な証拠ですでに質問に答えられる場合、追加の page 取得は不要です。
+
 ```go
 // In a stream subscriber
 func handleToolEnd(event *stream.ToolEndEvent) {


### PR DESCRIPTION
Partial tool results can support useful answers without supporting claims about items that were not returned. This adds that distinction to the bounded-results guide in English and its four existing translations: Spanish, French, Italian, and Japanese.

### What readers should understand

The guide already described bounds metadata and pagination mechanics, but did not explain that stating a result is partial does not supply missing evidence. The new paragraph makes the answer's scope explicit:

- Returned items can support a useful answer when that scope is clear.
- A truncation disclaimer, or another page that remains partial, does not establish facts about items still omitted.
- Totals that the tool provider establishes for the full query retain that scope. Later, independently complete evidence supports conclusions within its own scope.
- No extra pagination is required when the available evidence already answers the question.

Services still own trimming and the bounds metadata describing returned data. The runtime reminds the model to state the view's limits when a truncated result has no next-page cursor. The model still chooses its answer and any next action from the available evidence. The corresponding reminder wording implementation is [goa-ai PR #325](https://github.com/goadesign/goa-ai/pull/325); this documentation change is not proof that a model will always follow that guidance.

### Scope and review

Review the added paragraph under Runtime Behavior in `content/en/docs/2-goa-ai/toolsets.md`, then its counterparts in `content/{es,fr,it,ja}/docs/2-goa-ai/toolsets.md`. Existing pagination instructions, examples, fields, validation, tool inputs, results, and errors are unchanged. No runtime code changes, migration, caller changes, or mixed-version handling are needed. Publication uses the existing documentation workflow; reverting the paragraph additions reverses this change.

### Validation performed

- Production Hugo build (`hugo --minify`) passed for all five languages.
- Repository tests (`npm test`): 70 passed across five files.
- `git diff --check` passed.
- Proofread each changed section and checked that each built page renders the added paragraph once.

Existing Hugo/Sass deprecation warnings and four npm dependency advisories remain unchanged; no dependencies were modified.
