### PR TITLE
Document caller-owned judge response limits

### DIFF
--- a/content/en/docs/2-goa-ai/evaluations.md
+++ b/content/en/docs/2-goa-ai/evaluations.md
@@ -344,7 +344,11 @@ if err != nil {
     return err
 }
 
-runner, err := eval.NewRunner(judge.New(modelClient), eval.RunnerConfig{
+grader, err := judge.New(modelClient, maxOutputTokens)
+if err != nil {
+    return err
+}
+runner, err := eval.NewRunner(grader, eval.RunnerConfig{
     MaxConcurrency: 5,
     Reporter:       reporter,
 })
@@ -402,6 +406,19 @@ that need a deterministic judge client should implement `model.Provider` and
 pass it through `model.NewClient`; application code cannot implement
 `model.Client` directly.
 
+The application must supply a positive `maxOutputTokens` to `judge.New` and
+handle its error. Read this value from application configuration before running
+the suite. Zero and negative values fail construction without calling the
+model; there is no default.
+
+The value is an inclusive output-token ceiling for **one complete model
+response**, including all judgments and their JSON structure. It is not a
+per-claim allowance or a total budget for the scenario or suite. Goa-AI sends
+the same value on the initial request and every permitted correction request,
+regardless of claim count. Choose a value supported by your configured provider
+and model; unsupported values remain errors, not silently reduced limits. A
+finite ceiling does not guarantee that a response will finish within it.
+
 For each scenario the judge receives the answer and the scenario's claims, and
 returns exactly one label and a short rationale per claim:
 
@@ -420,10 +437,13 @@ before touching the application. Calibration runs under a two-minute deadline
 owned by the runner, so an unreachable or stalled model endpoint fails the
 suite with a clear error instead of blocking it forever.
 
-The judge is strict about its own protocol: missing or duplicate claim IDs,
-unknown labels, extra fields, and malformed responses are errors. It never
-retries or repairs a bad response, because a judge that edits its own output
-is no longer trustworthy evidence.
+The judge requires exactly one judgment per claim, in the same order, with a
+known label and a nonempty rationale. Claim IDs stay outside the model request
+and are restored by position. Missing or extra judgments, unknown labels,
+extra fields, and malformed responses are rejected. The existing bounded
+correction flow can ask the model for a replacement response; it never edits
+invalid output into an accepted result. If correction is exhausted, the caller
+receives an error rather than invented judgments.
 
 ## Read the report
 
@@ -443,6 +463,19 @@ Failures land at two levels:
 After a run without a suite-level error, check `report.Passed`: it is true
 only when every selected scenario passed all of its checks and claims. A false
 value must fail the calling command or CI job.
+
+## Upgrade judge construction
+
+`judge.New(client, opts...) *Judge` is replaced by
+`judge.New(client, maxOutputTokens, opts...) (*Judge, error)`. Update every
+caller to supply its configured positive response limit and handle the error
+before creating the runner. Existing options such as `WithModelClass` follow
+the required limit and keep their meaning.
+
+The former `256 × claim count` calculation is removed. This is a Go source
+change: existing callers must be updated to compile against the new version.
+It does not change the judge's model selection, prompt, labels, strict response
+validation, or correction count. No saved-report migration is required.
 
 ## Upgrade from string-input suites
 

--- a/content/es/docs/2-goa-ai/evaluations.md
+++ b/content/es/docs/2-goa-ai/evaluations.md
@@ -78,8 +78,12 @@ artefactos inválidos y respuestas incompletas del juez semántico.
 La concurrencia es explícita y limitada:
 
 ```go
+grader, err := judge.New(modelClient, maxOutputTokens)
+if err != nil {
+    return err
+}
 runner, err := eval.NewRunner(
-    judge.New(modelClient),
+    grader,
     eval.RunnerConfig{MaxConcurrency: 5},
 )
 if err != nil {
@@ -117,6 +121,20 @@ vacíos, duplicados e IDs o etiquetas desconocidos.
 
 ## Evaluación semántica
 
+La aplicación debe pasar un `maxOutputTokens` positivo a `judge.New` y manejar
+el error devuelto. Lee el valor de la configuración de la aplicación antes de
+ejecutar la suite. Cero y los valores negativos hacen fallar la construcción
+sin llamar al modelo; no hay un valor predeterminado.
+
+El valor es un límite inclusivo de tokens de salida para **una respuesta
+completa del modelo**, incluidos todos los juicios y su estructura JSON. No es
+una asignación por afirmación ni un presupuesto total por escenario o suite.
+Goa-AI envía el mismo valor en la petición inicial y en cada petición de
+corrección permitida, independientemente del número de afirmaciones. Elige un
+valor compatible con el proveedor y el modelo configurados; los valores no
+compatibles siguen siendo errores, sin reducir silenciosamente el límite. Un
+límite finito no garantiza que la respuesta pueda completarse.
+
 Antes de ejecutar escenarios, el runner verifica el juez con cuatro ejemplos
 propiedad del framework: `entailed` (la respuesta demuestra la afirmación),
 `contradicted` (demuestra lo contrario), `not_addressed` (habla de otra cosa) e
@@ -125,7 +143,30 @@ propiedad del framework: `entailed` (la respuesta demuestra la afirmación),
 Los cuatro resultados deben ser correctos. Así, un juez que siempre responde
 `entailed` no puede hacer que toda la suite pase. Un fallo de calibración detiene
 la suite antes de llamar a la aplicación. En los escenarios, solo `entailed`
-aprueba; el juez no reintenta ni repara su salida.
+aprueba.
+
+El juez exige exactamente un juicio por afirmación, en el mismo orden, con una
+etiqueta conocida y una justificación no vacía. Los IDs de las afirmaciones no
+se envían al modelo y se restauran según su posición. Los juicios ausentes o
+adicionales, etiquetas desconocidas, campos adicionales y respuestas malformadas
+se rechazan. El mecanismo de corrección existente, con un número limitado de
+intentos, puede pedir al modelo una respuesta de reemplazo; nunca modifica una
+salida inválida para aceptarla. Si se agotan las correcciones, el llamante
+recibe un error en lugar de juicios inventados.
+
+## Migrar la construcción del juez
+
+`judge.New(client, opts...) *Judge` se sustituye por
+`judge.New(client, maxOutputTokens, opts...) (*Judge, error)`. Actualiza todos
+los llamantes para pasar el límite positivo configurado y manejar el error
+antes de crear el runner. Las opciones existentes, como `WithModelClass`, van
+después del límite obligatorio y mantienen su significado.
+
+Se elimina el cálculo anterior de `256 × número de afirmaciones`. Este cambio
+del código fuente Go exige actualizar los llamantes para compilar con la nueva
+versión. No cambia la selección del modelo, el prompt, las etiquetas, la
+validación estricta de las respuestas ni el número de correcciones. No hace
+falta migrar los informes guardados.
 
 ## Leer el informe
 

--- a/content/fr/docs/2-goa-ai/evaluations.md
+++ b/content/fr/docs/2-goa-ai/evaluations.md
@@ -332,7 +332,11 @@ if err != nil {
     return err
 }
 
-runner, err := eval.NewRunner(judge.New(modelClient), eval.RunnerConfig{
+grader, err := judge.New(modelClient, maxOutputTokens)
+if err != nil {
+    return err
+}
+runner, err := eval.NewRunner(grader, eval.RunnerConfig{
     MaxConcurrency: 5,
     Reporter:       reporter,
 })
@@ -381,6 +385,21 @@ que le reste de Goa-AI. Les tests qui ont besoin d'un client déterministe
 implémentent `model.Provider` puis appellent `model.NewClient` ; le code
 d'application ne peut pas implémenter directement `model.Client`.
 
+L'application doit fournir un `maxOutputTokens` strictement positif à
+`judge.New` et traiter son erreur. Lisez cette valeur dans la configuration de
+l'application avant d'exécuter la suite. Zéro et les valeurs négatives font
+échouer la construction sans appeler le modèle ; il n'existe aucune valeur par
+défaut.
+
+Cette valeur est un plafond inclusif de jetons de sortie pour **une réponse
+complète du modèle**, comprenant tous les jugements et leur structure JSON.
+Ce n'est ni un quota par affirmation, ni un budget total par scénario ou suite.
+Goa-AI transmet la même valeur dans la requête initiale et chaque requête de
+correction autorisée, quel que soit le nombre d'affirmations. Choisissez une
+valeur prise en charge par le fournisseur et le modèle configurés ; une valeur
+non prise en charge reste une erreur, sans réduction silencieuse du plafond.
+Un plafond fini ne garantit pas que la réponse pourra se terminer.
+
 Le juge reçoit la réponse et les affirmations, puis attribue exactement un
 résultat et une justification courte à chacune :
 
@@ -394,9 +413,15 @@ exemple fixe de chaque résultat. Un juge incapable de les distinguer arrête la
 suite avant tout appel à l'application. Cette calibration a un délai de deux
 minutes géré par le runner.
 
-Le protocole du juge est strict : IDs absents ou dupliqués, résultats inconnus,
-champs supplémentaires et réponses mal formées sont des erreurs. Il ne réessaie
-ni ne répare une réponse incorrecte.
+Le juge exige exactement un jugement par affirmation, dans le même ordre, avec
+un résultat connu et une justification non vide. Les IDs d'affirmations restent
+hors de la requête au modèle et sont rétablis selon leur position. Les jugements
+manquants ou supplémentaires, les résultats inconnus, les champs supplémentaires
+et les réponses mal formées sont refusés. Le mécanisme de correction existant,
+limité en nombre de tentatives, peut demander une réponse de remplacement au
+modèle ; il ne modifie jamais une sortie invalide pour la rendre acceptable. Une
+fois les corrections épuisées, l'appelant reçoit une erreur, pas des jugements
+inventés.
 
 ## Lire le rapport
 
@@ -411,6 +436,20 @@ comprend le hook, la validation du résultat et le jugement.
 Après une exécution sans erreur de suite, `report.Passed` n'est vrai que si
 toutes les vérifications et affirmations de tous les scénarios sélectionnés ont
 réussi. Une valeur false doit faire échouer la commande ou le travail CI.
+
+## Migrer la construction du juge
+
+`judge.New(client, opts...) *Judge` est remplacé par
+`judge.New(client, maxOutputTokens, opts...) (*Judge, error)`. Modifiez chaque
+appelant pour fournir son plafond de réponse configuré, strictement positif,
+et traiter l'erreur avant de créer le runner. Les options existantes comme
+`WithModelClass` suivent le plafond obligatoire et conservent leur sens.
+
+L'ancien calcul `256 × nombre d'affirmations` est supprimé. Ce changement du
+code source Go exige de modifier les appelants pour compiler avec la nouvelle
+version. Il ne change ni le choix du modèle, ni le prompt, ni les résultats
+possibles, ni la validation stricte, ni le nombre de corrections. Aucune
+migration des rapports enregistrés n'est nécessaire.
 
 ## Migrer depuis les suites à entrée texte
 

--- a/content/it/docs/2-goa-ai/evaluations.md
+++ b/content/it/docs/2-goa-ai/evaluations.md
@@ -77,8 +77,12 @@ non validi e risposte incomplete del giudice.
 La concorrenza è esplicita e limitata:
 
 ```go
+grader, err := judge.New(modelClient, maxOutputTokens)
+if err != nil {
+    return err
+}
 runner, err := eval.NewRunner(
-    judge.New(modelClient),
+    grader,
     eval.RunnerConfig{MaxConcurrency: 5},
 )
 if err != nil {
@@ -117,6 +121,21 @@ ID o tag sconosciuti.
 
 ## Giudizio semantico
 
+L'applicazione deve passare un `maxOutputTokens` positivo a `judge.New` e
+gestire l'errore restituito. Leggi il valore dalla configurazione
+dell'applicazione prima di eseguire la suite. Zero e valori negativi fanno
+fallire la costruzione senza chiamare il modello; non esiste un valore
+predefinito.
+
+Il valore è un limite inclusivo di token di output per **una risposta completa
+del modello**, comprendente tutti i giudizi e la loro struttura JSON. Non è un
+limite per claim né un budget totale per scenario o suite. Goa-AI invia lo
+stesso valore nella richiesta iniziale e in ogni richiesta di correzione
+consentita, indipendentemente dal numero di claim. Scegli un valore supportato
+dal provider e dal modello configurati; i valori non supportati restano errori,
+senza riduzioni silenziose del limite. Un limite finito non garantisce che la
+risposta riesca a completarsi.
+
 Prima degli scenari, il runner verifica il giudice con quattro esempi gestiti dal
 framework: `entailed` (la risposta dimostra il claim), `contradicted` (dimostra
 il contrario), `not_addressed` (parla d'altro) e `indeterminate` (informazioni
@@ -125,7 +144,30 @@ in conflitto impediscono una conclusione).
 Tutti e quattro i risultati devono essere corretti. In questo modo, un giudice
 che risponde sempre `entailed` non può far passare l'intera suite. Un errore di
 calibrazione ferma la suite prima della chiamata all'applicazione. Negli scenari
-passa solo `entailed`; il giudice non ritenta né ripara il proprio output.
+passa solo `entailed`.
+
+Il giudice richiede esattamente un giudizio per claim, nello stesso ordine, con
+un'etichetta nota e una motivazione non vuota. Gli ID dei claim non vengono
+inviati al modello e sono ripristinati in base alla posizione. Giudizi mancanti
+o aggiuntivi, etichette sconosciute, campi aggiuntivi e risposte malformate sono
+rifiutati. Il meccanismo di correzione esistente, con un numero limitato di
+tentativi, può chiedere al modello una risposta sostitutiva; non modifica mai
+un output invalido per accettarlo. Esaurite le correzioni, il chiamante riceve
+un errore anziché giudizi inventati.
+
+## Migrare la costruzione del giudice
+
+`judge.New(client, opts...) *Judge` è sostituito da
+`judge.New(client, maxOutputTokens, opts...) (*Judge, error)`. Aggiorna ogni
+chiamante per passare il limite positivo configurato e gestire l'errore prima
+di creare il runner. Le opzioni esistenti, come `WithModelClass`, seguono il
+limite obbligatorio e mantengono il loro significato.
+
+Il precedente calcolo `256 × numero di claim` viene rimosso. Questa modifica
+al codice sorgente Go richiede l'aggiornamento dei chiamanti per compilare con
+la nuova versione. Non cambia la selezione del modello, il prompt, le
+etichette, la convalida rigorosa delle risposte o il numero di correzioni. Non
+è necessaria alcuna migrazione dei report salvati.
 
 ## Leggere il report
 

--- a/content/ja/docs/2-goa-ai/evaluations.md
+++ b/content/ja/docs/2-goa-ai/evaluations.md
@@ -250,7 +250,11 @@ if err != nil {
     return err
 }
 
-runner, err := eval.NewRunner(judge.New(modelClient), eval.RunnerConfig{
+grader, err := judge.New(modelClient, maxOutputTokens)
+if err != nil {
+    return err
+}
+runner, err := eval.NewRunner(grader, eval.RunnerConfig{
     MaxConcurrency: 5,
     Reporter:       reporter,
 })
@@ -290,6 +294,10 @@ report, err := runner.RunTags(ctx, suite, "smoke", "alarm")
 
 `eval/judge` は、Goa-AI の他の箇所と同じ不透明な検証済み `model.Client` から judge を作るため、設定済みのどの provider でも利用できます。deterministic な judge client が必要な test は `model.Provider` を実装し、`model.NewClient` を通します。application code は `model.Client` を直接実装できません。
 
+application は `judge.New` に正の `maxOutputTokens` を渡し、返された error を処理する必要があります。suite を実行する前に application の設定からこの値を読み取ってください。ゼロや負の値では model を呼ばずに生成が失敗します。default 値はありません。
+
+この値は、全 judgment と JSON 構造を含む**モデルの 1 回の応答全体**に対する output token 数の上限です。上限と同じ値までは許可されます。claim ごとの割り当てでも、scenario や suite 全体の予算でもありません。Goa-AI は claim 数にかかわらず、初回 request と許可された各 correction request に同じ値を渡します。設定された provider と model が対応する値を選んでください。未対応の値は黙って引き下げられず、error になります。有限の上限では、その範囲内で応答が完了することは保証されません。
+
 各 scenario について、judge は回答と claim を受け取り、claim ごとに正確に 1 label と短い理由を返します。
 
 - `entailed`: 回答が claim を真だと裏付ける。
@@ -301,7 +309,7 @@ report, err := runner.RunTags(ctx, suite, "smoke", "alarm")
 
 scenario を開始する前に、runner は label ごとに 1 つ、固定の 4 example で judge を検査します。この手順を calibration と呼びます。たとえば常に `entailed` を返して全 evaluation を成功させるような、label を区別できない judge は calibration に失敗し、application へ触れる前に suite を停止します。calibration は runner 所有の 2 分 deadline 内で行うため、接続不能または停止した model endpoint は suite を永久に block せず、明確な error になります。
 
-judge は自身の protocol を厳格に検証します。claim ID の欠落や重複、未知の label、余分な field、不正な response は error です。不正出力を retry または修復しません。自分の出力を編集する judge は、信頼できる evidence ではないからです。
+judge は、各 claim に対して同じ順序で正確に 1 つの judgment を要求します。各 judgment には既知の label と空でない理由が必要です。claim ID は model request に含めず、位置に基づいて復元します。judgment の不足や超過、未知の label、余分な field、不正な response は拒否されます。既存の回数制限付き correction 処理は model に代わりの応答を求めることがありますが、不正な出力を書き換えて受理することはありません。correction 回数を使い切ると、呼び出し元には架空の judgment ではなく error が返ります。
 
 ## report を読む
 
@@ -313,6 +321,12 @@ report とその全要素は安定した JSON field 名を使うため、tooling
 - **scenario-level**: hook error、不正な result、timeout、judging failure は該当 scenario の report に記録され、残りの scenario は完了まで続きます。
 
 suite-level error なしで実行を終えたら `report.Passed` を確認します。全 selected scenario がすべての check と claim に成功した場合だけ true です。false なら呼び出し元 command または CI job を失敗させてください。
+
+## judge の生成処理を移行する
+
+`judge.New(client, opts...) *Judge` は `judge.New(client, maxOutputTokens, opts...) (*Judge, error)` に置き換わります。すべての呼び出し元で、設定済みの正の応答上限を渡し、runner を作る前に error を処理してください。`WithModelClass` など既存の option は必須の上限値の後に渡し、意味は変わりません。
+
+以前の `256 × claim 数` という計算は削除されます。これは Go source の変更なので、新しい version で compile するには呼び出し元の更新が必要です。judge の model 選択、prompt、label、厳格な応答検証、correction 回数は変わりません。保存済み report の移行は不要です。
 
 ## string-input suite からの upgrade
 


### PR DESCRIPTION
The evaluation judge classifies an application's answer against its claims. Its constructor is changing from an implicit claim-count allowance to a required, application-chosen output limit. The documentation must show callers how to configure the judge and handle invalid configuration before starting a suite.

This updates all five evaluation guides (English, Spanish, French, Italian and Japanese). Each constructor example now uses `judge.New(modelClient, maxOutputTokens)` and checks its returned error. The upgrade section explains that the positive limit covers one complete response, including every judgment and its JSON structure. It is reused unchanged on existing correction requests, not multiplied by claim count or treated as a whole-suite budget. No universal numeric recommendation is introduced.

The guides also correct the directly related statement that the judge never requests corrections: it can request bounded replacements, but it never edits malformed output into a valid judgment. Invalid results remain errors after the existing correction allowance is exhausted. Claim IDs remain outside model input and are restored by position.

## Upgrade and publication

This documents a source-breaking constructor migration, not a change to model selection, prompts, labels, strict validation, correction counts or stored reports. Applications must supply their own supported positive limit and handle the constructor error. No data migration is needed. Merge this documentation after the matching framework constructor change is available; older framework users should follow the documentation for their installed version.

## Verification

The production Hugo build passed, all 70 website tests passed, and rendered-page checks passed in all five languages for the migrated call, error handling, upgrade signature and unique headings. Whitespace checks and independent review passed. Existing dependency advisories and unrelated older typed-input examples in Spanish and Italian are unchanged.
