### PR TITLE
docs(eval): explain shared reference context and judge migration

### DIFF
--- a/content/en/docs/2-goa-ai/evaluations.md
+++ b/content/en/docs/2-goa-ai/evaluations.md
@@ -419,6 +419,48 @@ regardless of claim count. Choose a value supported by your configured provider
 and model; unsupported values remain errors, not silently reduced limits. A
 finite ceiling does not guarantee that a response will finish within it.
 
+### Shared reference and judge migration
+
+Put factual context shared by several claims in the optional `Result.Reference`
+string, instead of repeating it inside each claim. Keep `Output` as the answer
+being evaluated:
+
+```go
+result := eval.Result{
+    Output:    answer,
+    Reference: "Supported export formats: CSV and JSON.",
+    Claims: []eval.Claim{{
+        ID:   "export_formats",
+        Text: "The answer lists the supported export formats.",
+    }},
+}
+```
+
+The runner passes the reference separately from the unchanged answer. The
+model-backed judge includes it once in each request, including existing
+correction requests. Reference facts help establish whether the answer is
+accurate; they never supply content missing from the answer. In this example,
+listing the formats only in the reference does not satisfy the claim. An empty
+`Output` still gives every claim `not_addressed` without calling the judge,
+even when the reference contains the answer.
+
+Custom judges implement the new four-argument interface:
+
+```go
+Judge(ctx context.Context, output string, claims []eval.Claim, reference string) ([]eval.Judgment, error)
+```
+
+Update direct calls to `grader.Judge(ctx, output, claims, reference)`. Pass `""`
+when no additional context is needed; calibration also uses an empty reference.
+The runner retains a nonempty reference as `reference` in the JSON report and
+omits the field when empty. Existing reports without it still mean no additional
+context. Strict external report readers must accept the new field before reading
+reports that include it. No saved-report migration, generated suite change, or
+product service contract change is required. This change adds no model call and
+does not change model selection, token limits, labels, or correction counts.
+
+### Labels and response validation
+
 For each scenario the judge receives the answer and the scenario's claims, and
 returns exactly one label and a short rationale per claim:
 

--- a/content/es/docs/2-goa-ai/evaluations.md
+++ b/content/es/docs/2-goa-ai/evaluations.md
@@ -70,8 +70,9 @@ otros valores exactos. Usa afirmaciones solo cuando sea necesario leer e
 interpretar la respuesta. Devuelve los fallos de infraestructura o protocolo
 como errores. Toda comprobación fallida debe incluir un diagnóstico.
 
-El runner rechaza resultados vacíos, IDs repetidos, afirmaciones sin respuesta,
-artefactos inválidos y respuestas incompletas del juez semántico.
+El runner rechaza resultados sin comprobaciones ni afirmaciones, IDs repetidos,
+artefactos inválidos y respuestas incompletas del juez semántico. Si `Output`
+está vacío, asigna `not_addressed` a cada afirmación sin llamar al juez.
 
 ## Crear y ejecutar un runner
 
@@ -134,6 +135,50 @@ corrección permitida, independientemente del número de afirmaciones. Elige un
 valor compatible con el proveedor y el modelo configurados; los valores no
 compatibles siguen siendo errores, sin reducir silenciosamente el límite. Un
 límite finito no garantiza que la respuesta pueda completarse.
+
+### Referencia compartida y migración del juez
+
+Pon el contexto factual compartido por varias afirmaciones en la cadena opcional
+`Result.Reference`, en lugar de repetirlo en cada afirmación. Mantén `Output`
+como la respuesta que se evalúa:
+
+```go
+result := eval.Result{
+    Output:    answer,
+    Reference: "Supported export formats: CSV and JSON.",
+    Claims: []eval.Claim{{
+        ID:   "export_formats",
+        Text: "The answer lists the supported export formats.",
+    }},
+}
+```
+
+El runner pasa la referencia por separado, sin modificar la respuesta. El juez
+basado en un modelo la incluye una vez en cada petición, incluidas las peticiones
+de corrección existentes. Los hechos de la referencia ayudan a comprobar la
+exactitud de la respuesta; nunca aportan contenido que falte en ella. En este
+ejemplo, enumerar los formatos solo en la referencia no satisface la afirmación.
+Un `Output` vacío sigue dando `not_addressed` a todas las afirmaciones sin llamar
+al juez, aunque la referencia contenga la respuesta.
+
+Los jueces personalizados implementan la nueva interfaz de cuatro argumentos:
+
+```go
+Judge(ctx context.Context, output string, claims []eval.Claim, reference string) ([]eval.Judgment, error)
+```
+
+Actualiza las llamadas directas a `grader.Judge(ctx, output, claims, reference)`.
+Pasa `""` cuando no se necesite contexto adicional; la calibración también usa
+una referencia vacía. El runner conserva una referencia no vacía como `reference`
+en el informe JSON y omite el campo cuando está vacía. Los informes anteriores
+sin ese campo siguen indicando que no hay contexto adicional. Los lectores
+externos estrictos deben aceptar el nuevo campo antes de consumir informes que
+lo incluyan. No hace falta migrar los informes guardados ni cambiar las suites
+generadas o los contratos de servicios del producto. Este cambio no añade llamadas
+al modelo ni modifica su selección, los límites de tokens, las etiquetas o el
+número de correcciones.
+
+### Etiquetas y validación de respuestas
 
 Antes de ejecutar escenarios, el runner verifica el juez con cuatro ejemplos
 propiedad del framework: `entailed` (la respuesta demuestra la afirmación),

--- a/content/fr/docs/2-goa-ai/evaluations.md
+++ b/content/fr/docs/2-goa-ai/evaluations.md
@@ -400,6 +400,52 @@ valeur prise en charge par le fournisseur et le modèle configurés ; une valeu
 non prise en charge reste une erreur, sans réduction silencieuse du plafond.
 Un plafond fini ne garantit pas que la réponse pourra se terminer.
 
+### Référence partagée et migration du juge
+
+Placez le contexte factuel partagé par plusieurs affirmations dans la chaîne
+facultative `Result.Reference`, au lieu de le répéter dans chaque affirmation.
+Conservez dans `Output` la réponse à évaluer :
+
+```go
+result := eval.Result{
+    Output:    answer,
+    Reference: "Supported export formats: CSV and JSON.",
+    Claims: []eval.Claim{{
+        ID:   "export_formats",
+        Text: "The answer lists the supported export formats.",
+    }},
+}
+```
+
+Le runner transmet la référence séparément, sans modifier la réponse. Le juge
+fondé sur un modèle l'inclut une seule fois dans chaque requête, y compris les
+requêtes de correction existantes. Les faits de la référence aident à vérifier
+l'exactitude de la réponse ; ils ne fournissent jamais le contenu qu'elle omet.
+Dans cet exemple, énumérer les formats uniquement dans la référence ne suffit
+pas à satisfaire l'affirmation. Un `Output` vide attribue toujours `not_addressed`
+à chaque affirmation sans appeler le juge, même si la référence contient la
+réponse.
+
+Les juges personnalisés implémentent la nouvelle interface à quatre arguments :
+
+```go
+Judge(ctx context.Context, output string, claims []eval.Claim, reference string) ([]eval.Judgment, error)
+```
+
+Modifiez les appels directs en `grader.Judge(ctx, output, claims, reference)`.
+Passez `""` lorsqu'aucun contexte supplémentaire n'est nécessaire ; la calibration
+utilise aussi une référence vide. Le runner conserve une référence non vide dans
+le champ `reference` du rapport JSON et omet ce champ lorsqu'elle est vide. Les
+anciens rapports sans ce champ indiquent toujours l'absence de contexte
+supplémentaire. Les lecteurs externes à validation stricte doivent accepter le
+nouveau champ avant de lire des rapports qui l'incluent. Aucune migration des
+rapports enregistrés ni modification des suites générées ou des contrats des
+services du produit n'est nécessaire. Ce changement n'ajoute aucun appel au modèle
+et ne modifie ni le choix du modèle, ni les limites de jetons, ni les résultats
+possibles, ni le nombre de corrections.
+
+### Résultats et validation des réponses
+
 Le juge reçoit la réponse et les affirmations, puis attribue exactement un
 résultat et une justification courte à chacune :
 

--- a/content/it/docs/2-goa-ai/evaluations.md
+++ b/content/it/docs/2-goa-ai/evaluations.md
@@ -69,8 +69,9 @@ i claim solo quando serve leggere e interpretare la risposta. Restituisci i
 guasti dell'infrastruttura o del protocollo come errori. Ogni controllo fallito
 deve includere una diagnosi.
 
-Il runner rifiuta risultati vuoti, ID duplicati, claim senza risposta, artefatti
-non validi e risposte incomplete del giudice.
+Il runner rifiuta risultati senza controlli né claim, ID duplicati, artefatti
+non validi e risposte incomplete del giudice. Se `Output` è vuoto, assegna
+`not_addressed` a ogni claim senza chiamare il giudice.
 
 ## Creare ed eseguire un runner
 
@@ -135,6 +136,50 @@ consentita, indipendentemente dal numero di claim. Scegli un valore supportato
 dal provider e dal modello configurati; i valori non supportati restano errori,
 senza riduzioni silenziose del limite. Un limite finito non garantisce che la
 risposta riesca a completarsi.
+
+### Riferimento condiviso e migrazione del giudice
+
+Inserisci il contesto fattuale condiviso da più claim nella stringa facoltativa
+`Result.Reference`, invece di ripeterlo in ogni claim. Mantieni in `Output` la
+risposta da valutare:
+
+```go
+result := eval.Result{
+    Output:    answer,
+    Reference: "Supported export formats: CSV and JSON.",
+    Claims: []eval.Claim{{
+        ID:   "export_formats",
+        Text: "The answer lists the supported export formats.",
+    }},
+}
+```
+
+Il runner passa il riferimento separatamente, senza modificare la risposta. Il
+giudice basato su un modello lo include una volta in ogni richiesta, comprese
+quelle di correzione già previste. I fatti nel riferimento aiutano a verificare
+l'accuratezza della risposta; non forniscono mai contenuti che la risposta omette.
+In questo esempio, elencare i formati solo nel riferimento non soddisfa il claim.
+Un `Output` vuoto continua a produrre `not_addressed` per ogni claim senza chiamare
+il giudice, anche quando il riferimento contiene la risposta.
+
+I giudici personalizzati implementano la nuova interfaccia a quattro argomenti:
+
+```go
+Judge(ctx context.Context, output string, claims []eval.Claim, reference string) ([]eval.Judgment, error)
+```
+
+Aggiorna le chiamate dirette a `grader.Judge(ctx, output, claims, reference)`.
+Passa `""` quando non serve altro contesto; anche la calibrazione usa un riferimento
+vuoto. Il runner conserva un riferimento non vuoto nel campo `reference` del
+report JSON e omette il campo quando è vuoto. I report precedenti senza tale campo
+continuano a indicare l'assenza di contesto aggiuntivo. I lettori esterni con
+convalida rigorosa devono accettare il nuovo campo prima di leggere report che lo
+includono. Non occorre migrare i report salvati né modificare le suite generate o
+i contratti dei servizi del prodotto. Questa modifica non aggiunge chiamate al
+modello e non cambia la scelta del modello, i limiti di token, le etichette o il
+numero di correzioni.
+
+### Etichette e convalida delle risposte
 
 Prima degli scenari, il runner verifica il giudice con quattro esempi gestiti dal
 framework: `entailed` (la risposta dimostra il claim), `contradicted` (dimostra

--- a/content/ja/docs/2-goa-ai/evaluations.md
+++ b/content/ja/docs/2-goa-ai/evaluations.md
@@ -298,6 +298,33 @@ application は `judge.New` に正の `maxOutputTokens` を渡し、返された
 
 この値は、全 judgment と JSON 構造を含む**モデルの 1 回の応答全体**に対する output token 数の上限です。上限と同じ値までは許可されます。claim ごとの割り当てでも、scenario や suite 全体の予算でもありません。Goa-AI は claim 数にかかわらず、初回 request と許可された各 correction request に同じ値を渡します。設定された provider と model が対応する値を選んでください。未対応の値は黙って引き下げられず、error になります。有限の上限では、その範囲内で応答が完了することは保証されません。
 
+### 共有する参照情報と judge の移行
+
+複数の claim に共通する事実情報は、各 claim に繰り返し書くのではなく、任意の文字列フィールド `Result.Reference` に入れます。`Output` には評価対象の回答をそのまま保持します。
+
+```go
+result := eval.Result{
+    Output:    answer,
+    Reference: "Supported export formats: CSV and JSON.",
+    Claims: []eval.Claim{{
+        ID:   "export_formats",
+        Text: "The answer lists the supported export formats.",
+    }},
+}
+```
+
+runner は回答を変更せず、参照情報を別に渡します。モデルを使う judge は、既存の修正リクエストも含め、各リクエストに参照情報を 1 回だけ含めます。参照情報の事実は回答の正確さを判断するためのものであり、回答に欠けた内容を補うものではありません。この例では、参照情報だけに形式が列挙されていても claim を満たしません。`Output` が空なら、参照情報に答えが含まれていても judge は呼ばれず、すべての claim が `not_addressed` になります。
+
+独自の judge は、新しい 4 引数のインターフェースを実装します。
+
+```go
+Judge(ctx context.Context, output string, claims []eval.Claim, reference string) ([]eval.Judgment, error)
+```
+
+直接の呼び出しは `grader.Judge(ctx, output, claims, reference)` に更新します。追加の情報が不要なら `""` を渡してください。calibration も空の参照情報を使います。runner は空でない参照情報を JSON report の `reference` フィールドに保存し、空ならフィールドを省略します。このフィールドがない既存の report は、引き続き追加情報がないことを意味します。report を厳格に検証する外部の読み取り側は、新しいフィールドを含む report を読む前に、そのフィールドを受け入れるよう更新する必要があります。保存済み report の移行、生成される suite の変更、製品のサービス契約の変更は不要です。この変更でモデルの呼び出しは増えず、モデルの選択、トークン上限、判定ラベル、修正回数も変わりません。
+
+### 判定ラベルと応答の検証
+
 各 scenario について、judge は回答と claim を受け取り、claim ごとに正確に 1 label と短い理由を返します。
 
 - `entailed`: 回答が claim を真だと裏付ける。


### PR DESCRIPTION
The evaluation guide now explains how to supply factual reference material once for multiple answer claims, without treating that material as part of the answer being graded. English, Spanish, French, Italian, and Japanese receive the same example and upgrade instructions.

**Merge after [goa-ai #341](https://github.com/goadesign/goa-ai/pull/341), which implements the documented contract.** That implementation is still under review and CI repair; this documentation must not publish ahead of it.

### What readers need to know

Previously, shared factual context had to be repeated inside individual claims. The framework change adds optional `eval.Result.Reference`, passed separately from the unchanged `Output`. The model-backed judge includes the reference once in each request, including existing correction requests. Reference facts can establish whether an answer is accurate, but cannot satisfy a claim by supplying something the answer omitted. An empty answer still receives `not_addressed` for every claim without calling the judge.

The guide gives a short export-format example and documents the source-level migration: custom judges now implement `Judge(ctx, output, claims, reference)`, and direct callers provide the fourth argument. Use an empty string when no additional context is needed. Calibration also uses an empty reference.

Nonempty reference material appears in the report's `reference` field; an empty value is omitted. Existing reports need no migration. Strict external JSON readers must accept the new field before reading reports that include it. No generated-suite or product-service contract changes are needed. Model selection, token limits, judgment labels, correction counts, and model-call counts are unchanged.

Spanish and Italian also correct nearby wording that incorrectly described an empty answer as a rejected result, so those paragraphs agree with the documented `not_addressed` behavior. This is a focused addition, not a full rewrite of the evaluation guides.

### Validation and publication

- `hugo --minify` passed with only existing Sass/Hugo deprecation warnings.
- Rendered HTML checks found the reference example and four-argument judge signature in all five languages, with unique level-two and level-three heading IDs.
- Source checks confirmed that all existing fenced examples and links remain unchanged and each language adds the same two Go examples.
- `git diff --check` passed.
- `npm test -- --reporter=dot` passed 69 of 70 tests. The only failure was the unchanged `toc-auto.test.js` Property 4 randomized long-page test reaching its 5,000 ms timeout. That test exercises generated text and `static/js/toc-auto.js`, not these documentation pages. No test or timeout was changed, and no retry-to-green result is claimed.

Translations were manually reviewed. The automated Japanese translation dry run could not proceed without its translation-service key; no automated translation success is claimed and no translation cache changed.

Only `content/{en,es,fr,it,ja}/docs/2-goa-ai/evaluations.md` changes. There are no generated website files, runtime changes, or data migrations in this PR. Publish through the normal website workflow after the framework PR merges; reverting these pages would not change application behavior or stored reports.
