### PR TITLE
docs(goa-ai): explain history summary evidence preservation

### DIFF
--- a/content/en/docs/2-goa-ai/runtime.md
+++ b/content/en/docs/2-goa-ai/runtime.md
@@ -1563,6 +1563,56 @@ Bedrock adapter returns `model.ErrTokenCountingUnsupported` for those models.
 The generated agent config exposes `HistoryCompression` for deployment-specific
 overrides without changing the design defaults.
 
+#### Evidence supplied to the summary model
+
+`Compress` gives its selected older messages to the summary model as evidence,
+not as a conversation to continue. Text, complete tool arguments and results,
+call/result IDs, error status and full error messages, and citation fields are
+quoted through the canonical `model.Message` JSON codec. Their original roles,
+message/part positions, and order remain explicit. Values are not selected,
+rounded, deduplicated, or replaced with tool-result placeholders. The model
+decides which supplied facts matter; the runtime does not predict relevance.
+
+`WithSummaryPrompt` still inserts the complete quoted textual transcript at its
+`%s` placeholder. Images and documents remain native attachments, supplied once
+after that prompt in the same completion. Each original user message containing
+media produces one user attachment message, with matching original message/part
+references. The history policy neither duplicates media bytes as base64 prose
+nor extracts or fetches document bodies. Historical tools are quoted data: the
+summary request advertises no tools and does not replay historical assistant
+turns as new actions.
+
+Original `Message.Meta`, thinking, cache checkpoints, and tool thought signatures
+are not copied into the new summary request. This does not redact or change
+original history, exact retained messages, stored diagnostics, or full tool
+errors. Put facts that must be available for summarization in canonical text,
+tool, citation, or media parts, not an opaque metadata map.
+
+The returned summary keeps its configured `WithSummaryRole`, single text part,
+`[Conversation Summary]` prefix, and runtime summary metadata. Plain text keeps
+its existing representation. Cited sentences and all supplied citation fields
+(title, source, location, and excerpts) survive in output order as quoted
+records, not native citation blocks replayed under another role. Whitespace-only
+generated text still fails as an empty summary, even with attribution fields.
+
+Citation coordinates retain the meaning of the request that produced them.
+Historical document indices are not reassigned to the summary's attachments.
+When a cited summary used native documents, its text also describes their
+request layout: attachment-message position, document occurrence within that
+message, original history position, and supplied name, format, and URI. It
+includes no document bodies and does not claim a mapping to a provider's
+`DocumentIndex` or invent a file link from incomplete attribution. Later
+compression treats these records as text, not a document registry to rebuild.
+
+This fuller input may be larger than the former placeholder prompt. The selected
+older messages, exact retained suffix, model class, thresholds, counting behavior,
+and single summary completion remain unchanged. Adapter support and existing
+client/provider limits still apply; providers may combine consecutive user
+messages. Unsupported media or an oversized request fails explicitly, without
+dropping evidence, a text-only fallback, or extra summary/count calls. Complete
+input does **not** guarantee that the model preserves every important fact in
+its prose, or that every history fits the summary model.
+
 ### Coordinated Generated-System Releases
 
 Compatible releases may roll transparently; incompatible generated changes

--- a/content/es/docs/2-goa-ai/runtime.md
+++ b/content/es/docs/2-goa-ai/runtime.md
@@ -1382,6 +1382,37 @@ ambiguos. No mezcles `PlannerModelClient.Stream(...)` con
 `planner.ConsumeStream`; elige un único propietario del stream por turno del
 planificador.
 
+### Evidencia disponible para el modelo de resumen
+
+`Compress` entrega los mensajes antiguos seleccionados como evidencia, no como
+una conversación que deba continuar. Cita el texto, los argumentos y resultados
+completos de las herramientas, sus identificadores, el estado y texto completo
+de los errores y los campos de las citas mediante el formato JSON canónico de
+`model.Message`. Conserva los roles, las posiciones y el orden, sin seleccionar,
+redondear ni eliminar valores repetidos. El modelo decide qué datos son relevantes.
+
+`WithSummaryPrompt` sigue insertando la transcripción textual completa en `%s`.
+Las imágenes y los documentos se adjuntan una sola vez como contenido nativo en
+la misma llamada: un mensaje de adjuntos por cada mensaje de usuario original
+que contenía archivos, con referencias a sus posiciones. No se ofrecen
+herramientas para ejecutar ni se extraen o recuperan documentos. `Message.Meta`,
+el razonamiento, los puntos de control de caché y las firmas de razonamiento de
+herramientas no se copian a esta nueva petición. El historial original, los
+mensajes conservados sin cambios, los diagnósticos y los errores completos
+permanecen intactos.
+
+El resumen mantiene su rol y formato textual. Conserva las frases citadas y
+todos sus campos de atribución, en orden, como registros citados. Las coordenadas
+pertenecen a la petición que las produjo. Si el nuevo resumen contiene citas y
+usó documentos nativos, incluye una descripción de su disposición, sin cuerpos
+de documentos, reasignar `DocumentIndex` ni inventar enlaces.
+
+No cambian los mensajes seleccionados, la retención, el modelo, los límites,
+el recuento ni la única llamada de resumen. El contenido no compatible o demasiado
+grande falla explícitamente; no se descarta evidencia ni se añaden llamadas.
+Recibir toda la evidencia no garantiza que el modelo conserve todos los hechos.
+Consulta el [contrato completo en inglés](https://goa.design/docs/2-goa-ai/runtime/#evidence-supplied-to-the-summary-model).
+
 ### Validación de ordenación de mensajes en Bedrock
 
 Cuando se usa AWS Bedrock con el modo de pensamiento habilitado, el runtime valida las restricciones de ordenación de mensajes antes de enviar peticiones. Bedrock requiere:

--- a/content/fr/docs/2-goa-ai/runtime.md
+++ b/content/fr/docs/2-goa-ai/runtime.md
@@ -1475,6 +1475,38 @@ mélangés ou ambigus. Ne combinez pas `PlannerModelClient.Stream(...)` avec
 `planner.ConsumeStream` ; choisissez un seul propriétaire du flux par tour du
 planificateur.
 
+### Éléments fournis au modèle de résumé
+
+`Compress` fournit les anciens messages sélectionnés comme éléments à résumer,
+et non comme une conversation à poursuivre. Le texte, les arguments et résultats
+complets des outils, leurs identifiants, l'état et le texte intégral des erreurs,
+ainsi que les champs des citations sont cités au format JSON canonique de
+`model.Message`. Les rôles, positions et ordre sont conservés, sans sélection,
+arrondi ni suppression des valeurs répétées. Le modèle juge leur pertinence.
+
+`WithSummaryPrompt` insère toujours la transcription textuelle complète dans
+`%s`. Les images et documents sont joints une seule fois comme contenu natif dans
+le même appel : un message de pièces jointes par message utilisateur original
+contenant des médias, avec des références à leurs positions. Aucun outil n'est
+proposé à l'exécution ; les documents ne sont ni extraits ni récupérés.
+`Message.Meta`, le raisonnement, les points de contrôle du cache et les signatures
+de raisonnement des outils ne sont pas copiés dans cette nouvelle requête.
+L'historique original, les messages conservés exactement, les diagnostics et les
+erreurs complètes restent inchangés.
+
+Le résumé conserve son rôle et sa représentation textuelle. Les phrases citées
+et tous leurs champs d'attribution sont conservés dans l'ordre sous forme
+d'enregistrements cités. Les coordonnées appartiennent à la requête qui les a
+produites. Si le nouveau résumé contient des citations et utilisait des documents
+natifs, il décrit aussi leur disposition, sans corps de document, réattribution
+de `DocumentIndex` ni lien inventé.
+
+La sélection des messages, la rétention, le modèle, les limites, le comptage et
+l'unique appel de résumé ne changent pas. Un contenu non pris en charge ou trop
+volumineux échoue explicitement, sans suppression d'éléments ni appel ajouté.
+Recevoir tous les éléments ne garantit pas que le modèle retiendra chaque fait.
+Voir le [contrat complet en anglais](https://goa.design/docs/2-goa-ai/runtime/#evidence-supplied-to-the-summary-model).
+
 ### Validation de l'ordre des messages Bedrock
 
 Lors de l'utilisation de AWS Bedrock avec le mode réflexion activé, le moteur d'exécution valide les contraintes d'ordre des messages avant d'envoyer les requêtes. Bedrock nécessite :

--- a/content/it/docs/2-goa-ai/runtime.md
+++ b/content/it/docs/2-goa-ai/runtime.md
@@ -1321,6 +1321,36 @@ non produce una risposta accettata. Non mescolare
 `PlannerModelClient.Stream(...)` con `planner.ConsumeStream`; scegliere un solo
 proprietario del flusso per turno del planner.
 
+### Evidenze fornite al modello di riepilogo
+
+`Compress` fornisce i messaggi precedenti selezionati come evidenze da riassumere,
+non come una conversazione da continuare. Testo, argomenti e risultati completi
+degli strumenti, identificatori, stato e testo integrale degli errori e campi
+delle citazioni vengono riportati nel formato JSON canonico di `model.Message`.
+Ruoli, posizioni e ordine restano espliciti, senza selezionare, arrotondare o
+eliminare valori ripetuti. Il modello decide quali fatti sono rilevanti.
+
+`WithSummaryPrompt` continua a inserire la trascrizione testuale completa in
+`%s`. Immagini e documenti vengono allegati una sola volta come contenuto nativo
+nella stessa chiamata: un messaggio di allegati per ogni messaggio utente
+originale contenente media, con riferimenti alle posizioni originali. Non vengono
+offerti strumenti da eseguire né estratti o recuperati documenti. `Message.Meta`,
+ragionamento, checkpoint della cache e firme di ragionamento degli strumenti non
+vengono copiati nella nuova richiesta. Cronologia originale, messaggi conservati
+esattamente, diagnostica ed errori completi rimangono invariati.
+
+Il riepilogo mantiene ruolo e rappresentazione testuale. Conserva nell'ordine le
+frasi citate e tutti i campi di attribuzione come record citati. Le coordinate
+appartengono alla richiesta che le ha prodotte. Se il nuovo riepilogo contiene
+citazioni e ha utilizzato documenti nativi, descrive anche la loro disposizione,
+senza corpi dei documenti, riassegnazioni di `DocumentIndex` o collegamenti inventati.
+
+Non cambiano selezione dei messaggi, conservazione, modello, limiti, conteggio e
+singola chiamata di riepilogo. Contenuti non supportati o troppo grandi producono
+errori espliciti: non si eliminano evidenze né si aggiungono chiamate. Ricevere
+tutte le evidenze non garantisce che il modello conservi ogni fatto nel testo.
+Vedere il [contratto completo in inglese](https://goa.design/docs/2-goa-ai/runtime/#evidence-supplied-to-the-summary-model).
+
 ### Convalida dell'ordinamento dei messaggi di Bedrock
 
 Quando si usa AWS Bedrock con la modalità di pensiero abilitata, il runtime convalida i vincoli di ordine dei messaggi prima di inviare le richieste. Bedrock richiede:

--- a/content/ja/docs/2-goa-ai/runtime.md
+++ b/content/ja/docs/2-goa-ai/runtime.md
@@ -1312,6 +1312,33 @@ history compression では、summary 開始条件と exact recent history の保
 
 Bedrock Runtime は structured-output request を count できません。Claude Opus 4.7、Sonnet 5、Mythos 5 は AWS の別 Mantle count endpoint を必要とするため、Bedrock adapter はこれらで `model.ErrTokenCountingUnsupported` を返します。生成 agent config の `HistoryCompression` により、design default を変えず deployment ごとに上書きできます。
 
+#### 要約モデルに渡す根拠
+
+`Compress` は、選択した過去のメッセージを、続行すべき会話ではなく要約対象の
+根拠として渡します。テキスト、ツールの完全な引数と結果、呼び出しと結果の ID、
+エラー状態と全文、引用の各フィールドを、`model.Message` の標準 JSON 形式で
+引用します。元のロール、位置、順序を保持し、値の選別、丸め、重複除去はしません。
+どの事実が重要かはモデルが判断します。
+
+`WithSummaryPrompt` は引き続き `%s` に完全な引用テキストを挿入します。
+画像と文書は同じ呼び出し内で、ネイティブの添付として一度だけ渡します。
+メディアを含む元のユーザーメッセージごとに添付メッセージを一つ作り、元の
+メッセージとパートの位置を示します。実行可能なツールは提示せず、文書本文の
+抽出や取得もしません。`Message.Meta`、思考内容、キャッシュのチェックポイント、
+ツールの思考署名は新しい要約リクエストにはコピーしません。元の履歴、正確に
+保持するメッセージ、診断情報、ツールのエラー全文は変更しません。
+
+返す要約のロールとテキスト形式は維持します。引用付きの文とすべての出典情報を、
+元の順序で引用レコードとして残します。引用の座標は、それを生成したリクエストに
+属します。新しい要約が引用を含み、そのリクエストでネイティブ文書を使った場合は、
+文書の配置も記録します。本文を複製せず、`DocumentIndex` を再割り当てせず、
+不明な出典からファイルへのリンクを推測しません。
+
+対象メッセージ、履歴の保持、モデル、上限、トークン計数、要約が一回の呼び出しで
+あることは変わりません。未対応または大きすぎる入力は明示的なエラーとなり、根拠の
+削除や追加呼び出しで回避しません。完全な根拠を渡しても、モデルがすべての事実を
+要約に残す保証にはなりません。詳細は[英語の契約](https://goa.design/docs/2-goa-ai/runtime/#evidence-supplied-to-the-summary-model)を参照してください。
+
 ### 生成 system の協調 release
 
 compatible release は透過的に rollout できます。incompatible な生成 contract 変更には coordinated drain と cutover が必要です。checkpoint version、generated codec、required tool name、worker retention の要件は [production rollout contract](../production/#transparent-rollouts) を参照してください。


### PR DESCRIPTION
The history-compression documentation now explains what the summary model receives and what the runtime preserves in its returned text. This accompanies goadesign/goa-ai#329; it documents that change without introducing a separate runtime policy.

Previously the pages described retention and token counting but did not explain the loss of tool evidence or cited sentences in summaries. The new English subsection describes complete quoted text/tool/citation records, native attachments grouped by their original user messages, and the distinction between original-history preservation and metadata excluded from a new summary request. Spanish, French, Italian, and Japanese provide concise matching explanations and link to the detailed English contract.

The documentation also explains the limits: the model still chooses relevance; complete evidence does not guarantee lossless prose. Existing model, selection, thresholds, counting behavior, and single-summary-call contracts remain unchanged. Unsupported or oversized input fails explicitly. Citation coordinates are preserved, not guessed into file links or reassigned to another request.

Only five runtime Markdown pages change. There are no API, dependency, routing, or persisted-data changes and no migration. Publish with or after the framework change so the new behavior is available; reverting this documentation does not change runtime behavior. This PR does not document the separate proposed summary-plus-history size-selection change.

Validation: production Hugo build passed; all 70 JavaScript tests passed; the built English anchor and all four translated links were checked directly; git diff --check passed. Independent review verified every addition against the corrected framework implementation and checked the built links again. Existing package advisories and unrelated token-count documentation drift were left unchanged.

Start with the English “Evidence supplied to the summary model” subsection and then its four translated counterparts. The runtime implementation and its deterministic provider-format tests are in the linked framework PR; no model-answer quality claim follows from these documentation checks.
