### PR TITLE
Document model and execution payload codecs

### DIFF
--- a/content/en/docs/2-goa-ai/tool-payload-defaults.md
+++ b/content/en/docs/2-goa-ai/tool-payload-defaults.md
@@ -11,6 +11,43 @@ Goa-AI generates **typed tool payload structs**, **JSON Schemas**, and **codecs*
 
 This is implemented to match Goa’s own HTTP pattern: **decode-body → transform**.
 
+## Model arguments and execution payloads
+
+A tool can accept fewer arguments from the model than its executor needs.
+Each input has its own JSON schema and codec (the generated functions that
+validate, decode, and encode that input):
+
+- `ToolSpec.Payload.Codec` matches `Payload.Schema` and its authored example.
+  Use it to validate arguments written by the model.
+- `ToolSpec.ExecutionPayloadCodec` matches `ExecutionPayloadSchema`.
+  Use it for complete execution payloads and when restoring saved tool work.
+
+For a dedicated continuation tool that retains the original query, the model
+sends `{}` to request the next page. The runtime restores the query and the provider's cursor before
+execution. The model codec therefore accepts `{}`, while the execution codec
+requires the retained query fields and cursor. An empty example must not fail
+registration merely because execution needs those additional fields.
+
+Both codecs are required when registering a tool. When the two inputs have the
+same shape, generation reuses one codec implementation. Fields declared with
+`Inject` appear in neither JSON input; the provider fills them from runtime
+context. Generated typed payload codecs and typed tool descriptors still
+represent execution payloads. A model codec may return the same Go payload type
+with fields left unset for the runtime to supply; that value is not yet ready
+for execution.
+
+### Upgrading tool specifications
+
+Regenerate tool specifications with the updated framework before starting
+workers. Handwritten specifications must also supply
+`ExecutionPayloadCodec`, including its encoder and decoder. Update consumers
+that decode executed or saved payloads to use this codec; model-input
+validation continues to use `Payload.Codec`. There is no fallback to the model
+codec for execution.
+
+This changes the in-process Go contract, not registry messages, model schemas,
+or saved payload formats. No wire-format or stored-data migration is required.
+
 ## Summary
 
 - **Decode JSON into a helper type** with pointer fields (the “decode-body” shape) so the codec can distinguish **missing** from **zero**.
@@ -87,5 +124,3 @@ If you mismatch them, Goa’s transform generator can emit uncompilable code suc
 
 - `if in.Field != nil { ... }` when `Field` is a value
 - `out.Field = "x"` when `Field` is a `*T`
-
-

--- a/content/en/docs/2-goa-ai/tool-payload-defaults.md
+++ b/content/en/docs/2-goa-ai/tool-payload-defaults.md
@@ -48,6 +48,14 @@ codec for execution.
 This changes the in-process Go contract, not registry messages, model schemas,
 or saved payload formats. No wire-format or stored-data migration is required.
 
+For tools with a dedicated continuation, the generated named initial payload
+codec now enforces the already-declared execution contract: the initial request
+does not accept a cursor. Decode later-page requests with the actual
+continuation tool's execution codec; do not relabel them as initial requests.
+Previously accepted initial requests containing a cursor were outside that
+contract and are not preserved by this upgrade. Declared execution schemas and
+valid saved history remain unchanged.
+
 ## Summary
 
 - **Decode JSON into a helper type** with pointer fields (the “decode-body” shape) so the codec can distinguish **missing** from **zero**.

--- a/content/es/docs/2-goa-ai/tool-payload-defaults.md
+++ b/content/es/docs/2-goa-ai/tool-payload-defaults.md
@@ -11,6 +11,45 @@ Goa-AI generates **typed tool payload structs**, **JSON Schemas**, and **codecs*
 
 This is implemented to match Goa’s own HTTP pattern: **decode-body → transform**.
 
+## Argumentos del modelo y datos de ejecución
+
+Una herramienta puede aceptar menos argumentos del modelo de los que necesita
+su ejecutor. Cada entrada tiene su propio esquema JSON y códec (las funciones
+generadas que validan, decodifican y codifican esa entrada):
+
+- `ToolSpec.Payload.Codec` corresponde a `Payload.Schema` y a su ejemplo
+  definido en el diseño. Úsalo para validar los argumentos escritos por el modelo.
+- `ToolSpec.ExecutionPayloadCodec` corresponde a `ExecutionPayloadSchema`.
+  Úsalo para los datos completos de ejecución y para restaurar trabajo guardado.
+
+En una herramienta dedicada a continuar la consulta original conservada, el modelo envía `{}`
+para solicitar la página siguiente. Antes de ejecutarla, el runtime recupera
+la consulta original y el cursor del proveedor. Por tanto, el códec del modelo
+acepta `{}`, mientras que el códec de ejecución exige los campos de consulta
+conservados y el cursor. Un ejemplo vacío no debe impedir registrar la
+herramienta solo porque su ejecución requiera esos campos adicionales.
+
+Ambos códecs son obligatorios al registrar una herramienta. Si las dos entradas
+tienen la misma estructura, el generador reutiliza una implementación. Los
+campos declarados con `Inject` no aparecen en ninguna de las entradas JSON;
+el proveedor los obtiene del contexto de ejecución. Los códecs de datos tipados
+y los descriptores tipados generados siguen representando datos de ejecución.
+Un códec del modelo puede devolver el mismo tipo Go con campos aún sin rellenar
+que el runtime proporcionará; ese valor todavía no está listo para ejecutarse.
+
+### Actualizar las especificaciones de herramientas
+
+Regenera las especificaciones con el framework actualizado antes de iniciar
+los workers. Las especificaciones escritas a mano también deben proporcionar
+`ExecutionPayloadCodec`, con codificador y decodificador. Los consumidores
+que decodifican datos ejecutados o guardados deben usar este códec; la validación
+de entradas del modelo sigue usando `Payload.Codec`. La ejecución no recurre
+al códec del modelo como alternativa.
+
+Este cambio afecta al contrato Go dentro del proceso, no a los mensajes del
+registro, los esquemas del modelo ni los formatos de datos guardados. No requiere
+migrar formatos de intercambio ni datos almacenados.
+
 ## Summary
 
 - **Decode JSON into a helper type** with pointer fields (the “decode-body” shape) so the codec can distinguish **missing** from **zero**.
@@ -67,5 +106,3 @@ If you mismatch them, Goa’s transform generator can emit uncompilable code suc
 
 - `if in.Field != nil { ... }` when `Field` is a value
 - `out.Field = "x"` when `Field` is a `*T`
-
-

--- a/content/es/docs/2-goa-ai/tool-payload-defaults.md
+++ b/content/es/docs/2-goa-ai/tool-payload-defaults.md
@@ -50,6 +50,15 @@ Este cambio afecta al contrato Go dentro del proceso, no a los mensajes del
 registro, los esquemas del modelo ni los formatos de datos guardados. No requiere
 migrar formatos de intercambio ni datos almacenados.
 
+Para herramientas con una continuación dedicada, el códec generado con nombre
+propio para el payload inicial ahora aplica el contrato de ejecución ya
+declarado: la solicitud inicial no acepta un cursor. Decodifica las solicitudes
+de páginas posteriores con el códec de ejecución de la herramienta de
+continuación que realmente se llamó; no las renombres como solicitudes
+iniciales. Las solicitudes iniciales con cursor que antes se aceptaban estaban
+fuera de ese contrato y esta actualización no mantiene su aceptación. Los
+esquemas de ejecución declarados y el historial guardado válido no cambian.
+
 ## Summary
 
 - **Decode JSON into a helper type** with pointer fields (the “decode-body” shape) so the codec can distinguish **missing** from **zero**.

--- a/content/fr/docs/2-goa-ai/tool-payload-defaults.md
+++ b/content/fr/docs/2-goa-ai/tool-payload-defaults.md
@@ -11,6 +11,46 @@ Goa-AI génère à partir de votre design Goa des **structures typées pour les 
 
 Cette implémentation suit le modèle HTTP de Goa : **décodage du corps → transformation**.
 
+## Arguments du modèle et données d'exécution
+
+Un outil peut accepter moins d'arguments du modèle que son exécuteur n'en exige.
+Chaque entrée possède son propre schéma JSON et son codec (les fonctions
+générées qui valident, décodent et encodent cette entrée) :
+
+- `ToolSpec.Payload.Codec` correspond à `Payload.Schema` et à l'exemple
+  défini dans le design. Il valide les arguments rédigés par le modèle.
+- `ToolSpec.ExecutionPayloadCodec` correspond à `ExecutionPayloadSchema`.
+  Il traite les données complètes d'exécution et restaure le travail sauvegardé.
+
+Pour un outil de continuation qui conserve la requête initiale, le modèle envoie `{}` pour demander
+la page suivante. Avant l'exécution, le runtime restaure la requête initiale et
+le curseur du fournisseur. Le codec du modèle accepte donc `{}`, tandis que
+le codec d'exécution exige les champs conservés de la requête et le curseur.
+Un exemple vide ne doit pas empêcher l'enregistrement de l'outil simplement
+parce que son exécution nécessite ces champs supplémentaires.
+
+Les deux codecs sont obligatoires à l'enregistrement. Si les deux entrées ont
+la même structure, le générateur réutilise une seule implémentation. Les champs
+déclarés avec `Inject` n'apparaissent dans aucune des deux entrées JSON ;
+le fournisseur les renseigne à partir du contexte d'exécution. Les codecs de
+charges utiles typées et les descripteurs d'outils typés générés représentent
+toujours les données d'exécution. Un codec du modèle peut renvoyer le même type
+Go avec des champs encore non renseignés que le runtime fournira ; cette valeur
+n'est pas encore prête à être exécutée.
+
+### Mise à jour des spécifications d'outils
+
+Régénérez les spécifications avec le framework mis à jour avant de démarrer les
+workers. Les spécifications écrites à la main doivent aussi fournir
+`ExecutionPayloadCodec`, avec son encodeur et son décodeur. Les consommateurs
+qui décodent des données exécutées ou sauvegardées doivent utiliser ce codec ;
+la validation des entrées du modèle continue d'utiliser `Payload.Codec`.
+L'exécution ne se rabat pas sur le codec du modèle.
+
+Ce changement concerne le contrat Go dans le processus, pas les messages du
+registre, les schémas du modèle ni les formats des données sauvegardées.
+Aucune migration des formats d'échange ou des données stockées n'est nécessaire.
+
 ## Résumé
 
 - **Décoder le JSON dans un type auxiliaire** dont les champs sont des pointeurs (la forme « decode-body ») afin que le codec distingue une valeur **absente** d'une valeur **nulle**.
@@ -97,5 +137,3 @@ Dans le cas contraire, le générateur de transformations de Goa peut produire d
 
 - `if in.Field != nil { ... }` lorsque `Field` est une valeur ;
 - `out.Field = "x"` lorsque `Field` est un `*T`.
-
-

--- a/content/fr/docs/2-goa-ai/tool-payload-defaults.md
+++ b/content/fr/docs/2-goa-ai/tool-payload-defaults.md
@@ -51,6 +51,15 @@ Ce changement concerne le contrat Go dans le processus, pas les messages du
 registre, les schémas du modèle ni les formats des données sauvegardées.
 Aucune migration des formats d'échange ou des données stockées n'est nécessaire.
 
+Pour les outils dotés d'une continuation dédiée, le codec nommé généré pour la
+charge utile initiale applique désormais le contrat d'exécution déjà déclaré :
+la requête initiale n'accepte pas de curseur. Décodez les requêtes des pages
+suivantes avec le codec d'exécution de l'outil de continuation réellement
+appelé ; ne les renommez pas en requêtes initiales. Les requêtes initiales avec
+curseur auparavant acceptées étaient hors contrat et cette mise à jour ne
+maintient pas leur acceptation. Les schémas d'exécution déclarés et l'historique
+sauvegardé valide restent inchangés.
+
 ## Résumé
 
 - **Décoder le JSON dans un type auxiliaire** dont les champs sont des pointeurs (la forme « decode-body ») afin que le codec distingue une valeur **absente** d'une valeur **nulle**.

--- a/content/it/docs/2-goa-ai/tool-payload-defaults.md
+++ b/content/it/docs/2-goa-ai/tool-payload-defaults.md
@@ -51,6 +51,15 @@ La modifica riguarda il contratto Go all'interno del processo, non i messaggi
 del registro, gli schemi del modello o i formati dei dati salvati. Non occorre
 migrare i formati di scambio o i dati archiviati.
 
+Per gli strumenti con una continuazione dedicata, il codec generato con nome
+proprio per il payload iniziale ora applica il contratto di esecuzione già
+dichiarato: la richiesta iniziale non accetta un cursore. Decodifica le richieste
+delle pagine successive con il codec di esecuzione dello strumento di
+continuazione effettivamente chiamato; non rinominarle come richieste iniziali.
+Le richieste iniziali con cursore precedentemente accettate erano fuori
+contratto e questo aggiornamento non ne mantiene l'accettazione. Gli schemi di
+esecuzione dichiarati e la cronologia salvata valida restano invariati.
+
 ## Summary
 
 - **Decode JSON into a helper type** with pointer fields (the “decode-body” shape) so the codec can distinguish **missing** from **zero**.

--- a/content/it/docs/2-goa-ai/tool-payload-defaults.md
+++ b/content/it/docs/2-goa-ai/tool-payload-defaults.md
@@ -11,6 +11,46 @@ Goa-AI generates **typed tool payload structs**, **JSON Schemas**, and **codecs*
 
 This is implemented to match Goa’s own HTTP pattern: **decode-body → transform**.
 
+## Argomenti del modello e dati di esecuzione
+
+Uno strumento può accettare dal modello meno argomenti di quanti ne richieda
+il suo esecutore. Ogni input ha il proprio schema JSON e codec (le funzioni
+generate che validano, decodificano e codificano quell'input):
+
+- `ToolSpec.Payload.Codec` corrisponde a `Payload.Schema` e all'esempio
+  definito nel design. Usalo per validare gli argomenti scritti dal modello.
+- `ToolSpec.ExecutionPayloadCodec` corrisponde a `ExecutionPayloadSchema`.
+  Usalo per i dati di esecuzione completi e per ripristinare il lavoro salvato.
+
+Per uno strumento di continuazione che conserva la query originale, il modello invia `{}` per
+richiedere la pagina successiva. Prima dell'esecuzione, il runtime ripristina
+la query originale e il cursore del provider. Il codec del modello accetta
+quindi `{}`, mentre quello di esecuzione richiede i campi conservati della
+query e il cursore. Un esempio vuoto non deve impedire la registrazione dello
+strumento solo perché l'esecuzione richiede quei campi aggiuntivi.
+
+Entrambi i codec sono obbligatori alla registrazione. Quando i due input hanno
+la stessa struttura, il generatore riutilizza una sola implementazione. I campi
+dichiarati con `Inject` non compaiono in nessuno dei due input JSON; il provider
+li compila dal contesto di esecuzione. I codec dei payload tipati e i descrittori
+degli strumenti tipati generati continuano a rappresentare dati di esecuzione.
+Un codec del modello può restituire lo stesso tipo Go lasciando non compilati
+alcuni campi che il runtime fornirà; quel valore non è ancora pronto per
+l'esecuzione.
+
+### Aggiornare le specifiche degli strumenti
+
+Rigenera le specifiche con il framework aggiornato prima di avviare i worker.
+Anche le specifiche scritte a mano devono fornire `ExecutionPayloadCodec`,
+con codificatore e decodificatore. I consumatori che decodificano dati eseguiti
+o salvati devono usare questo codec; la validazione degli input del modello
+continua a usare `Payload.Codec`. L'esecuzione non usa il codec del modello
+come alternativa.
+
+La modifica riguarda il contratto Go all'interno del processo, non i messaggi
+del registro, gli schemi del modello o i formati dei dati salvati. Non occorre
+migrare i formati di scambio o i dati archiviati.
+
 ## Summary
 
 - **Decode JSON into a helper type** with pointer fields (the “decode-body” shape) so the codec can distinguish **missing** from **zero**.
@@ -67,5 +107,3 @@ If you mismatch them, Goa’s transform generator can emit uncompilable code suc
 
 - `if in.Field != nil { ... }` when `Field` is a value
 - `out.Field = "x"` when `Field` is a `*T`
-
-

--- a/content/ja/docs/2-goa-ai/tool-payload-defaults.md
+++ b/content/ja/docs/2-goa-ai/tool-payload-defaults.md
@@ -47,6 +47,14 @@ This is implemented to match Goa’s own HTTP pattern: **decode-body → transfo
 スキーマ、保存されたペイロードの形式は変わりません。通信形式や保存データの
 移行は不要です。
 
+継続専用ツールがある場合、初回ペイロード用に生成された名前付きコーデックは、
+既に宣言されている実行契約を厳密に適用するようになります。初回リクエストは
+カーソルを受け付けません。後続ページのリクエストは、実際に呼び出された
+継続ツールの実行用コーデックでデコードしてください。初回リクエストとして
+名前を付け替えてはいけません。以前は受け付けられていたカーソル付きの
+初回リクエストは契約外であり、このアップグレードでは受け付けられなくなります。
+宣言済みの実行スキーマと、契約に適合する保存済み履歴は変わりません。
+
 ## Summary
 
 - **Decode JSON into a helper type** with pointer fields (the “decode-body” shape) so the codec can distinguish **missing** from **zero**.

--- a/content/ja/docs/2-goa-ai/tool-payload-defaults.md
+++ b/content/ja/docs/2-goa-ai/tool-payload-defaults.md
@@ -11,6 +11,42 @@ Goa-AI generates **typed tool payload structs**, **JSON Schemas**, and **codecs*
 
 This is implemented to match Goa’s own HTTP pattern: **decode-body → transform**.
 
+## モデルの引数と実行用ペイロード
+
+ツールがモデルから受け取る引数は、実行側が必要とする引数より少ない場合があります。
+それぞれの入力には、専用の JSON スキーマとコーデック（入力の検証、デコード、
+エンコードを行う生成関数）があります。
+
+- `ToolSpec.Payload.Codec` は `Payload.Schema` と設計で指定した例に対応します。
+  モデルが作成した引数の検証に使います。
+- `ToolSpec.ExecutionPayloadCodec` は `ExecutionPayloadSchema` に対応します。
+  完全な実行用ペイロードや、保存されたツール処理の復元に使います。
+
+元のクエリを保持する継続専用ツールでは、モデルは次のページを要求するために `{}` を送ります。
+実行前に、ランタイムが元のクエリとプロバイダーのカーソルを復元します。
+そのため、モデル用コーデックは `{}` を受け入れますが、実行用コーデックは
+保持されたクエリのフィールドとカーソルを必須とします。実行時に追加のフィールドが
+必要だからといって、空の例でツールの登録が失敗してはいけません。
+
+ツールの登録には両方のコーデックが必要です。入力の構造が同じ場合、生成処理は
+単一の実装を共有します。`Inject` で宣言したフィールドは、どちらの JSON 入力にも
+含まれません。プロバイダーが実行コンテキストから値を設定します。生成された型付き
+ペイロードのコーデックと型付きツール記述子は、引き続き実行用ペイロードを表します。
+モデル用コーデックは同じ Go 型を返すことがありますが、ランタイムが設定する
+フィールドは未設定のままです。その値はまだ実行できる状態ではありません。
+
+### ツール仕様のアップグレード
+
+ワーカーを起動する前に、更新後のフレームワークでツール仕様を再生成してください。
+手書きの仕様にも、エンコーダーとデコーダーを備えた `ExecutionPayloadCodec` が
+必要です。実行済みまたは保存済みのペイロードをデコードするコードは、この
+コーデックを使うよう変更してください。モデル入力の検証には引き続き
+`Payload.Codec` を使います。実行時にモデル用コーデックで代用することはありません。
+
+この変更はプロセス内の Go 契約に関するもので、レジストリのメッセージ、モデルの
+スキーマ、保存されたペイロードの形式は変わりません。通信形式や保存データの
+移行は不要です。
+
 ## Summary
 
 - **Decode JSON into a helper type** with pointer fields (the “decode-body” shape) so the codec can distinguish **missing** from **zero**.
@@ -67,5 +103,3 @@ If you mismatch them, Goa’s transform generator can emit uncompilable code suc
 
 - `if in.Field != nil { ... }` when `Field` is a value
 - `out.Field = "x"` when `Field` is a `*T`
-
-


### PR DESCRIPTION
Tool authors need to distinguish the arguments a model writes from the complete input an executor receives. This documentation companion to [goa-ai #345](https://github.com/goadesign/goa-ai/pull/345) explains that distinction on the existing Tool Payload Defaults page in English, Spanish, French, Italian, and Japanese. The runtime pages already link there; no second contract description is added.

## What the two codecs accept

A codec is the generated code that validates, decodes, and encodes an input. Previously, the documentation explained payload defaults without identifying which codec accepts model input and which accepts complete execution input. A dedicated continuation tool illustrates why that matters: the model can send `{}` for the next page while execution still requires the original query and the provider's cursor. Using the execution decoder to validate the empty model example incorrectly rejects registration.

The new section defines `ToolSpec.Payload.Codec` against `Payload.Schema` and its authored example, and `ToolSpec.ExecutionPayloadCodec` against `ExecutionPayloadSchema`. The runtime supplies retained query fields and the cursor before execution. The provider still supplies fields declared with `Inject`; those fields are absent from both JSON inputs. When the input shapes match, generation shares one codec implementation. Generated typed payload codecs and typed tool descriptors retain their execution meaning.

## Required upgrade, unchanged data formats

With the framework change, applications must regenerate tool specifications before starting workers. Handwritten specifications must provide the execution encoder and decoder, and consumers of executed or saved payloads must use `ExecutionPayloadCodec`. Model-input validation continues to use `Payload.Codec`; execution does not fall back to it.

The generated initial codec also enforces the existing no-cursor contract for dedicated pagination. Later-page requests must use their actual continuation tool codec, without relabeling them as initial requests. Previously accepted cursor-bearing initial requests were outside that contract and are not preserved; declared schemas and valid saved history remain unchanged.

This is an in-process Go contract change, not a change to registry messages, model schemas, or saved payload formats. No wire-format or stored-data migration is needed. This PR changes only documentation and does not deploy workers or change runtime behavior. Its publication should accompany the framework change so users do not mistake the new field for an already available API.

## Verification

Read all five changed pages end to end and compared the new text with the framework's `ToolSpec` and registration implementation. `hugo --minify` completed successfully; all five rendered pages contain both codec names, and the existing runtime links resolve to the appropriate language page. Hugo and Sass emitted existing deprecation warnings, with no build errors. `git diff --check` passed.

Review the English **Model arguments and execution payloads** and **Upgrading tool specifications** sections first; the four translations mirror those additions. Existing defaults and unrelated retry or paging documentation are unchanged.

