### PR TITLE
Document finish recovery without reopening new operations

### DIFF
--- a/content/en/docs/2-goa-ai/runtime.md
+++ b/content/en/docs/2-goa-ai/runtime.md
@@ -507,11 +507,11 @@ Agent("chat", "Conversational runner", func() {
 
 This becomes a `runtime.RunPolicy` attached to the agent's registration:
 
-- **Caps**: `MaxToolCalls` is the total budgeted tool calls per run. `MaxRecoveryTurns` limits replacement planner calls after rejected tool or model output. A successful budgeted tool call starts a fresh recovery allowance. Tools declared `Bookkeeping()` consume neither budget. Model-authored batches stay atomic: bookkeeping calls add zero cost, but the runtime never removes individual calls to make a mixed batch fit. Successful bookkeeping results stay out of compact future `ToolOutputs`.
+- **Caps**: `MaxToolCalls` is the total budgeted tool calls per run. `MaxRecoveryTurns` limits replacement planner calls after rejected tool or model output. Successful budgeted work starts a fresh recovery allowance unless a `finish` failure remains active; successful pages never reset that failure's allowance. Tools declared `Bookkeeping()` consume neither budget. Model-authored batches stay atomic: bookkeeping calls add zero cost, but the runtime never removes individual calls to make a mixed batch fit. Successful bookkeeping results stay out of compact future `ToolOutputs`.
 - **Time budget**: `TimeBudget` – wall-clock budget for the run. `FinalizerGrace` (runtime-only) – optional reserved window for finalization.
 - **Interrupts**: `InterruptsAllowed` – opt-in for pause/resume.
 - **Missing fields behavior**: `OnMissingFields` – governs what happens when validation indicates missing fields.
-- **Terminal tools**: Tools declared `TerminalRun()` automatically become bookkeeping and complete the run once they succeed—no follow-up `PlanResume` turn is scheduled. A terminal commit can therefore be admitted with no retrieval budget remaining. During forced finalization, the runtime admits only terminal bookkeeping calls, executes them inside the remaining hard-deadline window, and closes the run only if every terminal side effect succeeds. Before execution, the runtime writes the exact `planner.TerminationReason` to `runtime.FinalizationReasonLabel` (`goa-ai.finalization_reason`). Run labels, policy labels, planner output, and model output cannot choose or replace this value. Ordinary calls do not receive it.
+- **Terminal tools**: Tools declared `TerminalRun()` automatically become bookkeeping and complete the run once they succeed—no follow-up `PlanResume` turn is scheduled. A terminal commit can therefore be admitted with no retrieval budget remaining. During deadline or cap finalization, the runtime admits only terminal bookkeeping calls, executes them inside the remaining hard-deadline window, and closes the run only if every terminal side effect succeeds. Before execution, the runtime writes the exact `planner.TerminationReason` to `runtime.FinalizationReasonLabel` (`goa-ai.finalization_reason`). Run labels, policy labels, planner output, and model output cannot choose or replace this value. Ordinary calls do not receive it.
 
   Consumers of fixed-limit or planner-authored terminal calls, including `tool_failure`, use `runtime.FinalizationReasonLabel`. Deploy a change to this execution contract across consumers and runtime workers together.
 
@@ -1227,7 +1227,7 @@ These contracts are separate:
 | `ToolFailure.Recovery.Action` | One failed result | Selects correction with the failed tool still available, replanning without it, or finalization. |
 | `PlanResult.SynthesizeAfterTools` | One selected batch | If the batch has no recoverable failure, the next planner turn must answer. |
 | `PlanResumeInput.SynthesisOnly` | One planner activity | Return a final answer; tool calls are invalid. |
-| `PlanResumeInput.Finalize` | Runtime-forced termination | A cap or deadline has prohibited normal work. |
+| `PlanResumeInput.Finalize` | Runtime-forced completion | New operations are forbidden. With reason `tool_failure`, the advertised catalog may retain pages of queries already started. |
 
 The runtime chooses one next state in this order:
 
@@ -1235,11 +1235,14 @@ The runtime chooses one next state in this order:
 | --- | --- |
 | A cap or deadline requires finalization | `Finalize` turn |
 | A successful `TerminalRun` tool completed | End immediately |
+| A `finish` failure remains active | `Finalize` with reason `tool_failure`; retain advertised pages and terminal bookkeeping |
 | Any failed result has `AllowsToolTurn() == true` | Normal repair turn |
 | `SynthesizeAfterTools` is true | `SynthesisOnly` turn |
 | Otherwise | Normal continuation turn |
 
 This keeps planner intent from becoming a second retry policy. A recoverable failure is repaired first; a successful or terminally failed final batch proceeds to synthesis. The runtime rejects tool calls returned from a `SynthesisOnly` turn.
+
+### Tool failure recovery {#finish-recovery}
 
 Each recoverable `ToolFailure` also selects a `Recovery.Action`:
 
@@ -1251,8 +1254,31 @@ Each recoverable `ToolFailure` also selects a `Recovery.Action`:
   answer from the evidence already collected.
 - `replan` removes the failed tool from the next planner turn. The planner may
   use another advertised tool, wait for input, or answer.
-- `finish` removes all tools and requires a final answer from the available
-  evidence.
+- `finish` forbids starting new operations until the run ends. The planner may
+  answer, use registered terminal bookkeeping tools to save its final result,
+  or fetch an advertised page of a query already started.
+
+For `finish`, `PlanResumeInput.Finalize` carries reason `tool_failure`. The
+current catalog, not the reason alone, determines the available actions. A page
+and a terminal submission cannot share a batch: the runtime rejects that batch
+before either executes. New input requests and separate synthesis steps are
+also rejected. With no live page, only terminal completion remains. Deadline
+and cap finalization never permit pagination.
+
+Active tool failures and feedback about one rejected model response are
+separate facts. Rejected responses and successful pages preserve the original
+failure, its message, and the restriction on new work. Ordinary `correct_call`
+and `replan` restrictions end with their own recovery episode. Model validation
+supplies schema constraints and examples; the runtime requests a replacement
+response under the current actions and completion requirements, not necessarily
+another tool call.
+
+Successful pages spend the normal tool/time budgets but neither consume a
+replacement attempt nor reset the active finish failure's recovery allowance.
+Each rejection-driven replacement still consumes `MaxRecoveryTurns`. If a
+terminal submission needs corrected arguments, the next request retains both
+the original failure and the new validation diagnostic. Only the failed
+terminal tool is advertised for that repair; pages do not reopen.
 
 An ordinary `correct_call` turn combines the current agent's executable tools
 with the exact failed-tool contracts. Matching names are deduplicated;
@@ -1265,7 +1291,8 @@ authorization still checks every executed call.
 Unfinished queries retain their runtime-generated continuation actions; failed
 requests do not create continuations. Forced finalization offers only the exact
 failed terminal tool for correction, and synthesis-only turns remain tool-free.
-After correction, normal turns return to the current agent's tools.
+After ordinary correction, normal turns return to the current agent's tools;
+an active finish failure keeps new operations closed.
 
 The workflow owns model-facing correction evidence. It replaces executor-
 supplied prior input and examples with the original provider call and the
@@ -1281,7 +1308,8 @@ every executable call outside it, including a call embedded in a request for
 user or external input. Generated codecs still validate every payload, and the
 run's tool, failure, and time limits still stop repeated invalid work. If a
 recovery turn waits for input, its failure evidence remains available when the
-run resumes; choosing a tool call or final answer clears that evidence.
+run resumes. Accepted ordinary recovery work ends its episode; a page or
+replacement response never clears an active finish failure.
 
 Recovery activity inputs and their advertised catalog are part of durable
 workflow history. Production deployments must use pinned Temporal Worker
@@ -1289,6 +1317,16 @@ Deployment Versioning and retain each old worker version until Temporal reports
 it drained. Starting a new worker does not make it safe to replay an existing
 workflow on new code. A continuation is a new workflow and may use the current
 version after its saved checkpoint passes validation.
+
+This finish-recovery change adds no activity or checkpoint fields and needs no
+data migration. Custom planners must use the advertised catalog alongside
+`Finalize.Reason`; update them with the runtime. Old histories that reopened
+domain work after a finish failure are not execution-compatible: their recorded
+ordinary-tool plans are rejected before execution. Keep affected unfinished
+histories on their owning worker version or complete them before replacement.
+Successful checkpoint decoding does not prove history replay compatibility.
+Review worker/history routing for rollback too; do not mix activity versions
+within an affected workflow.
 
 When `PlanResumeInput.Finalize` is set, planners may return terminal bookkeeping tools; those calls are not replayed into a later planner turn and must durably finish finalization.
 

--- a/content/en/docs/2-goa-ai/toolsets.md
+++ b/content/en/docs/2-goa-ai/toolsets.md
@@ -318,7 +318,10 @@ When a bounded tool executes:
 4. If another tool in the same parallel batch requires `finish` recovery, the
    failed tool cannot run again and no new domain work can start. Continuation
    actions remain available for successful queries that already returned a
-   next-page cursor. Without such an action, finalization starts immediately
+   next-page cursor, alongside terminal bookkeeping tools that save the final
+   result. The planner may fetch a page or submit the result, never both in one
+   batch. Neither a page nor a rejected response reopens new operations. Without
+   a live page, only terminal completion remains. See [tool failure recovery](../runtime/#finish-recovery)
 5. For direct `Cursor`, the runtime projects the opaque cursor into
    `next_cursor` and the model supplies it on the next call
 6. Stream subscribers and finalizers access bounds for UI display, logging, or
@@ -809,7 +812,8 @@ explicit actions:
 - `RecoveryCorrectCall` keeps the failed tool available and supplies structured
   correction evidence.
 - `RecoveryReplan` removes the failed tool from the next planner turn.
-- `RecoveryFinish` allows only finalization from evidence already collected.
+- `RecoveryFinish` forbids new operations while permitting terminal completion
+  or advertised pages of queries already started.
 
 `ToolResult` carries either a typed result or one structured failure:
 
@@ -896,7 +900,8 @@ func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *runtime.Tool
 canonical payload/result bytes plus `Failure`. For `RecoveryCorrectCall`, field
 issues, prior input, and example JSON let the next planner turn correct the
 call. `RecoveryReplan` removes the failed tool from that next turn.
-`RecoveryFinish` permits only finalization. The runtime enforces these
+`RecoveryFinish` follows the [finish-recovery contract](../runtime/#finish-recovery).
+The runtime enforces these
 transitions; planners do not infer them from error text. Only provider-authored
 calls can use `RecoveryCorrectCall`. Runtime-created continuations have no
 model-authored input and must replan or finish instead of exposing their

--- a/content/es/docs/2-goa-ai/runtime.md
+++ b/content/es/docs/2-goa-ai/runtime.md
@@ -522,7 +522,7 @@ Agent("chat", "Conversational runner", func() {
 
 Esto se convierte en un `runtime.RunPolicy` adjunto al registro del agente:
 
-- **Límites**: `MaxToolCalls` limita el total de llamadas a herramientas con presupuesto por ejecución. `MaxRecoveryTurns` limita las nuevas llamadas al planificador después de rechazar el resultado de una herramienta o una respuesta del modelo. Una llamada correcta a una herramienta con presupuesto reinicia este límite. Las herramientas `Bookkeeping()` no consumen ninguno de estos presupuestos.
+- **Límites**: `MaxToolCalls` limita el total de llamadas a herramientas con presupuesto por ejecución. `MaxRecoveryTurns` limita las nuevas llamadas al planificador después de rechazar el resultado de una herramienta o una respuesta del modelo. El trabajo correcto con presupuesto reinicia esta asignación salvo que siga activo un fallo `finish`; las páginas obtenidas correctamente nunca reinician la asignación de ese fallo. Las herramientas `Bookkeeping()` no consumen ninguno de estos presupuestos.
 - **Presupuesto de tiempo**: `TimeBudget` – presupuesto de reloj de pared para la ejecución. `FinalizerGrace` (solo runtime) – ventana reservada opcional para la finalización.
 - **Interrupciones**: `InterruptsAllowed` – opt-in para pausa/reanudación.
 - **Comportamiento ante campos faltantes**: `OnMissingFields` – rige lo que ocurre cuando la validación indica que faltan campos.
@@ -530,7 +530,7 @@ Esto se convierte en un `runtime.RunPolicy` adjunto al registro del agente:
   convierten automáticamente en bookkeeping y completan la ejecución al tener
   éxito, sin programar un turno `PlanResume` posterior. Por tanto, un commit
   terminal puede admitirse sin presupuesto de recuperación restante. Durante
-  la finalización forzada, el runtime admite solo llamadas terminales de
+  la finalización por plazo o límite, el runtime admite solo llamadas terminales de
   bookkeeping, las ejecuta dentro de la ventana restante del hard deadline y
   cierra la ejecución solo si todos los efectos laterales terminales tienen
   éxito. Antes de ejecutarlas, el runtime escribe el
@@ -1190,7 +1190,7 @@ Estos contratos son independientes:
 | `ToolFailure.Recovery.Action` | Un resultado fallido | Selecciona la corrección manteniendo disponible la herramienta fallida, la replanificación sin ella o la finalización. |
 | `PlanResult.SynthesizeAfterTools` | Un lote seleccionado | Si el lote no tiene un fallo recuperable, el siguiente turno del planner debe responder. |
 | `PlanResumeInput.SynthesisOnly` | Una actividad del planner | Devuelve una respuesta final; las llamadas a herramientas no son válidas. |
-| `PlanResumeInput.Finalize` | Finalización forzada por el runtime | Un límite o deadline ha prohibido el trabajo normal. |
+| `PlanResumeInput.Finalize` | Finalización impuesta por el runtime | No se permiten nuevas operaciones. Con el motivo `tool_failure`, el catálogo anunciado puede conservar páginas de consultas ya iniciadas. |
 
 El runtime elige un único estado siguiente en este orden:
 
@@ -1198,11 +1198,14 @@ El runtime elige un único estado siguiente en este orden:
 | --- | --- |
 | Un límite o deadline exige finalización | Turno `Finalize` |
 | Se completó una herramienta `TerminalRun` correcta | Finaliza inmediatamente |
+| Sigue activo un fallo `finish` | `Finalize` con motivo `tool_failure`; conserva las páginas anunciadas y las herramientas terminales de bookkeeping |
 | Algún resultado fallido tiene `AllowsToolTurn() == true` | Turno normal de recuperación |
 | `SynthesizeAfterTools` es true | Turno `SynthesisOnly` |
 | En otro caso | Turno normal de continuación |
 
 Esto evita que la intención del planner se convierta en una segunda política de reintentos. Un fallo recuperable se repara primero; un lote final correcto o con fallo terminal pasa a síntesis. El runtime rechaza las llamadas a herramientas devueltas desde un turno `SynthesisOnly`.
+
+### Recuperación de fallos de herramientas {#finish-recovery}
 
 Cada `ToolFailure` recuperable también selecciona una `Recovery.Action`:
 
@@ -1214,8 +1217,31 @@ Cada `ToolFailure` recuperable también selecciona una `Recovery.Action`:
   con la evidencia ya recopilada.
 - `replan` elimina la herramienta que falló del siguiente turno del planner. El
   planner puede usar otra herramienta anunciada, esperar una entrada o responder.
-- `finish` elimina todas las herramientas y exige una respuesta final basada en
-  la evidencia disponible.
+- `finish` prohíbe iniciar nuevas operaciones hasta que termine la ejecución.
+  El planificador puede responder, usar herramientas terminales registradas para
+  guardar el resultado final u obtener una página anunciada de una consulta ya iniciada.
+
+Con `finish`, `PlanResumeInput.Finalize` lleva el motivo `tool_failure`. El
+catálogo actual, no solo el motivo, determina las acciones disponibles. Una
+página y un envío terminal no pueden compartir lote: el runtime rechaza el
+lote antes de ejecutar cualquiera de ellos. También rechaza nuevas solicitudes
+de entrada y pasos separados de síntesis. Sin páginas disponibles, solo queda
+la finalización terminal. La finalización por plazo o límite nunca permite paginar.
+
+Los fallos activos de herramientas y las indicaciones para una respuesta del
+modelo rechazada son hechos separados. Los rechazos y las páginas obtenidas
+conservan el fallo original, su mensaje y la prohibición de nuevo trabajo.
+Las restricciones ordinarias de `correct_call` y `replan` terminan con su
+propio episodio de recuperación. La validación del modelo aporta restricciones
+del esquema y ejemplos; el runtime pide una respuesta de reemplazo conforme a
+las acciones y requisitos de finalización actuales, no necesariamente otra llamada.
+
+Las páginas correctas consumen el presupuesto normal de herramientas y tiempo,
+pero no un intento de reemplazo ni reinician la asignación del fallo `finish`.
+Cada reemplazo causado por un rechazo sigue consumiendo `MaxRecoveryTurns`.
+Si el envío terminal necesita argumentos corregidos, la siguiente solicitud
+conserva el fallo original y el nuevo diagnóstico de validación. Para esa
+corrección solo se anuncia la herramienta terminal fallida; las páginas no reaparecen.
 
 Un turno normal de `correct_call` combina las herramientas ejecutables del
 agente actual con los contratos exactos de las herramientas fallidas. Elimina
@@ -1231,7 +1257,8 @@ Las consultas sin terminar conservan sus acciones de continuación generadas
 por el runtime; las solicitudes fallidas no crean continuaciones. La
 finalización forzada solo ofrece para corrección la herramienta terminal exacta
 que falló, y los turnos de solo síntesis siguen sin herramientas. Después de la
-corrección, los turnos normales vuelven a las herramientas del agente actual.
+corrección ordinaria, los turnos normales vuelven a las herramientas del agente
+actual; un fallo `finish` activo sigue prohibiendo nuevas operaciones.
 
 El runtime registra el catálogo exacto de herramientas mostrado en un turno de
 recuperación y rechaza cualquier llamada ejecutable que quede fuera de él,
@@ -1239,14 +1266,28 @@ incluidas las llamadas incorporadas en una solicitud de entrada del usuario o
 de un sistema externo. Los codecs generados siguen validando cada payload, y
 los límites de herramientas, fallos y tiempo de la ejecución siguen deteniendo
 el trabajo inválido repetido. Si un turno de recuperación espera una entrada,
-su evidencia de fallo sigue disponible cuando la ejecución continúa; elegir
-una llamada o una respuesta final elimina esa evidencia.
+su evidencia de fallo sigue disponible cuando la ejecución continúa. El trabajo
+de recuperación ordinario aceptado termina su episodio; una página o una
+respuesta de reemplazo nunca elimina un fallo `finish` activo.
 
 Las entradas de las actividades de recuperación y su catálogo anunciado forman
-parte del historial duradero del workflow. Un despliegue que cambie este
-contrato debe drenar o detener los workers antiguos y los workflows en curso
-antes de iniciar el nuevo conjunto de workers. No es seguro mezclar versiones
-de workers a través de este límite.
+parte del historial duradero del workflow. Los despliegues de producción deben
+usar Temporal Worker Deployment Versioning con versiones fijadas y conservar
+cada versión antigua hasta que Temporal indique que está drenada. Iniciar un
+worker nuevo no permite reproducir automáticamente un workflow existente con
+código nuevo. Una continuación es un workflow nuevo y puede usar la versión
+actual una vez validado su checkpoint guardado.
+
+Este cambio no añade campos a las actividades ni a los checkpoints y no necesita
+migración de datos. Los planificadores personalizados deben usar el catálogo
+anunciado junto con `Finalize.Reason`; actualízalos con el runtime. Los
+historiales antiguos que reabrieron trabajo de dominio tras un fallo `finish`
+no son compatibles con la ejecución: sus planes de herramientas ordinarias
+se rechazan antes de ejecutarlos. Mantén los historiales afectados sin terminar
+en su versión de worker original o complétalos antes de reemplazarla. Poder
+decodificar un checkpoint no demuestra compatibilidad de reproducción del
+historial. Revisa también la asignación de historiales a workers al revertir;
+no mezcles versiones de actividades dentro de un workflow afectado.
 
 Cuando `PlanResumeInput.Finalize` está presente, los planners pueden devolver herramientas terminales de bookkeeping; esas llamadas no se reproducen en un turno posterior del planner y deben terminar la finalización de forma duradera.
 

--- a/content/es/docs/2-goa-ai/toolsets.md
+++ b/content/es/docs/2-goa-ai/toolsets.md
@@ -305,7 +305,7 @@ Cuando se ejecuta una herramienta acotada:
 1. El runtime valida que una herramienta acotada exitosa haya devuelto `planner.ToolResult.Bounds`
 2. El runtime fusiona esos bounds en el JSON emitido usando los nombres JSON visibles para el modelo generados desde `BoundedResult(...)`
 3. Con `ContinueWith`, el runtime ofrece la acción vacía solo cuando una única cabeza activa de la cadena puede continuar y enlaza el cursor antes de ejecutar
-4. Si otra herramienta del mismo lote paralelo requiere recuperación `finish`, la herramienta fallida no puede volver a ejecutarse y no puede iniciarse nuevo trabajo de dominio. Las acciones de continuación siguen disponibles para las consultas exitosas que ya devolvieron un cursor de página siguiente. Sin una acción de ese tipo, la finalización comienza inmediatamente
+4. Si otra herramienta del mismo lote paralelo requiere recuperación `finish`, no pueden iniciarse nuevas operaciones. Las consultas correctas con una página siguiente conservan sus acciones de continuación junto con las herramientas terminales que guardan el resultado final. El planificador puede obtener una página o enviar el resultado, nunca ambos en un lote. Ni una página ni una respuesta rechazada reabren operaciones. Sin páginas disponibles, solo queda la finalización terminal. Consulta la [recuperación de fallos](../runtime/#finish-recovery)
 5. Con `Cursor` directo, el runtime emite el cursor opaco en `next_cursor` para la siguiente llamada del modelo
 6. Los suscriptores de streams y los finalizadores acceden a los bounds para su visualización en la UI, logging o decisiones de políticas
 
@@ -773,7 +773,8 @@ errores internos. La recuperación tiene tres acciones explícitas:
 - `RecoveryCorrectCall` mantiene disponible la herramienta que falló y aporta
   evidencia estructurada para corregirla.
 - `RecoveryReplan` elimina esa herramienta del siguiente turno.
-- `RecoveryFinish` permite únicamente finalizar con la evidencia ya reunida.
+- `RecoveryFinish` prohíbe nuevas operaciones y permite la finalización terminal
+  o páginas anunciadas de consultas ya iniciadas.
 
 `ToolResult` lleva un resultado tipado o un único fallo estructurado:
 
@@ -864,8 +865,9 @@ func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *runtime.Tool
 llamada: los bytes canónicos de payload y resultado, más `Failure`. Para
 `RecoveryCorrectCall`, los problemas de campo, la entrada anterior y el JSON de
 ejemplo permiten corregir la llamada en el siguiente turno.
-`RecoveryReplan` elimina la herramienta que falló; `RecoveryFinish` permite
-solo la finalización. El runtime impone estas transiciones: el planificador no
+`RecoveryReplan` elimina la herramienta que falló; `RecoveryFinish` sigue el
+[contrato de finalización tras un fallo](../runtime/#finish-recovery).
+El runtime impone estas transiciones: el planificador no
 las deduce del texto del error.
 
 Solo las llamadas creadas por el proveedor pueden usar

--- a/content/fr/docs/2-goa-ai/runtime.md
+++ b/content/fr/docs/2-goa-ai/runtime.md
@@ -529,14 +529,14 @@ Agent("chat", "Conversational runner", func() {
 
 Celui-ci devient un `runtime.RunPolicy` attaché à l'inscription de l'agent :
 
-- **Caps** : `MaxToolCalls` limite le nombre total d'appels d'outils budgétisés par exécution. `MaxRecoveryTurns` limite les nouveaux appels au planificateur après le rejet d'un résultat d'outil ou d'une réponse du modèle. Un appel d'outil budgétisé réussi réinitialise cette allocation. Les outils déclarés `Bookkeeping()` ne consomment aucun de ces budgets.
+- **Caps** : `MaxToolCalls` limite le nombre total d'appels d'outils budgétisés par exécution. `MaxRecoveryTurns` limite les nouveaux appels au planificateur après le rejet d'un résultat d'outil ou d'une réponse du modèle. Le travail budgétisé réussi réinitialise cette allocation sauf si un échec `finish` reste actif ; les pages obtenues ne réinitialisent jamais l'allocation de cet échec. Les outils déclarés `Bookkeeping()` ne consomment aucun de ces budgets.
 - **Budget temps** : `TimeBudget` – budget d'horloge murale pour la course. `FinalizerGrace` (exécution uniquement) – fenêtre réservée en option pour la finalisation.
 - **Interruptions** : `InterruptsAllowed` – option pour la pause/reprise.
 - **Comportement des champs manquants** : `OnMissingFields` – régit ce qui se passe lorsque la validation indique des champs manquants.
 - **Outils terminaux** : les outils déclarés `TerminalRun()` deviennent
   automatiquement comptables et terminent l'exécution après leur succès ;
   aucun tour `PlanResume` supplémentaire n'est planifié. Pendant la
-  finalisation forcée, le runtime n'admet que les appels comptables terminaux,
+  finalisation due à un délai ou un plafond, le runtime n'admet que les appels comptables terminaux,
   les exécute avant l'échéance absolue et ne ferme l'exécution que si tous leurs
   effets réussissent. Avant l'appel, il écrit la valeur exacte de
   `planner.TerminationReason` dans `runtime.FinalizationReasonLabel`
@@ -1193,7 +1193,7 @@ Ces contrats sont distincts :
 | `ToolFailure.Recovery.Action` | Un résultat en échec | Choisit la correction en gardant l'outil en échec disponible, la replanification sans cet outil ou la finalisation. |
 | `PlanResult.SynthesizeAfterTools` | Un lot sélectionné | Si le lot n'a aucun échec récupérable, le prochain tour du planificateur doit répondre. |
 | `PlanResumeInput.SynthesisOnly` | Une activité du planificateur | Renvoyer une réponse finale ; les appels d'outils sont invalides. |
-| `PlanResumeInput.Finalize` | Arrêt imposé par le runtime | Un plafond ou une deadline interdit le travail normal. |
+| `PlanResumeInput.Finalize` | Fin imposée par le runtime | Les nouvelles opérations sont interdites. Avec le motif `tool_failure`, le catalogue annoncé peut conserver les pages de requêtes déjà commencées. |
 
 Le runtime choisit l'état suivant dans cet ordre :
 
@@ -1201,6 +1201,7 @@ Le runtime choisit l'état suivant dans cet ordre :
 | --- | --- |
 | Un plafond ou une deadline impose la finalisation | Tour `Finalize` |
 | Un outil `TerminalRun` a réussi | Fin immédiate |
+| Un échec `finish` reste actif | `Finalize` avec le motif `tool_failure` ; conserve les pages annoncées et les outils terminaux de comptabilité |
 | Un résultat en échec a `ToolFailure.AllowsToolTurn() == true` | Tour normal de récupération |
 | `SynthesizeAfterTools` vaut true | Tour `SynthesisOnly` |
 | Sinon | Tour normal de continuation |
@@ -1209,6 +1210,8 @@ Ainsi, l'intention du planificateur ne devient pas une seconde politique de
 reprise. Un échec récupérable est réparé d'abord ; un lot final réussi ou en
 échec terminal passe à la synthèse. Le runtime rejette les appels d'outils
 renvoyés depuis un tour `SynthesisOnly`.
+
+### Récupération après un échec d'outil {#finish-recovery}
 
 Chaque `ToolFailure` récupérable sélectionne aussi une `Recovery.Action` :
 
@@ -1220,8 +1223,32 @@ Chaque `ToolFailure` récupérable sélectionne aussi une `Recovery.Action` :
   entrée ou répondre avec les éléments déjà recueillis.
 - `replan` retire l'outil en échec du prochain tour. Le planificateur peut
   utiliser un autre outil annoncé, attendre une entrée ou répondre.
-- `finish` retire tous les outils et exige une réponse finale fondée sur les
-  éléments disponibles.
+- `finish` interdit toute nouvelle opération jusqu'à la fin de l'exécution.
+  Le planificateur peut répondre, utiliser les outils terminaux enregistrés pour
+  sauvegarder son résultat final ou lire une page annoncée d'une requête déjà commencée.
+
+Avec `finish`, `PlanResumeInput.Finalize` porte le motif `tool_failure`. Le
+catalogue actuel, et non le motif seul, détermine les actions disponibles. Une
+page et un envoi terminal ne peuvent pas partager un lot : le runtime rejette
+ce lot avant toute exécution. Les nouvelles demandes d'entrée et les étapes
+de synthèse séparées sont également rejetées. Sans page disponible, seule la
+conclusion terminale reste possible. Une finalisation due à un délai ou un
+plafond ne permet jamais la pagination.
+
+Les échecs d'outils actifs et les indications concernant une réponse du modèle
+rejetée sont des faits distincts. Les rejets et les pages obtenues conservent
+l'échec original, son message et l'interdiction de nouveau travail. Les
+restrictions ordinaires de `correct_call` et `replan` prennent fin avec leur
+propre épisode de récupération. La validation du modèle fournit les contraintes
+du schéma et les exemples ; le runtime demande une réponse de remplacement
+conforme aux actions et exigences de conclusion actuelles, pas nécessairement un appel d'outil.
+
+Les pages obtenues consomment les budgets habituels d'outils et de temps, mais
+ni tentative de remplacement ni réinitialisation de l'allocation de l'échec
+`finish`. Chaque remplacement dû à un rejet consomme toujours `MaxRecoveryTurns`.
+Si l'envoi terminal nécessite des arguments corrigés, la requête suivante
+conserve l'échec original et le nouveau diagnostic de validation. Seul l'outil
+terminal en échec est annoncé pour cette correction ; les pages ne réapparaissent pas.
 
 Un tour ordinaire de `correct_call` combine les outils exécutables de l'agent
 actuel avec les contrats exacts des outils en échec. Les noms et contrats
@@ -1236,8 +1263,9 @@ toujours chaque appel.
 Les requêtes inachevées conservent leurs actions de continuation générées par le
 runtime ; les demandes en échec ne créent pas de continuation. La finalisation
 forcée ne propose à la correction que l'outil terminal exact en échec, et les
-tours de synthèse seule restent sans outils. Après la correction, les tours
-normaux reviennent aux outils de l'agent actuel.
+tours de synthèse seule restent sans outils. Après une correction ordinaire,
+les tours normaux reviennent aux outils de l'agent actuel ; un échec `finish`
+actif continue d'interdire les nouvelles opérations.
 
 Le workflow possède les informations de correction visibles par le modèle.
 Avant d'enregistrer l'échec, il remplace l'entrée antérieure et l'exemple
@@ -1258,14 +1286,29 @@ compris un appel intégré à une demande d'entrée utilisateur ou externe. Les
 codecs générés valident toujours chaque charge utile, et les limites d'outils,
 d'échecs et de temps arrêtent toujours les travaux invalides répétés. Si un
 tour de récupération attend une entrée, ses éléments d'échec restent
-disponibles à la reprise ; le choix d'un appel d'outil ou d'une réponse finale
-les efface.
+disponibles à la reprise. Le travail de récupération ordinaire accepté termine
+son épisode ; une page ou une réponse de remplacement n'efface jamais un échec
+`finish` actif.
 
 Les entrées d'activité de récupération et leur catalogue annoncé font partie de
-l'historique durable du workflow. Un déploiement qui modifie ce contrat doit
-drainer ou arrêter les anciens workers et les workflows en cours avant de
-démarrer le nouveau groupe de workers. Mélanger les versions de workers à cette
-frontière n'est pas sûr.
+l'historique durable du workflow. Les déploiements de production doivent utiliser
+Temporal Worker Deployment Versioning avec des versions épinglées et conserver
+chaque ancienne version jusqu'à ce que Temporal la signale comme drainée.
+Démarrer un nouveau worker n'autorise pas à rejouer un workflow existant avec
+du nouveau code. Une continuation est un nouveau workflow et peut utiliser la
+version actuelle après validation de son checkpoint enregistré.
+
+Ce changement n'ajoute aucun champ aux activités ou aux checkpoints et ne
+nécessite aucune migration de données. Les planificateurs personnalisés doivent
+utiliser le catalogue annoncé avec `Finalize.Reason` ; mettez-les à jour avec
+le runtime. Les anciens historiques qui ont rouvert du travail métier après
+un échec `finish` ne sont pas compatibles avec cette exécution : leurs plans
+d'outils ordinaires sont rejetés avant exécution. Gardez les historiques
+concernés encore actifs sur leur version de worker d'origine ou terminez-les
+avant de la remplacer. Décoder un checkpoint ne prouve pas la compatibilité
+de rejeu de l'historique. Vérifiez aussi l'affectation des historiques aux
+workers lors d'un retour arrière ; ne mélangez pas les versions d'activités
+au sein d'un workflow concerné.
 
 Lorsque `PlanResumeInput.Finalize` est défini, les planificateurs peuvent
 renvoyer des outils terminaux de comptabilité ; ces appels ne sont pas rejoués

--- a/content/fr/docs/2-goa-ai/toolsets.md
+++ b/content/fr/docs/2-goa-ai/toolsets.md
@@ -303,7 +303,7 @@ Lorsqu'un outil limité s'exécute :
 1. Le runtime valide qu'un outil limité réussi a renvoyé `planner.ToolResult.Bounds`
 2. Le moteur d'exécution fusionne ces limites dans le JSON émis en utilisant les noms de champs de `BoundedResult(...)`.
 3. Avec `ContinueWith`, le runtime propose l'action vide uniquement pour une tête de chaîne active non ambiguë et associe le curseur avant l'exécution
-4. Si un autre outil du même lot parallèle nécessite une récupération `finish`, l'outil en échec ne peut pas être relancé et aucun nouveau travail métier ne peut commencer. Les actions de continuation restent disponibles pour les requêtes réussies qui ont déjà renvoyé un curseur de page suivante. Sans une telle action, la finalisation commence immédiatement
+4. Si un autre outil du même lot parallèle nécessite une récupération `finish`, aucune nouvelle opération ne peut commencer. Les requêtes réussies ayant une page suivante conservent leurs actions de continuation, avec les outils terminaux qui sauvegardent le résultat final. Le planificateur peut lire une page ou soumettre le résultat, jamais les deux dans un lot. Ni une page ni une réponse rejetée ne rouvre les opérations. Sans page disponible, seule la conclusion terminale reste possible. Voir la [récupération après un échec](../runtime/#finish-recovery)
 5. Avec `Cursor` direct, le runtime émet le curseur opaque dans `next_cursor` pour l'appel suivant du modèle
 6. Les abonnés au flux et les finaliseurs accèdent aux limites pour l'affichage UI, la journalisation ou les décisions de politique
 
@@ -768,8 +768,8 @@ et les erreurs internes. Trois actions de récupération sont explicites :
 - `RecoveryCorrectCall` conserve l'outil en échec et fournit des informations
   structurées pour corriger l'appel.
 - `RecoveryReplan` retire cet outil du tour suivant du planificateur.
-- `RecoveryFinish` n'autorise plus que la finalisation à partir des éléments
-  déjà recueillis.
+- `RecoveryFinish` interdit les nouvelles opérations et permet la conclusion
+  terminale ou les pages annoncées de requêtes déjà commencées.
 
 `ToolResult` transporte soit un résultat typé, soit un échec structuré :
 
@@ -860,8 +860,9 @@ func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *runtime.Tool
 chaque appel : octets canoniques de la charge utile et du résultat, ainsi que
 `Failure`. Pour `RecoveryCorrectCall`, les problèmes de champs, l'entrée
 antérieure et l'exemple permettent au tour suivant de corriger l'appel.
-`RecoveryReplan` retire l'outil en échec et `RecoveryFinish` ne permet plus que
-la finalisation. Le runtime applique ces transitions ; le planificateur ne les
+`RecoveryReplan` retire l'outil en échec et `RecoveryFinish` suit le
+[contrat de conclusion après un échec](../runtime/#finish-recovery).
+Le runtime applique ces transitions ; le planificateur ne les
 déduit jamais du texte d'une erreur. Seuls les appels provenant du fournisseur
 peuvent utiliser `RecoveryCorrectCall`. Une continuation créée par le runtime
 n'a pas d'entrée produite par le modèle et doit replanifier ou terminer.

--- a/content/it/docs/2-goa-ai/runtime.md
+++ b/content/it/docs/2-goa-ai/runtime.md
@@ -510,10 +510,10 @@ Agent("chat", "Conversational runner", func() {
 
 Questo diventa un `runtime.RunPolicy` allegato alla registrazione dell'agente:
 
-- **Limiti**: `MaxToolCalls` limita il numero totale di chiamate agli strumenti con budget per ogni esecuzione. `MaxRecoveryTurns` limita le nuove chiamate al pianificatore dopo il rifiuto del risultato di uno strumento o di una risposta del modello. Una chiamata riuscita a uno strumento con budget reimposta questo limite. Gli strumenti `Bookkeeping()` non consumano nessuno dei due budget.
+- **Limiti**: `MaxToolCalls` limita il numero totale di chiamate agli strumenti con budget per ogni esecuzione. `MaxRecoveryTurns` limita le nuove chiamate al pianificatore dopo il rifiuto del risultato di uno strumento o di una risposta del modello. Il lavoro riuscito con budget ripristina questa disponibilità salvo quando resta attivo un errore `finish`; le pagine ottenute non ripristinano mai la disponibilità di quell'errore. Gli strumenti `Bookkeeping()` non consumano nessuno dei due budget.
 - **Bilancio di tempo**: `TimeBudget` - budget di tempo per la corsa. `FinalizerGrace` (solo per la corsa) - finestra riservata opzionale per la finalizzazione.
 - **Interruzioni**: `InterruptsAllowed` - opt-in per pausa/ripresa.
-- **Completamento terminale del run**: gli strumenti dichiarati `TerminalRun()` diventano automaticamente bookkeeping e chiudono il run dopo una chiamata riuscita, senza un turno `PlanResume` successivo. Un commit terminale può quindi essere ammesso senza budget di retrieval residuo. Durante la finalizzazione forzata, il runtime ammette solo chiamate terminali di bookkeeping, le esegue nella finestra restante dell'hard deadline e chiude il run solo se ogni effetto terminale riesce. Prima dell'esecuzione, il runtime scrive l'esatto `planner.TerminationReason` in `runtime.FinalizationReasonLabel` (`goa-ai.finalization_reason`). Etichette del run o della policy e output del planner o del modello non possono scegliere né sostituire questo valore; le chiamate ordinarie non lo ricevono.
+- **Completamento terminale del run**: gli strumenti dichiarati `TerminalRun()` diventano automaticamente bookkeeping e chiudono il run dopo una chiamata riuscita, senza un turno `PlanResume` successivo. Un commit terminale può quindi essere ammesso senza budget di retrieval residuo. Durante la finalizzazione dovuta a scadenze o limiti, il runtime ammette solo chiamate terminali di bookkeeping, le esegue nella finestra restante dell'hard deadline e chiude il run solo se ogni effetto terminale riesce. Prima dell'esecuzione, il runtime scrive l'esatto `planner.TerminationReason` in `runtime.FinalizationReasonLabel` (`goa-ai.finalization_reason`). Etichette del run o della policy e output del planner o del modello non possono scegliere né sostituire questo valore; le chiamate ordinarie non lo ricevono.
 
   I consumer di chiamate terminali dovute a limiti fissi o scelte dal planner,
   incluso `tool_failure`, usano `runtime.FinalizationReasonLabel`. Distribuire
@@ -1085,7 +1085,7 @@ Questi contratti sono distinti:
 | `ToolFailure.Recovery.Action` | Un risultato fallito | Sceglie la correzione mantenendo disponibile lo strumento fallito, una nuova pianificazione senza di esso oppure la finalizzazione. |
 | `PlanResult.SynthesizeAfterTools` | Un batch selezionato | Se il batch non contiene errori recuperabili, il turno successivo del planner deve rispondere. |
 | `PlanResumeInput.SynthesisOnly` | Un'attività del planner | Restituire una risposta finale; le chiamate agli strumenti non sono valide. |
-| `PlanResumeInput.Finalize` | Terminazione forzata dal runtime | Un limite o una deadline impedisce il lavoro normale. |
+| `PlanResumeInput.Finalize` | Conclusione imposta dal runtime | Le nuove operazioni sono vietate. Con il motivo `tool_failure`, il catalogo annunciato può conservare pagine di query già iniziate. |
 
 Il runtime sceglie il prossimo stato in quest'ordine:
 
@@ -1093,6 +1093,7 @@ Il runtime sceglie il prossimo stato in quest'ordine:
 | --- | --- |
 | Un limite o una deadline richiede la finalizzazione | Turno `Finalize` |
 | Uno strumento `TerminalRun` è riuscito | Termine immediato |
+| Resta attivo un errore `finish` | `Finalize` con motivo `tool_failure`; conserva le pagine annunciate e gli strumenti terminali di bookkeeping |
 | Un risultato fallito ha `AllowsToolTurn() == true` | Normale turno di riparazione |
 | `SynthesizeAfterTools` è true | Turno `SynthesisOnly` |
 | Altrimenti | Normale turno di continuazione |
@@ -1101,6 +1102,8 @@ In questo modo l'intento del planner non diventa una seconda policy di retry.
 Un errore recuperabile viene riparato per primo; un batch finale riuscito o con
 errore terminale passa alla sintesi. Il runtime rifiuta chiamate agli strumenti
 restituite da un turno `SynthesisOnly`.
+
+### Recupero dopo un errore dello strumento {#finish-recovery}
 
 Ogni `ToolFailure` recuperabile seleziona anche una `Recovery.Action`:
 
@@ -1112,8 +1115,31 @@ Ogni `ToolFailure` recuperabile seleziona anche una `Recovery.Action`:
   input o rispondere usando le prove già raccolte.
 - `replan` rimuove lo strumento che ha fallito dal turno successivo. Il planner
   può usare un altro strumento annunciato, attendere un input o rispondere.
-- `finish` rimuove tutti gli strumenti e richiede una risposta finale basata
-  sulle prove disponibili.
+- `finish` vieta nuove operazioni fino al termine del run. Il planner può
+  rispondere, usare gli strumenti terminali registrati per salvare il risultato
+  finale oppure leggere una pagina annunciata di una query già iniziata.
+
+Con `finish`, `PlanResumeInput.Finalize` porta il motivo `tool_failure`. Il
+catalogo corrente, non il solo motivo, determina le azioni disponibili. Una
+pagina e un invio terminale non possono condividere un batch: il runtime lo
+rifiuta prima di eseguire qualsiasi chiamata. Rifiuta anche nuove richieste di
+input e passaggi separati di sintesi. Senza pagine disponibili resta solo la
+conclusione terminale. La finalizzazione dovuta a scadenze o limiti non consente mai la paginazione.
+
+Gli errori attivi degli strumenti e le indicazioni su una risposta del modello
+rifiutata sono fatti separati. I rifiuti e le pagine ottenute conservano
+l'errore originale, il suo messaggio e il divieto di nuovo lavoro. Le normali
+restrizioni `correct_call` e `replan` terminano con il proprio episodio di
+recupero. La validazione del modello fornisce vincoli dello schema ed esempi;
+il runtime richiede una risposta sostitutiva conforme alle azioni e ai requisiti
+di conclusione correnti, non necessariamente un'altra chiamata a uno strumento.
+
+Le pagine riuscite consumano i normali budget di strumenti e tempo, ma non
+un tentativo sostitutivo e non ripristinano la disponibilità dell'errore
+`finish` attivo. Ogni sostituzione causata da un rifiuto consuma ancora
+`MaxRecoveryTurns`. Se l'invio terminale richiede argomenti corretti, la richiesta
+successiva conserva l'errore originale e la nuova diagnosi di validazione. Per
+quella correzione viene annunciato solo lo strumento terminale fallito; le pagine non ricompaiono.
 
 Un normale turno `correct_call` combina gli strumenti eseguibili dell'agente
 attuale con i contratti esatti degli strumenti falliti. Nomi e contratti
@@ -1127,8 +1153,9 @@ filtro. L'autorizzazione nel servizio esecutore verifica ancora ogni chiamata.
 Le query incompiute conservano le azioni di continuazione generate dal runtime;
 le richieste fallite non creano continuazioni. La finalizzazione forzata offre
 per la correzione solo l'esatto strumento terminale fallito, e i turni di sola
-sintesi restano privi di strumenti. Dopo la correzione, i turni normali tornano
-agli strumenti dell'agente attuale.
+sintesi restano privi di strumenti. Dopo una correzione ordinaria, i turni
+normali tornano agli strumenti dell'agente attuale; un errore `finish` attivo
+continua a vietare nuove operazioni.
 
 Il workflow possiede le prove di correzione mostrate al modello. Prima di
 salvare l'errore nella cronologia, sostituisce input ed esempi forniti
@@ -1145,13 +1172,27 @@ incorporate in una richiesta di input utente o esterno. I codec generati
 continuano a validare ogni payload e i limiti di strumenti, errori e tempo del
 run continuano a interrompere il lavoro non valido ripetuto. Se un turno di
 recupero attende un input, le prove dell'errore restano disponibili alla
-ripresa; la scelta di una chiamata o di una risposta finale le elimina.
+ripresa. Il lavoro di recupero ordinario accettato termina il suo episodio;
+una pagina o una risposta sostitutiva non elimina mai un errore `finish` attivo.
 
 Gli input delle attività di recupero e il catalogo annunciato fanno parte della
-cronologia durevole del workflow. Un deployment che modifica questo contratto
-deve drenare o arrestare i vecchi worker e i workflow in esecuzione prima di
-avviare il nuovo gruppo di worker. Non è sicuro combinare versioni diverse dei
-worker attraverso questo limite.
+cronologia durevole del workflow. I deployment di produzione devono usare
+Temporal Worker Deployment Versioning con versioni fissate e conservare ogni
+vecchia versione finché Temporal non la segnala come drenata. Avviare un nuovo
+worker non autorizza il replay di un workflow esistente con nuovo codice.
+Una continuazione è un nuovo workflow e può usare la versione corrente dopo
+la validazione del checkpoint salvato.
+
+Questo cambiamento non aggiunge campi ad attività o checkpoint e non richiede
+migrazioni dei dati. I planner personalizzati devono usare il catalogo
+annunciato insieme a `Finalize.Reason`; aggiornarli con il runtime. Le vecchie
+cronologie che hanno riaperto lavoro di dominio dopo un errore `finish` non
+sono compatibili con questa esecuzione: i loro piani con strumenti ordinari
+vengono rifiutati prima dell'esecuzione. Conservare le cronologie interessate
+non ancora terminate sulla versione di worker originale oppure completarle
+prima di sostituirla. Decodificare un checkpoint non dimostra compatibilità
+di replay della cronologia. Verificare l'assegnazione delle cronologie ai worker
+anche per il rollback; non mescolare versioni delle attività in un workflow interessato.
 
 Quando `PlanResumeInput.Finalize` è impostato, i planner possono restituire
 strumenti terminali di bookkeeping; queste chiamate non vengono riprodotte in

--- a/content/it/docs/2-goa-ai/toolsets.md
+++ b/content/it/docs/2-goa-ai/toolsets.md
@@ -304,7 +304,7 @@ When a bounded tool executes:
 1. The runtime validates that a successful bounded tool returned `planner.ToolResult.Bounds`
 2. The runtime merges those bounds into emitted JSON using the model-facing JSON field names generated from `BoundedResult(...)`
 3. Con `ContinueWith`, il runtime offre l'azione vuota solo per una singola testa di catena attiva non ambigua e associa il cursor prima dell'esecuzione
-4. Se un altro strumento nello stesso batch parallelo richiede il recovery `finish`, lo strumento fallito non può essere eseguito di nuovo e non può iniziare nuovo lavoro di dominio. Le azioni di continuazione restano disponibili per le query riuscite che hanno già restituito un cursor della pagina successiva. Senza tale azione, la finalizzazione inizia immediatamente
+4. Se un altro strumento nello stesso batch parallelo richiede il recupero `finish`, non possono iniziare nuove operazioni. Le query riuscite con una pagina successiva conservano le azioni di continuazione insieme agli strumenti terminali che salvano il risultato finale. Il planner può leggere una pagina o inviare il risultato, mai entrambi nello stesso batch. Né una pagina né una risposta rifiutata riapre le operazioni. Senza pagine disponibili resta solo la conclusione terminale. Vedere il [recupero dopo un errore](../runtime/#finish-recovery)
 5. Con `Cursor` diretto, il runtime emette il cursor opaco in `next_cursor` per la chiamata successiva del modello
 6. I sottoscrittori dello stream e i finalizer accedono ai bounds per UI, log e decisioni di policy
 
@@ -774,8 +774,8 @@ Le azioni di recupero sono esplicite:
 - `RecoveryCorrectCall` mantiene disponibile lo strumento e fornisce prove
   strutturate per la correzione.
 - `RecoveryReplan` rimuove lo strumento che ha fallito dal turno successivo.
-- `RecoveryFinish` permette soltanto la finalizzazione usando le prove già
-  raccolte.
+- `RecoveryFinish` vieta nuove operazioni e consente la conclusione terminale
+  oppure le pagine annunciate di query già iniziate.
 
 `ToolResult` contiene un risultato tipizzato oppure un solo errore strutturato:
 
@@ -864,8 +864,9 @@ func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *runtime.Tool
 chiamata: payload e risultato canonici più `Failure`. Per
 `RecoveryCorrectCall`, problemi dei campi, input precedente ed esempio JSON
 consentono al turno successivo di correggere la chiamata. `RecoveryReplan`
-rimuove lo strumento; `RecoveryFinish` consente solo la finalizzazione. Il
-runtime applica queste transizioni: il planner non le deduce dal testo
+rimuove lo strumento; `RecoveryFinish` segue il
+[contratto di conclusione dopo un errore](../runtime/#finish-recovery).
+Il runtime applica queste transizioni: il planner non le deduce dal testo
 dell'errore. Solo le chiamate prodotte dal provider possono usare
 `RecoveryCorrectCall`; le continuazioni create dal runtime devono ripianificare
 o terminare, senza esporre il payload privato di esecuzione.

--- a/content/ja/docs/2-goa-ai/runtime.md
+++ b/content/ja/docs/2-goa-ai/runtime.md
@@ -495,10 +495,10 @@ Agent("chat", "Conversational runner", func() {
 
 これはエージェント登録に紐づく `runtime.RunPolicy` になります。
 
-- **上限**: `MaxToolCalls` は実行ごとの予算対象ツール呼び出し総数を制限します。`MaxRecoveryTurns` は、ツール結果またはモデル回答が拒否された後にプランナーを再実行できる回数を制限します。予算対象ツールが成功すると、この回数はリセットされます。`Bookkeeping()` ツールはいずれの予算も消費しません。
+- **上限**: `MaxToolCalls` は実行ごとの予算対象ツール呼び出し総数を制限します。`MaxRecoveryTurns` は、ツール結果またはモデル回答が拒否された後にプランナーを再実行できる回数を制限します。予算対象の処理が成功すると回数はリセットされますが、`finish` の失敗が有効な間は例外です。ページ取得の成功でその失敗の回数がリセットされることはありません。`Bookkeeping()` ツールはいずれの予算も消費しません。
 - **Time budget**: `TimeBudget`（run の wall-clock 予算）、`FinalizerGrace`（ランタイム専用: 最終化のための予約ウィンドウ）。
 - **Interrupts**: `InterruptsAllowed`（pause/resume のオプトイン）。
-- **Terminal tools**: DSL で `TerminalRun()` として宣言された tool は自動的に bookkeeping となり、成功すると後続 `PlanResume` なしで run を終了します。したがって terminal commit は retrieval budget が残っていなくても受理されます。強制 finalization 中、runtime は terminal bookkeeping call だけを受理し、残りの hard deadline 内で実行し、すべての terminal side effect が成功した場合にのみ run を閉じます。実行前に runtime は正確な `planner.TerminationReason` を `runtime.FinalizationReasonLabel`（`goa-ai.finalization_reason`）へ書き込みます。run label、policy label、planner output、model output はこの値を選択したり置き換えたりできません。通常 call には渡されません。
+- **Terminal tools**: DSL で `TerminalRun()` として宣言された tool は自動的に bookkeeping となり、成功すると後続 `PlanResume` なしで run を終了します。したがって terminal commit は retrieval budget が残っていなくても受理されます。期限や上限による finalization 中、runtime は terminal bookkeeping call だけを受理し、残りの hard deadline 内で実行し、すべての terminal side effect が成功した場合にのみ run を閉じます。実行前に runtime は正確な `planner.TerminationReason` を `runtime.FinalizationReasonLabel`（`goa-ai.finalization_reason`）へ書き込みます。run label、policy label、planner output、model output はこの値を選択したり置き換えたりできません。通常 call には渡されません。
 - **Missing fields behavior**: `OnMissingFields`（バリデーションが欠落フィールドを示した場合の挙動）。
 
   `tool_failure` を含む fixed-limit または planner-generated terminal call の consumer は `runtime.FinalizationReasonLabel` を使います。この execution contract の変更は consumer と runtime worker にまとめて deploy してください。
@@ -1051,7 +1051,7 @@ planner-generated request には domain intent だけを含めます。`planner.
 | `ToolFailure.Recovery.Action` | 1 つの失敗 result | failed tool を引き続き利用可能にした修正、その tool を除いた replanning、finalization のいずれかを選ぶ。 |
 | `PlanResult.SynthesizeAfterTools` | 選択された 1 batch | recoverable failure がなければ、次の planner turn は回答しなければならない。 |
 | `PlanResumeInput.SynthesisOnly` | 1 planner activity | 最終回答を返す。tool call は無効。 |
-| `PlanResumeInput.Finalize` | runtime が強制する終了 | cap または deadline により通常作業が禁止されている。 |
+| `PlanResumeInput.Finalize` | runtime が要求する完了 | 新しい操作は禁止。理由が `tool_failure` の場合、提示されたカタログには開始済みクエリのページが残ることがある。 |
 
 ランタイムは次の順序で次状態を選びます。
 
@@ -1059,6 +1059,7 @@ planner-generated request には domain intent だけを含めます。`planner.
 | --- | --- |
 | cap または deadline が finalization を要求 | `Finalize` turn |
 | `TerminalRun` tool が成功 | 即時終了 |
+| `finish` の失敗が有効 | 理由 `tool_failure` の `Finalize`。提示済みページと結果を保存する終端ツールを保持 |
 | 失敗 result のいずれかで `AllowsToolTurn() == true` | 通常の repair turn |
 | `SynthesizeAfterTools` が true | `SynthesisOnly` turn |
 | その他 | 通常の continuation turn |
@@ -1067,6 +1068,8 @@ planner-generated request には domain intent だけを含めます。`planner.
 recoverable failure を先に修復し、成功した final batch または terminal failure を
 含む final batch は synthesis に進みます。ランタイムは `SynthesisOnly` turn
 から返された tool call を拒否します。
+
+### ツール失敗後の回復 {#finish-recovery}
 
 recoverable な `ToolFailure` は `Recovery.Action` も 1 つ選択します。
 
@@ -1077,8 +1080,27 @@ recoverable な `ToolFailure` は `Recovery.Action` も 1 つ選択します。
   input を待つか、すでに集めた evidence から回答できます。
 - `replan` は失敗した tool を次の planner turn から除外します。planner は別の
   表示済み tool を使うか、input を待つか、回答できます。
-- `finish` はすべての tool を除外し、利用可能な evidence に基づく最終回答を
-  要求します。
+- `finish` は実行が終了するまで新しい操作を禁止します。プランナーは回答するか、
+  登録済みの終端ツールで最終結果を保存するか、開始済みクエリの提示されたページを取得できます。
+
+`finish` では `PlanResumeInput.Finalize` の理由が `tool_failure` になります。
+利用可能な操作は理由だけでなく、現在のカタログで決まります。ページ取得と終端の
+送信を同じバッチに含めると、runtime はどちらも実行する前に拒否します。新しい
+入力要求や独立した要約ステップも拒否します。取得できるページがなければ、
+終端の完了だけが可能です。期限や上限による finalization ではページ取得を許可しません。
+
+有効なツール失敗と、拒否されたモデル応答に対する修正指示は別の情報です。
+応答が拒否されてもページ取得が成功しても、元の失敗、そのメッセージ、新しい
+処理の禁止は保持されます。通常の `correct_call` と `replan` の制限は、それぞれの
+回復処理が終わると解除されます。モデル検証はスキーマの制約と例を提供し、
+runtime は現在の操作と完了要件に従う代替応答を要求します。必ずしも別の
+ツール呼び出しを要求するわけではありません。
+
+成功したページ取得は通常のツール数と時間の予算を使いますが、代替応答の試行回数を
+消費せず、有効な `finish` の失敗の残り回数もリセットしません。拒否による
+代替応答は引き続き `MaxRecoveryTurns` を消費します。終端の送信に引数修正が
+必要な場合、次のリクエストは元の失敗と新しい検証診断の両方を保持します。
+その修正では失敗した終端ツールだけを提示し、ページ取得は再開しません。
 
 通常の `correct_call` turn では、現在の agent が実行できる tool と、失敗した tool の
 正確な contract を組み合わせます。同じ名前と contract は重複を除きます。
@@ -1090,16 +1112,27 @@ caller の制限、run tag の制限、recovery による除外も適用しま�
 未完了の query は runtime が生成した continuation action を保持します。失敗した
 request から continuation は生成しません。強制 finalization で修正できるのは、
 失敗した正確な terminal tool だけです。synthesis-only turn には tool を提示しません。
-修正後の通常 turn は、現在の agent の tool に戻ります。
+通常の修正後は現在の agent の tool に戻りますが、`finish` の失敗が有効な間は
+新しい操作の禁止が続きます。
 
 ランタイムは recovery turn で表示した tool catalog を正確に記録し、その外側の
 実行可能な call をすべて拒否します。user または外部 input の要求に埋め込まれた
 call も対象です。生成済み codec は引き続きすべての payload を検証し、run の
 tool・failure・time limit は無効な作業の繰り返しを停止します。recovery turn が
-input を待つ場合、failure evidence は再開後も利用できます。tool call または最終
-回答を選ぶと、その evidence は消去されます。
+input を待つ場合、failure evidence は再開後も利用できます。通常の回復処理が
+受理されるとその回復は終了しますが、ページや代替応答によって有効な `finish`
+の失敗が消去されることはありません。
 
 recovery activity の input と表示された catalog は durable workflow history の一部です。production deployment は pinned Temporal Worker Deployment Versioning を使い、Temporal が drained と報告するまで各 old worker version を保持しなければなりません。新 worker の起動は、既存 workflow を新 code で replay してよい根拠にはなりません。continuation は新 workflow なので、保存済み checkpoint の validation を通過した後なら current version を使えます。
+
+この変更は activity や checkpoint にフィールドを追加せず、データ移行も不要です。
+独自プランナーは `Finalize.Reason` と提示されたカタログを併用し、runtime と
+一緒に更新してください。`finish` の失敗後に新しい処理を再開した旧履歴は、
+この実行契約と互換性がありません。記録済みの通常ツールの計画は実行前に拒否されます。
+影響する未完了の履歴は元の worker バージョンで実行し続けるか、worker の置き換え前に
+完了してください。checkpoint のデコード成功は履歴の replay 互換性を証明しません。
+ロールバックでも履歴と worker の割り当てを確認し、影響する workflow 内で
+activity のバージョンを混在させないでください。
 
 `PlanResumeInput.Finalize` が設定されている場合、プランナーは terminal
 bookkeeping tool を返せます。これらは後続プランナーターンには再生されず、

--- a/content/ja/docs/2-goa-ai/toolsets.md
+++ b/content/ja/docs/2-goa-ai/toolsets.md
@@ -292,7 +292,7 @@ bounded tool が実行されると:
 1. runtime は successful bounded tool が `planner.ToolResult.Bounds` を返したことを検証します
 2. runtime は `BoundedResult(...)` の field name を使い、emitted JSON に bounds を merge します
 3. `ContinueWith` では、runtime は一意な live chain head に対してのみ空の action を公開し、実行前に cursor を bind します
-4. 同じ parallel batch の別の tool が `finish` recovery を要求した場合、failed tool は再実行できず、新しい domain work も開始できません。next-page cursor を既に返した successful query の continuation action は引き続き利用できます。そのような action がない場合は、直ちに finalization が始まります
+4. 同じバッチの別のツールが `finish` を要求した場合、新しい操作は開始できません。成功したクエリに次のページがあれば、その継続アクションと最終結果を保存する終端ツールを提示します。プランナーはページ取得か結果送信を選び、両方を同じバッチには含められません。ページや拒否された応答によって新しい操作が再開することはありません。ページがなければ終端の完了だけが可能です。[ツール失敗後の回復](../runtime/#finish-recovery)を参照してください
 5. direct `Cursor` では、runtime は opaque cursor を `next_cursor` に出力し、model が次の call で指定します
 6. stream subscriber と finalizer は bounds を UI display、logging、policy decision に使えます
 
@@ -731,7 +731,7 @@ timeout、malformed result、internal error があります。回復 action は�
 
 - `RecoveryCorrectCall`: 失敗した tool を利用可能なままにし、構造化された correction evidence を渡す
 - `RecoveryReplan`: 次の planner turn から失敗した tool を除く
-- `RecoveryFinish`: すでに集めた evidence に基づく finalization だけを許可する
+- `RecoveryFinish`: 新しい操作を禁止し、終端の完了または開始済みクエリの提示されたページ取得を許可する
 
 `ToolResult` は型付き result または 1 つの構造化 failure を持ちます:
 
@@ -812,7 +812,7 @@ func Execute(ctx context.Context, meta *runtime.ToolCallMeta, call *runtime.Tool
 payload/result bytes と `Failure` を持ちます。`RecoveryCorrectCall` では field
 issue、prior input、example JSON により次の planner turn が call を修正できます。
 `RecoveryReplan` はその turn から失敗した tool を除き、`RecoveryFinish` は
-finalization だけを許可します。runtime がこの transition を強制するため、
+[失敗後の完了契約](../runtime/#finish-recovery)に従います。runtime がこの transition を強制するため、
 planner が error text から推測する必要はありません。`RecoveryCorrectCall` を
 使えるのは provider-authored call だけです。runtime-created continuation には
 model-authored input がないため、execution payload を公開せず replan または


### PR DESCRIPTION
## Explain how a failed run can still finish correctly

The runtime and toolset guides said that `finish` recovery removes every tool and requires a plain final answer. That description is wrong for the contract implemented in merged [goa-ai #346](https://github.com/goadesign/goa-ai/pull/346): an already-started query may still have another page, and an application may need a registered terminal tool to save its final result. Planners must use the actual advertised catalog instead of treating every `Finalize` request as tool-free or terminal-only.

This documentation-only change updates the runtime and toolset guides in English, Spanish, French, Italian, and Japanese. The runtime guide owns the detailed contract; the toolset guide gives a short explanation and links to the same-language recovery section.

## The contract readers should implement

A tool failure marked `finish` forbids starting new operations until the run ends. The planner receives `Finalize` with reason `tool_failure` and may use available pages of queries already started or registered terminal bookkeeping tools that save the final result. It may not combine pagination and terminal submission in one batch. Deadline and cap finalization remain terminal-only.

A rejected model response or successful page does not remove the original failure or reopen ordinary tools. Successful pages keep their normal tool/time cost without consuming replacement attempts or resetting the unresolved failure's recovery allowance. If the final submission needs corrected arguments, only that terminal tool remains available, and both the original failure and the newest validation diagnostic stay in the next request. Ordinary correction and replanning still end with their own recovery episode.

Model validation supplies schema constraints and examples; the runtime requests a replacement response under the current legal actions and completion requirements. The documentation no longer implies that every correction must produce another tool call.

## Upgrade guidance and publication

No runtime code, API, schema, dependency, navigation, or generated asset changes are included. The docs describe the existing public inputs and errors introduced by the linked runtime change; this PR introduces no additional behavior or migration.

The runtime update adds no activity/checkpoint fields, but unchanged fields do not prove history replay compatibility. The guides explain that old histories which reopened domain work after a finish failure must remain on their owning worker version or complete before replacement. They also distinguish checkpoint validation from replay and call out worker/history routing for rollback. Spanish, French, and Italian now match the existing English/Japanese pinned-worker guidance instead of requiring all old workers to stop before any new worker starts.

Merging publishes documentation through the site's existing main-branch workflow. The runtime change has already merged; application rollout and unfinished-workflow safety remain separate operational work. Reverting this docs commit changes only the published guidance, not running systems.

## Verification and review focus

- `hugo --minify` passed for all five languages. It emitted existing theme/Sass deprecation warnings, not content errors.
- `npm test` passed: 5 test files, 70 tests.
- A JSDOM check of the generated pages verified exactly one `finish-recovery` heading per language and both toolset links targeting that local section.
- `git diff --check` passed, and independent review confirmed semantic parity and the corrected finalization/worker-version wording.

Review the runtime recovery section and policy-limit paragraph first, then the short toolset descriptions. The scope is exactly `content/{en,es,fr,it,ja}/docs/2-goa-ai/{runtime,toolsets}.md`. No captured production-history replay or live-model test is claimed by this documentation change.