### PR TITLE
Document v8 continuation and tool recovery contracts

### DIFF
--- a/content/en/docs/2-goa-ai/production.md
+++ b/content/en/docs/2-goa-ai/production.md
@@ -429,9 +429,13 @@ runtime release and should be deleted after the cutover is verified.
    active.
 2. Run the migration in verification mode and correct every rejected record.
 3. Apply the conversion, then verify the schema, indexes, session state, run
-   metadata, v7 checkpoints, and immutable run records.
+   metadata, current-format checkpoints, and immutable run records.
 4. Deploy the storage owner and all workers together, then remove the temporary
    migration program.
+
+This physical storage conversion does not translate suspension formats. Saved
+work must separately satisfy the [current continuation contract](../runtime/#external-input-and-workflow-continuations).
+Keep completed history and stored tool results intact.
 
 Once the conversion starts, rollback is a database restore, not a mixed-version
 deployment. If conversion or verification fails, keep runtime traffic closed
@@ -544,10 +548,10 @@ workflow when it requests human or external input and stores a private
 checkpoint under the completed run ID. The accepted answer starts a new
 workflow on the current worker version. The new version must therefore accept
 the saved checkpoint format, generated result codecs, and required tool names.
-The current runtime accepts only `goa-ai.run-suspension.v7`; earlier checkpoint
-versions are rejected. Migrate or remove older saved checkpoints before
-promoting the release. Worker versioning cannot translate incompatible stored
-values.
+The current runtime accepts only `goa-ai.run-suspension.v8`; earlier checkpoint
+versions are rejected. Follow [Generated contract changes](#generated-contract-changes)
+for an incompatible upgrade rather than this overlapping-worker procedure.
+Worker versioning cannot translate incompatible stored values.
 
 The rest of the application must preserve availability during the same
 overlap:
@@ -607,12 +611,21 @@ all agents and completions, drain or stop affected work, and deploy the runtime,
 workers, and callers as one coordinated release. Goa-AI does not provide a
 dual-read mode for generated runtime contracts.
 
-The runtime accepts only the exact `goa-ai.run-suspension.v7` schema. Planners
+The runtime accepts only the exact `goa-ai.run-suspension.v8` schema. Planners
 that wait for questions, clarification, or external tools preserve the
 provider's `ModelToolCallID`; the workflow assigns the separate runtime
 `ToolCallID` before it saves the suspension. Other suspension schemas do not
-resume. A future schema change must inventory and retire incompatible saved
-work before the coordinated release; do not add a dual reader or infer fields.
+resume. Version eight also retains the advertised choices when an accepted
+recovery plan waits for input. Follow the host-owned preservation and
+resumability decision in [External Input and Workflow Continuations](../runtime/#external-input-and-workflow-continuations)
+before replacing workers that own older saved work; do not add a dual reader or
+infer fields.
+
+Update cooperating workers for every workflow and activity queue, generated
+packages, and callers before accepting new work. Once new workers save v8
+suspensions, older workers cannot resume those suspensions: reverting an image
+alone does not restore resumability. Preserve completed history and stored tool
+results; any physical storage conversion is a separate host-owned operation.
 
 #### Release verification
 

--- a/content/en/docs/2-goa-ai/runtime.md
+++ b/content/en/docs/2-goa-ai/runtime.md
@@ -1035,10 +1035,17 @@ never send them to an untrusted client. Goa-AI validates the checkpoint's
 version and pending request, restores saved payloads through the current
 generated codecs, and resumes planning.
 
-The accepted checkpoint format is exactly `goa-ai.run-suspension.v7`. Goa-AI
-rejects every earlier version instead of guessing how to translate it. A host
-upgrading from an earlier format must migrate or remove those suspended runs
-before it accepts continuation traffic on the new runtime.
+The accepted checkpoint format is exactly `goa-ai.run-suspension.v8`. Version
+eight saves the advertised tool names when an accepted recovery plan waits for
+input: failed tool names alone cannot reconstruct the other choices offered
+on that turn. Continuation preserves those choices while still checking the
+current agent definition and execution policy.
+
+Goa-AI rejects every earlier checkpoint version. Before upgrading, finish
+old-format saved work under its owning runtime. If any must remain unfinished,
+the host must explicitly decide how to preserve it and whether it will remain
+resumable; this runtime cannot resume it. The framework supplies no conversion
+command and never automatically deletes, cancels, or rewrites saved work.
 
 When an answer completes a model-authored tool call from the earlier workflow,
 the new `tool_end` event has two distinct run identities:
@@ -1177,7 +1184,7 @@ These contracts are separate:
 | `ToolSpec.Meta` | A tool, for every run | Inert generated annotations whose semantics belong to the named consumer; metadata alone changes no runtime behavior. |
 | `ToolSpec.Bookkeeping` | A tool, for every run | The call is a durable control record whose success does not require another planner turn. It consumes no retrieval or consecutive-failure budget. |
 | `ToolSpec.TerminalRun` | A tool, for every run | Successful execution itself ends the run. It automatically implies bookkeeping. |
-| `ToolFailure.Recovery.Action` | One failed result | Selects same-tool correction, replanning without the failed tool, or finalization. |
+| `ToolFailure.Recovery.Action` | One failed result | Selects correction with the failed tool still available, replanning without it, or finalization. |
 | `PlanResult.SynthesizeAfterTools` | One selected batch | If the batch has no recoverable failure, the next planner turn must answer. |
 | `PlanResumeInput.SynthesisOnly` | One planner activity | Return a final answer; tool calls are invalid. |
 | `PlanResumeInput.Finalize` | Runtime-forced termination | A cap or deadline has prohibited normal work. |
@@ -1206,6 +1213,19 @@ Each recoverable `ToolFailure` also selects a `Recovery.Action`:
   use another advertised tool, wait for input, or answer.
 - `finish` removes all tools and requires a final answer from the available
   evidence.
+
+An ordinary `correct_call` turn combines the current agent's executable tools
+with the exact failed-tool contracts. Matching names are deduplicated;
+conflicting contracts, missing executable registrations, and revoked tools
+fail before a model call. Caller restrictions, run tag restrictions, and
+recovery exclusions still apply. A denied correction tool causes an error; the
+runtime does not silently drop it or restore it after filtering. Downstream
+authorization still checks every executed call.
+
+Unfinished queries retain their runtime-generated continuation actions; failed
+requests do not create continuations. Forced finalization offers only the exact
+failed terminal tool for correction, and synthesis-only turns remain tool-free.
+After correction, normal turns return to the current agent's tools.
 
 The workflow owns model-facing correction evidence. It replaces executor-
 supplied prior input and examples with the original provider call and the
@@ -1380,6 +1400,16 @@ the whole operation; Goa-AI never truncates, repairs, or coerces model data.
 `ValidatedStream` must be drained to `io.EOF`. Only then does `Response()`
 return the accepted canonical response. An incomplete, malformed, or
 contradictory stream returns an error and no accepted response.
+
+Complete tool calls must satisfy their advertised schema and any attached generated
+decoder before planner code can observe them. When a schema rejection has one
+unique deepest cause matching generated array field metadata, correction
+guidance names that array's inclusive minimum or maximum, for example:
+`Field "items" must contain at most 3 items.` Ambiguous or unsupported causes
+retain generic guidance. These are bounds on that one submitted array, not a
+limit on the complete run. The arguments remain rejected before execution;
+Goa-AI does not split, truncate, or rewrite them. The original validation error,
+acceptance rules, and configured recovery-turn limit remain unchanged.
 
 ### Provider Adapters
 

--- a/content/en/docs/2-goa-ai/testing.md
+++ b/content/en/docs/2-goa-ai/testing.md
@@ -294,8 +294,15 @@ Test the hook codec separately: decoders for `RunStarted`, `RunSuspended`,
 `RunCompleted`, and `ChildRunLinked` must reject `null`, unknown fields, and a
 second trailing JSON value.
 
-Continuation tests should accept `goa-ai.run-suspension.v7` and reject every
+Continuation tests should accept `goa-ai.run-suspension.v8` and reject every
 earlier checkpoint version before restoring payloads or calling a planner.
+For a recovery plan that waits for input, verify that continuation retains all
+advertised alternatives, not just the failed tool. Also verify that the current
+agent definition and execution policy reject removed, conflicting, or denied
+tools before planning; saved choices do not grant permanent authorization.
+Keep positive checks for allowed alternatives, unfinished-query continuations,
+terminal-only forced correction, and tool-free synthesis. These contract tests
+prove which actions are legal, not the quality of a live model's choice.
 
 ---
 

--- a/content/es/docs/2-goa-ai/production.md
+++ b/content/es/docs/2-goa-ai/production.md
@@ -417,8 +417,13 @@ no forma parte del release normal y se elimina tras verificar el cambio.
 1. Crea y verifica una copia de seguridad y confirma que no haya writers.
 2. Ejecuta la migración en modo de verificación y corrige cada registro rechazado.
 3. Aplica la conversión y verifica esquema, índices, sesiones, metadatos,
-   checkpoints v7 y registros inmutables.
+   checkpoints del formato actual y registros inmutables.
 4. Despliega juntos al propietario y a todos los workers, y elimina el programa.
+
+Esta conversión del almacenamiento físico no traduce los formatos de
+suspensión. El trabajo guardado debe cumplir por separado el
+[contrato actual de continuación](../runtime/#entrada-externa-y-continuaciones-de-workflow).
+Conserva intactos el historial completado y los resultados guardados de herramientas.
 
 Una vez iniciada la conversión, el rollback restaura la copia completa. No
 ejecutes writers antiguos sobre una base parcialmente convertida.
@@ -493,13 +498,23 @@ runtime, los workers y los llamadores. Goa-AI no ofrece lectura dual para los
 contratos generados del runtime.
 
 El runtime acepta únicamente el esquema exacto
-`goa-ai.run-suspension.v7`. Los planificadores que esperan preguntas,
+`goa-ai.run-suspension.v8`. Los planificadores que esperan preguntas,
 aclaraciones o herramientas externas conservan el `ModelToolCallID` del
 proveedor; el workflow asigna el `ToolCallID` independiente del runtime antes
 de guardar la suspensión. Las suspensiones con otros esquemas no se reanudan.
-Antes de cambiar este esquema en el futuro, inventaría y retira el trabajo
-guardado incompatible durante el despliegue coordinado; no añadas un lector
-dual ni deduzcas campos ausentes.
+La versión ocho también conserva las opciones anunciadas cuando un plan de
+recuperación aceptado espera una entrada. Antes de reemplazar los workers que
+poseen trabajo guardado anterior, aplica la decisión del host sobre conservación
+y posibilidad de reanudar descrita en
+[Entrada externa y continuaciones de workflow](../runtime/#entrada-externa-y-continuaciones-de-workflow);
+no añadas un lector dual ni deduzcas campos ausentes.
+
+Antes de aceptar trabajo nuevo, actualiza conjuntamente los workers de todas
+las colas de workflows y actividades, los paquetes generados y los llamadores.
+Una vez que los nuevos workers guardan suspensiones v8, los anteriores no
+pueden reanudarlas: revertir solo una imagen no recupera esa capacidad.
+Conserva el historial completado y los resultados guardados de herramientas;
+cualquier conversión del almacenamiento físico es una operación separada del host.
 
 ### Buenas prácticas
 

--- a/content/es/docs/2-goa-ai/runtime.md
+++ b/content/es/docs/2-goa-ai/runtime.md
@@ -999,10 +999,19 @@ pueden contener una copia de ese checkpoint y la transcripción completa.
 Guárdalos únicamente en almacenamiento de aplicación confiable y con acceso
 controlado; nunca los envíes a un cliente no confiable.
 
-El único formato aceptado es `goa-ai.run-suspension.v7`. Goa-AI rechaza todas
-las versiones anteriores en lugar de adivinar cómo traducirlas. Antes de
-aceptar continuaciones con el nuevo runtime, el host debe migrar o eliminar las
-ejecuciones suspendidas que usen un formato anterior.
+El único formato aceptado es `goa-ai.run-suspension.v8`. La versión ocho guarda
+los nombres de las herramientas anunciadas cuando un plan de recuperación
+aceptado espera una entrada: los nombres de las herramientas fallidas no bastan
+para reconstruir las otras opciones ofrecidas en ese turno. La continuación
+conserva esas opciones y sigue comprobando la definición actual del agente y la
+política de ejecución.
+
+Goa-AI rechaza todas las versiones anteriores del checkpoint. Antes de
+actualizar, termina el trabajo guardado con el formato anterior en el runtime
+que lo posee. Si debe quedar trabajo sin terminar, el host debe decidir
+explícitamente cómo conservarlo y si seguirá siendo reanudable; este runtime
+no puede reanudarlo. El framework no proporciona un comando de conversión ni
+elimina, cancela o reescribe automáticamente el trabajo guardado.
 
 - Los llamadores proporcionan exactamente uno de estos valores: `Success`, con
   el **JSON de resultado canónico en bruto** y `Bounds` opcional, o `Failure`,
@@ -1134,7 +1143,7 @@ Estos contratos son independientes:
 | `ToolSpec.Meta` | Una herramienta, para cada ejecución | Anotaciones generadas e inertes cuyas semánticas pertenecen al consumidor identificado; los metadatos por sí solos no cambian el runtime. |
 | `ToolSpec.Bookkeeping` | Una herramienta, para cada ejecución | La llamada es un registro de control duradero cuyo éxito no necesita otro turno del planner. No consume presupuesto de recuperación ni de fallos consecutivos. |
 | `ToolSpec.TerminalRun` | Una herramienta, para cada ejecución | La ejecución correcta finaliza por sí misma la ejecución e implica automáticamente bookkeeping. |
-| `ToolFailure.Recovery.Action` | Un resultado fallido | Selecciona la corrección con la misma herramienta, la replanificación sin ella o la finalización. |
+| `ToolFailure.Recovery.Action` | Un resultado fallido | Selecciona la corrección manteniendo disponible la herramienta fallida, la replanificación sin ella o la finalización. |
 | `PlanResult.SynthesizeAfterTools` | Un lote seleccionado | Si el lote no tiene un fallo recuperable, el siguiente turno del planner debe responder. |
 | `PlanResumeInput.SynthesisOnly` | Una actividad del planner | Devuelve una respuesta final; las llamadas a herramientas no son válidas. |
 | `PlanResumeInput.Finalize` | Finalización forzada por el runtime | Un límite o deadline ha prohibido el trabajo normal. |
@@ -1163,6 +1172,22 @@ Cada `ToolFailure` recuperable también selecciona una `Recovery.Action`:
   planner puede usar otra herramienta anunciada, esperar una entrada o responder.
 - `finish` elimina todas las herramientas y exige una respuesta final basada en
   la evidencia disponible.
+
+Un turno normal de `correct_call` combina las herramientas ejecutables del
+agente actual con los contratos exactos de las herramientas fallidas. Elimina
+duplicados cuando coinciden los nombres y contratos; los contratos en conflicto,
+los registros de ejecución ausentes y las herramientas revocadas producen un
+error antes de llamar al modelo. Siguen aplicándose las restricciones del
+llamador, las de etiquetas de la ejecución y las exclusiones de recuperación.
+Una herramienta de corrección denegada provoca un error; el runtime no la
+descarta silenciosamente ni la restaura después del filtrado. La autorización
+en el servicio ejecutor sigue comprobando cada llamada.
+
+Las consultas sin terminar conservan sus acciones de continuación generadas
+por el runtime; las solicitudes fallidas no crean continuaciones. La
+finalización forzada solo ofrece para corrección la herramienta terminal exacta
+que falló, y los turnos de solo síntesis siguen sin herramientas. Después de la
+corrección, los turnos normales vuelven a las herramientas del agente actual.
 
 El runtime registra el catálogo exacto de herramientas mostrado en un turno de
 recuperación y rechaza cualquier llamada ejecutable que quede fuera de él,
@@ -1298,6 +1323,18 @@ type Client interface {
     Stream(ctx context.Context, req *Request) (Streamer, error)
 }
 ```
+
+Las llamadas completas a herramientas deben cumplir su esquema anunciado y el
+decodificador generado asociado, si lo hay, antes de que el planner pueda observarlas.
+Cuando un rechazo del esquema tiene una sola causa en el nivel más profundo y
+esta coincide con los metadatos generados de un campo de tipo array, la guía de
+corrección indica el mínimo o máximo inclusivo de ese array, por ejemplo:
+`Field "items" must contain at most 3 items.` Las causas ambiguas o no
+compatibles conservan una guía genérica. Estos límites corresponden a ese único
+array enviado, no a la ejecución completa. Los argumentos siguen rechazados
+antes de la ejecución; Goa-AI no los divide, recorta ni reescribe. El error de
+validación original, las reglas de aceptación y el límite configurado de turnos
+de recuperación no cambian.
 
 ### Adaptadores de proveedor
 

--- a/content/es/docs/2-goa-ai/testing.md
+++ b/content/es/docs/2-goa-ai/testing.md
@@ -294,9 +294,18 @@ Prueba por separado el codec de hooks: los decodificadores de `RunStarted`,
 `RunSuspended`, `RunCompleted` y `ChildRunLinked` deben rechazar `null`, campos
 desconocidos y un segundo valor JSON al final.
 
-Las pruebas de continuación deben aceptar `goa-ai.run-suspension.v7` y rechazar
+Las pruebas de continuación deben aceptar `goa-ai.run-suspension.v8` y rechazar
 todas las versiones anteriores antes de restaurar payloads o llamar al
 planificador.
+Para un plan de recuperación que espera una entrada, verifica que la
+continuación conserve todas las alternativas anunciadas, no solo la herramienta
+fallida. Comprueba también que la definición actual del agente y la política de
+ejecución rechacen herramientas eliminadas, en conflicto o denegadas antes de
+planificar; las opciones guardadas no conceden autorización permanente.
+Conserva pruebas positivas para las alternativas permitidas, las continuaciones
+de consultas sin terminar, la corrección forzada solo con herramientas
+terminales y la síntesis sin herramientas. Estas pruebas de contrato demuestran
+qué acciones son legales, no la calidad de la elección de un modelo real.
 
 ---
 

--- a/content/fr/docs/2-goa-ai/production.md
+++ b/content/fr/docs/2-goa-ai/production.md
@@ -418,8 +418,13 @@ après vérification.
 1. Créez et vérifiez une sauvegarde, puis confirmez l’absence de writers.
 2. Exécutez la migration en mode vérification et corrigez chaque rejet.
 3. Appliquez la conversion et vérifiez schéma, index, sessions, métadonnées,
-   checkpoints v7 et enregistrements immuables.
+   points de reprise au format actuel et enregistrements immuables.
 4. Déployez ensemble le propriétaire et tous les workers, puis supprimez le programme.
+
+Cette conversion du stockage physique ne traduit pas les formats de suspension.
+Le travail enregistré doit satisfaire séparément le
+[contrat actuel de continuation](../runtime/#entrées-externes-et-continuations-de-workflow).
+Conservez intacts l'historique terminé et les résultats d'outils enregistrés.
 
 Après le début de la conversion, le rollback restaure la sauvegarde complète.
 N’exécutez pas d’anciens writers sur une base partiellement convertie.
@@ -532,6 +537,11 @@ courante. Cette version doit donc rester compatible avec la version du point
 de reprise, les codecs générés et les noms d'outils requis. Le versionnement
 des workers ne traduit pas des valeurs enregistrées incompatibles.
 
+Le runtime actuel accepte uniquement `goa-ai.run-suspension.v8` et rejette les
+versions précédentes. Pour une mise à niveau incompatible, suivez la section
+« Changements de contrats générés » ci-dessous plutôt que cette procédure de
+chevauchement des workers.
+
 Le reste de l'application doit rester disponible pendant le chevauchement :
 
 - chaque service en aval conserve au moins un endpoint prêt ; utilisez un
@@ -577,13 +587,24 @@ concerné, puis déployez ensemble le runtime, les workers et les appelants.
 Goa-AI n'offre aucun mode de double lecture pour ses contrats générés.
 
 Le runtime accepte uniquement le schéma exact
-`goa-ai.run-suspension.v7`. Les planificateurs qui attendent des questions, une
+`goa-ai.run-suspension.v8`. Les planificateurs qui attendent des questions, une
 clarification ou des outils externes conservent le `ModelToolCallID` du
 fournisseur ; le workflow attribue un `ToolCallID` d'exécution distinct avant
 d'enregistrer la suspension. Aucun autre schéma de suspension ne peut reprendre.
-Un changement futur doit inventorier et retirer le travail enregistré
-incompatible avant la version coordonnée ; n'ajoutez ni double lecteur ni
-déduction de champs.
+La version huit conserve aussi les choix annoncés lorsqu'un plan de
+récupération accepté attend une entrée. Avant de remplacer les workers qui
+possèdent du travail enregistré dans l'ancien format, appliquez la décision de
+l'hôte sur sa conservation et sa reprise décrite dans
+[Entrées externes et continuations de workflow](../runtime/#entrées-externes-et-continuations-de-workflow) ;
+n'ajoutez ni double lecteur ni déduction de champs.
+
+Mettez à jour ensemble les workers de toutes les files de workflows et
+d'activités, les packages générés et les appelants avant d'accepter du nouveau
+travail. Dès que les nouveaux workers enregistrent des suspensions v8, les
+anciens ne peuvent pas les reprendre : rétablir une image seule ne restaure
+pas cette capacité. Conservez l'historique terminé et les résultats d'outils
+enregistrés ; toute conversion du stockage physique reste une opération
+distincte appartenant à l'hôte.
 
 #### Vérification d'une version
 

--- a/content/fr/docs/2-goa-ai/runtime.md
+++ b/content/fr/docs/2-goa-ai/runtime.md
@@ -1003,10 +1003,18 @@ octets de `PreparedRun` peuvent contenir une copie de ce point de reprise et la
 transcription complète. Conservez-les uniquement dans un stockage applicatif
 fiable avec un accès contrôlé ; ne les envoyez jamais à un client non fiable.
 
-Le seul format accepté est `goa-ai.run-suspension.v7`. Goa-AI rejette toutes les
-versions précédentes au lieu de deviner comment les traduire. Avant d’accepter
-des continuations avec le nouveau runtime, l’hôte doit migrer ou supprimer les
-exécutions suspendues qui utilisent un ancien format.
+Le seul format accepté est `goa-ai.run-suspension.v8`. La version huit conserve
+les noms des outils annoncés lorsqu'un plan de récupération accepté attend une
+entrée : les noms des outils en échec ne suffisent pas à reconstruire les autres
+choix proposés pendant ce tour. La continuation conserve ces choix tout en
+vérifiant la définition actuelle de l'agent et la politique d'exécution.
+
+Goa-AI rejette toutes les versions précédentes du point de reprise. Avant la
+mise à niveau, terminez le travail enregistré dans l'ancien format avec le
+runtime qui le possède. Si du travail doit rester inachevé, l'hôte doit décider
+explicitement comment le conserver et s'il restera reprenable ; ce runtime ne
+peut pas le reprendre. Le framework ne fournit aucune commande de conversion
+et ne supprime, n'annule ni ne réécrit automatiquement le travail enregistré.
 
 Lorsqu’une réponse termine un appel d’outil créé par le modèle dans le workflow
 précédent, le nouvel événement `tool_end` porte deux identités :
@@ -1134,7 +1142,7 @@ Ces contrats sont distincts :
 | `ToolSpec.Meta` | Un outil, pour chaque exécution | Annotations générées et inertes dont la sémantique appartient au consommateur nommé ; les métadonnées seules ne changent pas le runtime. |
 | `ToolSpec.Bookkeeping` | Un outil, pour chaque exécution | L'appel est un enregistrement de contrôle durable dont le succès ne requiert pas un autre tour du planificateur. Il ne consomme aucun budget de récupération ou d'échecs consécutifs. |
 | `ToolSpec.TerminalRun` | Un outil, pour chaque exécution | Le succès termine lui-même l'exécution et implique automatiquement la comptabilité. |
-| `ToolFailure.Recovery.Action` | Un résultat en échec | Définit la prochaine transition autorisée : corriger le même appel, replanifier sans l'outil en échec ou terminer avec les éléments disponibles. |
+| `ToolFailure.Recovery.Action` | Un résultat en échec | Choisit la correction en gardant l'outil en échec disponible, la replanification sans cet outil ou la finalisation. |
 | `PlanResult.SynthesizeAfterTools` | Un lot sélectionné | Si le lot n'a aucun échec récupérable, le prochain tour du planificateur doit répondre. |
 | `PlanResumeInput.SynthesisOnly` | Une activité du planificateur | Renvoyer une réponse finale ; les appels d'outils sont invalides. |
 | `PlanResumeInput.Finalize` | Arrêt imposé par le runtime | Un plafond ou une deadline interdit le travail normal. |
@@ -1166,6 +1174,22 @@ Chaque `ToolFailure` récupérable sélectionne aussi une `Recovery.Action` :
   utiliser un autre outil annoncé, attendre une entrée ou répondre.
 - `finish` retire tous les outils et exige une réponse finale fondée sur les
   éléments disponibles.
+
+Un tour ordinaire de `correct_call` combine les outils exécutables de l'agent
+actuel avec les contrats exacts des outils en échec. Les noms et contrats
+identiques sont dédupliqués ; les contrats contradictoires, les enregistrements
+d'exécution manquants et les outils révoqués provoquent un échec avant l'appel
+au modèle. Les restrictions de l'appelant, celles des étiquettes de l'exécution
+et les exclusions de récupération restent applicables. Un outil de correction
+interdit provoque une erreur ; le runtime ne l'écarte pas silencieusement et ne
+le rétablit pas après filtrage. L'autorisation du service exécutant vérifie
+toujours chaque appel.
+
+Les requêtes inachevées conservent leurs actions de continuation générées par le
+runtime ; les demandes en échec ne créent pas de continuation. La finalisation
+forcée ne propose à la correction que l'outil terminal exact en échec, et les
+tours de synthèse seule restent sans outils. Après la correction, les tours
+normaux reviennent aux outils de l'agent actuel.
 
 Le workflow possède les informations de correction visibles par le modèle.
 Avant d'enregistrer l'échec, il remplace l'entrée antérieure et l'exemple
@@ -1347,6 +1371,18 @@ tronque, ne répare et ne convertit jamais les données du modèle.
 Un `ValidatedStream` doit être lu jusqu'à `io.EOF`. Ce n'est qu'alors que
 `Response()` rend la réponse canonique acceptée. Un flux incomplet, mal formé
 ou contradictoire renvoie une erreur sans réponse acceptée.
+
+Les appels d'outils complets doivent satisfaire leur schéma annoncé et leur
+décodeur généré associé, s'il existe, avant d'être transmis au planificateur. Lorsqu'un rejet
+de schéma possède une seule cause au niveau le plus profond et que celle-ci
+correspond aux métadonnées générées d'un champ tableau, l'instruction de
+correction indique le minimum ou le maximum inclusif de ce tableau, par exemple :
+`Field "items" must contain at most 3 items.` Les causes ambiguës ou non prises
+en charge conservent une instruction générique. Ces bornes s'appliquent à ce
+seul tableau soumis, pas à l'exécution entière. Les arguments restent rejetés
+avant l'exécution ; Goa-AI ne les découpe, ne les tronque ni ne les réécrit.
+L'erreur de validation d'origine, les règles d'acceptation et la limite
+configurée de tours de récupération restent inchangées.
 
 ### Adaptateurs de fournisseur
 

--- a/content/fr/docs/2-goa-ai/testing.md
+++ b/content/fr/docs/2-goa-ai/testing.md
@@ -304,9 +304,18 @@ Testez séparément le codec des hooks : les décodeurs de `RunStarted`,
 `RunSuspended`, `RunCompleted` et `ChildRunLinked` doivent rejeter `null`, les
 champs inconnus et une seconde valeur JSON finale.
 
-Les tests de continuation doivent accepter `goa-ai.run-suspension.v7` et rejeter
+Les tests de continuation doivent accepter `goa-ai.run-suspension.v8` et rejeter
 toutes les versions précédentes avant de restaurer les payloads ou d’appeler le
 planificateur.
+Pour un plan de récupération qui attend une entrée, vérifiez que la continuation
+conserve toutes les alternatives annoncées, pas seulement l'outil en échec.
+Vérifiez aussi que la définition actuelle de l'agent et la politique d'exécution
+rejettent avant la planification les outils supprimés, contradictoires ou
+interdits ; les choix enregistrés n'accordent pas une autorisation permanente.
+Conservez des tests positifs pour les alternatives autorisées, les continuations
+de requêtes inachevées, la correction forcée limitée aux outils terminaux et la
+synthèse sans outils. Ces tests de contrat prouvent quelles actions sont
+permises, pas la qualité du choix d'un modèle réel.
 
 ---
 

--- a/content/it/docs/2-goa-ai/production.md
+++ b/content/it/docs/2-goa-ai/production.md
@@ -417,8 +417,13 @@ programma; non fa parte del release normale e va eliminato dopo la verifica.
 1. Creare e verificare un backup e confermare che non vi siano writer.
 2. Eseguire la migrazione in modalità verifica e correggere ogni record rifiutato.
 3. Applicare la conversione e verificare schema, indici, sessioni, metadati,
-   checkpoint v7 e record immutabili.
+   checkpoint nel formato attuale e record immutabili.
 4. Distribuire insieme proprietario e worker, quindi eliminare il programma.
+
+Questa conversione dello storage fisico non traduce i formati di sospensione.
+Il lavoro salvato deve rispettare separatamente il
+[contratto attuale di continuazione](../runtime/#input-esterno-e-continuazioni-dei-workflow).
+Conservare intatti la cronologia completata e i risultati degli strumenti salvati.
 
 Dopo l’avvio della conversione, il rollback ripristina il backup completo. Non
 eseguire writer precedenti su un database convertito solo in parte.
@@ -505,12 +510,23 @@ chiamanti come un'unica release coordinata. Goa-AI non offre una modalità di
 lettura doppia per i contratti runtime generati.
 
 Il runtime accetta esclusivamente lo schema esatto
-`goa-ai.run-suspension.v7`. I planner che attendono domande, chiarimenti o
+`goa-ai.run-suspension.v8`. I planner che attendono domande, chiarimenti o
 strumenti esterni conservano il `ModelToolCallID` del provider; il workflow
 assegna il distinto `ToolCallID` del runtime prima di salvare la sospensione.
-Gli altri schemi di sospensione non vengono ripresi. Un futuro cambio di schema
-deve censire e ritirare il lavoro salvato incompatibile prima della release
-coordinata; non aggiungere un lettore doppio e non inferire campi.
+Gli altri schemi di sospensione non vengono ripresi. La versione otto conserva
+anche le scelte annunciate quando un piano di recupero accettato attende un
+input. Prima di sostituire i worker che possiedono lavoro salvato precedente,
+applicare la decisione dell'host sulla conservazione e sulla possibilità di
+ripresa descritta in
+[Input esterno e continuazioni dei workflow](../runtime/#input-esterno-e-continuazioni-dei-workflow);
+non aggiungere un lettore doppio e non inferire campi.
+
+Aggiornare insieme i worker di tutte le code di workflow e attività, i package
+generati e i chiamanti prima di accettare nuovo lavoro. Quando i nuovi worker
+salvano sospensioni v8, i vecchi worker non possono riprenderle: ripristinare
+solo un'immagine non restituisce questa capacità. Conservare la cronologia
+completata e i risultati degli strumenti salvati; qualsiasi conversione dello
+storage fisico rimane un'operazione separata di proprietà dell'host.
 
 #### Verifica della release
 

--- a/content/it/docs/2-goa-ai/runtime.md
+++ b/content/it/docs/2-goa-ai/runtime.md
@@ -889,10 +889,18 @@ con i codec generati correnti e riprende la pianificazione. I byte di
 completa. Salvali solo in uno storage applicativo affidabile e con accesso
 controllato; non inviarli mai a un client non attendibile.
 
-L’unico formato accettato è `goa-ai.run-suspension.v7`. Goa-AI rifiuta tutte le
-versioni precedenti invece di tentare di tradurle. Prima di accettare
-continuazioni con il nuovo runtime, l’host deve migrare o rimuovere le
-esecuzioni sospese che usano un formato precedente.
+L'unico formato accettato è `goa-ai.run-suspension.v8`. La versione otto salva i
+nomi degli strumenti annunciati quando un piano di recupero accettato attende
+un input: i nomi degli strumenti falliti non bastano a ricostruire le altre
+scelte offerte in quel turno. La continuazione conserva queste scelte e
+verifica comunque la definizione attuale dell'agente e la policy di esecuzione.
+
+Goa-AI rifiuta tutte le versioni precedenti del checkpoint. Prima dell'upgrade,
+completare il lavoro salvato nel vecchio formato con il runtime che lo possiede.
+Se deve restare lavoro incompiuto, l'host deve decidere esplicitamente come
+conservarlo e se resterà riprendibile; questo runtime non può riprenderlo.
+Il framework non fornisce comandi di conversione e non elimina, annulla o
+riscrive automaticamente il lavoro salvato.
 
 Quando una risposta completa una chiamata a un tool creata dal modello nel
 workflow precedente, il nuovo evento `tool_end` contiene due identità:
@@ -1029,7 +1037,7 @@ Questi contratti sono distinti:
 | `ToolSpec.Meta` | Uno strumento, per ogni run | Annotazioni generate e inerti la cui semantica appartiene al consumer denominato; i metadati da soli non cambiano il runtime. |
 | `ToolSpec.Bookkeeping` | Uno strumento, per ogni run | La chiamata è un record di controllo durevole il cui successo non richiede un altro turno del planner. Non consuma budget di retrieval o di errori consecutivi. |
 | `ToolSpec.TerminalRun` | Uno strumento, per ogni run | Il successo termina direttamente il run e implica automaticamente bookkeeping. |
-| `ToolFailure.Recovery.Action` | Un risultato fallito | Sceglie la correzione sullo stesso strumento, una nuova pianificazione senza lo strumento fallito oppure la finalizzazione. |
+| `ToolFailure.Recovery.Action` | Un risultato fallito | Sceglie la correzione mantenendo disponibile lo strumento fallito, una nuova pianificazione senza di esso oppure la finalizzazione. |
 | `PlanResult.SynthesizeAfterTools` | Un batch selezionato | Se il batch non contiene errori recuperabili, il turno successivo del planner deve rispondere. |
 | `PlanResumeInput.SynthesisOnly` | Un'attività del planner | Restituire una risposta finale; le chiamate agli strumenti non sono valide. |
 | `PlanResumeInput.Finalize` | Terminazione forzata dal runtime | Un limite o una deadline impedisce il lavoro normale. |
@@ -1061,6 +1069,21 @@ Ogni `ToolFailure` recuperabile seleziona anche una `Recovery.Action`:
   può usare un altro strumento annunciato, attendere un input o rispondere.
 - `finish` rimuove tutti gli strumenti e richiede una risposta finale basata
   sulle prove disponibili.
+
+Un normale turno `correct_call` combina gli strumenti eseguibili dell'agente
+attuale con i contratti esatti degli strumenti falliti. Nomi e contratti
+identici vengono deduplicati; contratti in conflitto, registrazioni di
+esecuzione mancanti e strumenti revocati causano un errore prima della chiamata
+al modello. Restano applicabili le restrizioni del chiamante, quelle dei tag
+del run e le esclusioni di recupero. Uno strumento di correzione negato causa
+un errore; il runtime non lo scarta silenziosamente e non lo ripristina dopo il
+filtro. L'autorizzazione nel servizio esecutore verifica ancora ogni chiamata.
+
+Le query incompiute conservano le azioni di continuazione generate dal runtime;
+le richieste fallite non creano continuazioni. La finalizzazione forzata offre
+per la correzione solo l'esatto strumento terminale fallito, e i turni di sola
+sintesi restano privi di strumenti. Dopo la correzione, i turni normali tornano
+agli strumenti dell'agente attuale.
 
 Il workflow possiede le prove di correzione mostrate al modello. Prima di
 salvare l'errore nella cronologia, sostituisce input ed esempi forniti
@@ -1228,6 +1251,18 @@ modello.
 `ValidatedStream` deve essere consumato fino a `io.EOF`; solo allora
 `Response()` restituisce la risposta canonica accettata. Uno stream incompleto,
 malformato o contraddittorio restituisce un errore e nessuna risposta accettata.
+
+Le chiamate complete agli strumenti devono rispettare lo schema annunciato e il
+decoder generato associato, se presente, prima di essere visibili al planner. Quando un
+rifiuto dello schema ha una sola causa al livello più profondo, corrispondente
+ai metadati generati di un campo array, la guida alla correzione indica il
+minimo o il massimo inclusivo di quell'array, per esempio:
+`Field "items" must contain at most 3 items.` Cause ambigue o non supportate
+mantengono una guida generica. Questi limiti riguardano solo quell'array
+inviato, non l'intero run. Gli argomenti restano rifiutati prima dell'esecuzione;
+Goa-AI non li divide, tronca o riscrive. L'errore di validazione originale, le
+regole di accettazione e il limite configurato dei turni di recupero restano
+invariati.
 
 ### Adattatori del provider
 

--- a/content/it/docs/2-goa-ai/testing.md
+++ b/content/it/docs/2-goa-ai/testing.md
@@ -288,9 +288,18 @@ Verifica separatamente il codec degli hook: i decoder di `RunStarted`,
 `RunSuspended`, `RunCompleted` e `ChildRunLinked` devono rifiutare `null`, i
 campi sconosciuti e un secondo valore JSON finale.
 
-I test delle continuazioni devono accettare `goa-ai.run-suspension.v7` e
+I test delle continuazioni devono accettare `goa-ai.run-suspension.v8` e
 rifiutare tutte le versioni precedenti prima di ripristinare i payload o
 chiamare il planner.
+Per un piano di recupero che attende un input, verificare che la continuazione
+conservi tutte le alternative annunciate, non solo lo strumento fallito.
+Verificare inoltre che la definizione attuale dell'agente e la policy di
+esecuzione rifiutino gli strumenti rimossi, in conflitto o negati prima della
+pianificazione; le scelte salvate non concedono autorizzazioni permanenti.
+Conservare test positivi per le alternative consentite, le continuazioni delle
+query incompiute, la correzione forzata limitata agli strumenti terminali e la
+sintesi senza strumenti. Questi test di contratto provano quali azioni sono
+lecite, non la qualità della scelta di un modello reale.
 
 ---
 

--- a/content/ja/docs/2-goa-ai/production.md
+++ b/content/ja/docs/2-goa-ai/production.md
@@ -403,9 +403,13 @@ program を実行します。この program は host application が所有し、
 
 1. runtime database を backup し、writer がないことを確認します。
 2. verification mode で migration を実行し、拒否された record をすべて修正します。
-3. conversion を適用し、schema、index、session、run metadata、v7 checkpoint、
+3. conversion を適用し、schema、index、session、run metadata、現在の形式の checkpoint、
    immutable record を検証します。
 4. storage owner と全 worker をまとめて deploy し、migration program を削除します。
+
+この物理 storage の変換は suspension 形式を変換しません。保存済み work は別途、
+[現在の continuation contract](../runtime/#外部入力と-workflow-continuation)
+を満たす必要があります。完了済み history と保存済み tool result は保持してください。
 
 conversion 開始後の rollback は database 全体の restore です。partial conversion の
 database に旧 writer を接続してはいけません。
@@ -486,6 +490,10 @@ worker version は次の順序で release します。
 
 受理された各 user input は top-level Goa-AI workflow を 1 つ開始します。Goa-AI は human または external input を要求すると workflow を終了し、completed run ID の下に非公開 checkpoint を保存します。受理された answer は current worker version で新しい workflow を開始します。そのため透過的 release では、新 version が保存済み checkpoint version、生成 result codec、必要な tool 名との互換性を保つ必要があります。Worker Versioning は互換性のない保存値を変換できません。
 
+現在の runtime が受理するのは `goa-ai.run-suspension.v8` だけで、それ以前の形式は
+拒否します。互換性のない upgrade では、worker を重ねて動かすこの手順ではなく、
+以下の「生成 contract の変更」に従ってください。
+
 application の残りの部分も、同じ overlap 中に availability を保つ必要があります。
 
 - downstream Service には常に 1 つ以上の ready endpoint が必要です。readiness-gated rolling replacement を使います。`Recreate` rollout は gap を作ります。
@@ -509,7 +517,13 @@ Worker Deployment Versioning は workflow replay を保護します。dependency
 
 生成 agent、completion package、永続 runtime payload を互換性なく変更する場合、上記の mixed-version 手順を適用しません。全 agent と completion を再生成し、影響を受ける work を drain または停止して、runtime、worker、caller を 1 回の coordinated release で deploy します。Goa-AI は生成 runtime contract の dual-read mode を提供しません。
 
-runtime が受理するのは、正確な `goa-ai.run-suspension.v7` schema だけです。question、clarification、external tool を待つ planner は provider の `ModelToolCallID` を保持し、workflow は停止データを保存する前に別の runtime `ToolCallID` を割り当てます。ほかの suspension schema は resume しません。将来 schema を変更する場合、coordinated release の前に互換性のない保存済み work を調査して廃止します。dual reader を追加したり field を推測したりしてはいけません。
+runtime が受理するのは、正確な `goa-ai.run-suspension.v8` schema だけです。question、clarification、external tool を待つ planner は provider の `ModelToolCallID` を保持し、workflow は停止データを保存する前に別の runtime `ToolCallID` を割り当てます。ほかの suspension schema は resume しません。version eight は、受理済み recovery plan が input を待つとき、提示した選択肢も保持します。古い保存済み work を所有する worker の置き換え前に、[External Input and Workflow Continuations](../runtime/#外部入力と-workflow-continuation) で説明した、host による保存方法と再開可能性の判断を行ってください。dual reader を追加したり field を推測したりしてはいけません。
+
+新規 work を受け付ける前に、すべての workflow queue と activity queue で協調する
+worker、生成済み package、caller を更新します。新 worker が v8 suspension を保存した
+後は、旧 worker ではそれを再開できません。image を戻すだけでは再開可能性は戻りません。
+完了済み history と保存済み tool result は保持します。物理 storage の変換は、別途
+host が所有する操作です。
 
 #### release の検証
 

--- a/content/ja/docs/2-goa-ai/runtime.md
+++ b/content/ja/docs/2-goa-ai/runtime.md
@@ -877,10 +877,17 @@ continuation の準備時に application が渡すのは、完了した run ID �
 場合があります。信頼できる access-controlled な application storage にだけ保存し、
 信頼できない client には決して送信しないでください。
 
-受理される形式は `goa-ai.run-suspension.v7` だけです。Goa-AI は以前の version を
-推測で変換せず、すべて拒否します。新しい runtime で continuation traffic を
-受け付ける前に、host は古い形式の suspended run を移行または削除する必要が
-あります。
+受理される形式は `goa-ai.run-suspension.v8` だけです。version eight は、受理済みの
+recovery plan が input を待つとき、その turn で提示した tool 名を保存します。
+失敗した tool 名だけから、ほかに提示した選択肢を復元することはできません。
+continuation はその選択肢を保持しますが、現在の agent definition と実行 policy の
+検証も引き続き行います。
+
+Goa-AI は以前の checkpoint version をすべて拒否します。upgrade 前に、古い形式の
+保存済み work は、それを所有する runtime で完了させてください。未完了のまま残す
+必要がある場合、host が保存方法と再開可能性を明示的に判断します。この runtime では
+再開できません。framework は変換 command を提供せず、保存済み work の削除、
+キャンセル、書き換えを自動で行うこともありません。
 
 回答が以前の workflow で model が作成した tool call を完了させる場合、新しい
 `tool_end` event には二つの run identity が含まれます。
@@ -1001,7 +1008,7 @@ planner-generated request には domain intent だけを含めます。`planner.
 | `ToolSpec.Meta` | すべての run における 1 つの tool | 名前付きコンシューマが意味を所有する、不活性な生成アノテーション。メタデータだけでは runtime 動作は変わらない。 |
 | `ToolSpec.Bookkeeping` | すべての run における 1 つの tool | 成功後に別の planner turn を必要としない durable な制御記録。retrieval と連続失敗の budget を消費しない。 |
 | `ToolSpec.TerminalRun` | すべての run における 1 つの tool | 成功そのものが run を終了し、自動的に bookkeeping を含む。 |
-| `ToolFailure.Recovery.Action` | 1 つの失敗 result | 同一 tool の修正、failed tool を除いた replanning、finalization のいずれかを選ぶ。 |
+| `ToolFailure.Recovery.Action` | 1 つの失敗 result | failed tool を引き続き利用可能にした修正、その tool を除いた replanning、finalization のいずれかを選ぶ。 |
 | `PlanResult.SynthesizeAfterTools` | 選択された 1 batch | recoverable failure がなければ、次の planner turn は回答しなければならない。 |
 | `PlanResumeInput.SynthesisOnly` | 1 planner activity | 最終回答を返す。tool call は無効。 |
 | `PlanResumeInput.Finalize` | runtime が強制する終了 | cap または deadline により通常作業が禁止されている。 |
@@ -1032,6 +1039,18 @@ recoverable な `ToolFailure` は `Recovery.Action` も 1 つ選択します。
   表示済み tool を使うか、input を待つか、回答できます。
 - `finish` はすべての tool を除外し、利用可能な evidence に基づく最終回答を
   要求します。
+
+通常の `correct_call` turn では、現在の agent が実行できる tool と、失敗した tool の
+正確な contract を組み合わせます。同じ名前と contract は重複を除きます。
+contract の不一致、実行登録の欠落、tool の取り消しは model 呼び出し前に失敗します。
+caller の制限、run tag の制限、recovery による除外も適用します。修正対象の tool が
+拒否されていれば error にし、黙って除外したり filtering 後に復活させたりしません。
+実行先での認可も、各 call に引き続き適用します。
+
+未完了の query は runtime が生成した continuation action を保持します。失敗した
+request から continuation は生成しません。強制 finalization で修正できるのは、
+失敗した正確な terminal tool だけです。synthesis-only turn には tool を提示しません。
+修正後の通常 turn は、現在の agent の tool に戻ります。
 
 ランタイムは recovery turn で表示した tool catalog を正確に記録し、その外側の
 実行可能な call をすべて拒否します。user または外部 input の要求に埋め込まれた
@@ -1156,6 +1175,15 @@ provider integration は raw transport response／chunk を生成する `model.P
 provider call 前には tool name／schema、message part、thinking option、structured-output metadata、request の dynamic value を検証します。request と unary response は 16 MiB、visited value は 100,000 個までで、nested dynamic metadata の depth は 64 までです。streaming では chunk と terminal response に 1 つの累積 budget を適用します。limit 超過では操作全体を拒否し、model data の切り詰め、修復、coercion は行いません。
 
 `ValidatedStream` は `io.EOF` まで drain する必要があります。完了した場合だけ `Response()` が受理済み canonical response を返します。不完全、不正、または矛盾する stream は error となり、受理済み response はありません。
+
+完了した tool call は、planner が受け取る前に、提示済み schema に合格する必要があります。
+生成済み decoder が付属する場合は、その検証にも合格します。schema の拒否に最深部の原因が一つだけあり、
+生成済みの配列 field metadata と一致する場合、修正指示はその配列の要素数の下限または
+上限を、境界値を含む形で示します。たとえば `Field "items" must contain at most 3 items.`
+です。原因が曖昧または未対応なら、一般的な修正指示を使います。この制限は提出した
+一つの配列に対するもので、run 全体の制限ではありません。引数は実行前に拒否された
+ままで、Goa-AI は分割、切り詰め、書き換えをしません。元の validation error、
+受理規則、設定済み recovery-turn 上限は変わりません。
 
 ### プロバイダーアダプター
 

--- a/content/ja/docs/2-goa-ai/testing.md
+++ b/content/ja/docs/2-goa-ai/testing.md
@@ -297,8 +297,15 @@ hook codec は別に test します。`RunStarted`、`RunSuspended`、`RunComple
 `ChildRunLinked` の decoder は、`null`、未知の field、末尾の二つ目の JSON 値を
 拒否する必要があります。
 
-continuation test は `goa-ai.run-suspension.v7` を受理し、それ以前の version は
+continuation test は `goa-ai.run-suspension.v8` を受理し、それ以前の version は
 payload の復元や planner 呼び出しの前に拒否することを確認します。
+input を待つ recovery plan では、失敗した tool だけでなく、提示したすべての代替手段が
+continuation に保持されることを確認します。現在の agent definition と実行 policy が、
+削除済み、不一致、または禁止された tool を planning 前に拒否することも確認します。
+保存済みの選択肢は恒久的な許可ではありません。許可された代替手段、未完了 query の
+continuation、terminal tool だけによる強制修正、tool のない synthesis の正常系テストも
+保持してください。これらの contract test が証明するのは合法な action であり、
+実際の model の選択の品質ではありません。
 
 ---
 


### PR DESCRIPTION
The runtime, production, and testing guides still described suspension format v7 after the runtime began accepting only v8. That could lead a host to deploy workers that cannot resume its saved work. This change corrects those three existing pages in English, Spanish, French, Italian, and Japanese, and documents the published tool-recovery behavior.

## Saved work and upgrades

The guides now explain that v8 retains the tool choices advertised when a recovery plan waits for input. Resumption still checks the current agent definition and execution policy; saved choices do not grant permanent permission.

Before an incompatible upgrade, old-format work must finish on its owning runtime, or the host must explicitly decide how to preserve it and whether it remains resumable. The framework does not convert, delete, cancel, or rewrite saved work automatically. Physical database conversion is a separate operation. Cooperating workers and callers must update before new work is admitted, and reverting an image alone cannot make older workers resume v8 suspensions. Completed history and stored tool results remain intact.

## Correction choices and validation feedback

Ordinary correction retains the current executable tools alongside the exact failed-tool contracts, while enforcing restrictions, registration, and authorization. The text preserves unfinished-query continuation, terminal-only forced correction, tool-free synthesis, and the return to ordinary tools afterward.

When one unambiguous generated array field caused validation failure, feedback can name that array's inclusive size bound. Ambiguous causes keep generic guidance. The bound applies to that submitted array, not the whole run; arguments remain rejected without splitting, truncation, rewriting, or a larger recovery budget.

These are descriptions of already published behavior, not runtime changes. This website release requires no regeneration or migration by itself. Hosts upgrading the framework must follow the documented saved-work contract.

## Review and verification

Start with the English runtime continuation, recovery, and provider-validation sections, then the production upgrade guidance and continuation-testing paragraph. The other four languages carry the same changes, with localized section links. No dependency, executable code, test, or fenced code example changes are included.

- Production Hugo build passed, including an independent rerun.
- All 15 affected rendered pages contain v8 guidance; all 11 changed section links resolve.
- All 392 fenced code blocks are byte-identical to the base.
- Contract and translation review passed against the published framework behavior.
- The initial test run passed 70/70. An independent run passed 69/70 and exposed an existing randomized `copy-page` test defect: title `"# "` is admitted by its generator but fails its heading assertion. That exact counterexample produces the same result on the unchanged base and this branch. The test and implementation are not modified here; no passing retry is represented as a fix.
- Whitespace checks passed. Existing dependency advisories and unrelated translation drift remain outside this change.

The translation helper rejected its existing credential before writing translations. The changed Spanish, French, and Italian paragraphs were translated manually and reviewed; Japanese followed its supported manual workflow. No successful automatic translation is claimed.