### PR TITLE
Explain omission-permitted evaluation constraints in five languages

### DIFF
--- a/content/en/docs/2-goa-ai/evaluations.md
+++ b/content/en/docs/2-goa-ai/evaluations.md
@@ -471,6 +471,17 @@ returns exactly one label and a short rationale per claim:
 
 Only `entailed` counts as passing.
 
+Apply each claim's conditions as written. “Report the price” requires a price.
+“Any quoted price must match the reference; quoting no price satisfies this
+constraint” permits omission: a nonempty answer quoting no price satisfies that
+constraint (`entailed`, not `not_addressed`) if its other requirements hold.
+Omission does not supply required content, support an included statement that
+lacks evidence, or resolve an unknown condition about the world.
+
+The model interprets these conditions; the framework does not classify claims
+in code or rewrite labels or rationales. An entirely empty `Output` still gives
+every claim `not_addressed` and fails the scenario without calling the judge.
+
 Before any scenario runs, the runner tests the judge with four fixed examples,
 one per label. This step is called calibration. A judge that cannot tell the
 labels apart — for example one that answers `entailed` for everything, which

--- a/content/es/docs/2-goa-ai/evaluations.md
+++ b/content/es/docs/2-goa-ai/evaluations.md
@@ -190,6 +190,19 @@ Los cuatro resultados deben ser correctos. Así, un juez que siempre responde
 la suite antes de llamar a la aplicación. En los escenarios, solo `entailed`
 aprueba.
 
+Aplica las condiciones de cada afirmación tal como están escritas. «Indica el
+precio» exige un precio. «Todo precio citado debe coincidir con la referencia;
+no citar ningún precio satisface esta restricción» permite omitirlo: una
+respuesta no vacía que no cite precios satisface esa restricción (`entailed`,
+no `not_addressed`) si cumple los demás requisitos. Omitir información no aporta
+contenido obligatorio, no respalda una afirmación incluida sin evidencia ni
+resuelve una condición desconocida sobre el mundo.
+
+El modelo interpreta estas condiciones; el framework no clasifica afirmaciones
+mediante código ni reescribe etiquetas o justificaciones. Un `Output` totalmente
+vacío sigue asignando `not_addressed` a todas las afirmaciones y hace fallar el
+escenario sin llamar al juez.
+
 El prompt pide llamar exactamente una vez a la herramienta de evaluación
 proporcionada, sin escribir un nombre específico del proveedor. Su esquema exige
 una propiedad con el ID de cada afirmación, que contenga una etiqueta y una

--- a/content/fr/docs/2-goa-ai/evaluations.md
+++ b/content/fr/docs/2-goa-ai/evaluations.md
@@ -459,6 +459,19 @@ exemple fixe de chaque résultat. Un juge incapable de les distinguer arrête la
 suite avant tout appel à l'application. Cette calibration a un délai de deux
 minutes géré par le runner.
 
+Appliquez les conditions de chaque affirmation telles qu'elles sont écrites.
+« Indiquer le prix » exige un prix. « Tout prix cité doit correspondre à la
+référence ; ne citer aucun prix satisfait cette contrainte » permet l'omission :
+une réponse non vide qui ne cite aucun prix satisfait cette contrainte
+(`entailed`, et non `not_addressed`) si ses autres exigences sont remplies.
+L'omission ne fournit pas le contenu obligatoire, n'étaye pas une déclaration
+incluse sans preuve et ne résout pas une condition inconnue sur le monde.
+
+Le modèle interprète ces conditions ; le framework ne classe pas les affirmations
+par du code et ne réécrit ni les résultats ni leurs justifications. Un `Output`
+entièrement vide attribue toujours `not_addressed` à chaque affirmation et fait
+échouer le scénario sans appeler le juge.
+
 Le prompt demande d'appeler exactement une fois l'outil d'évaluation fourni,
 sans indiquer un nom propre au fournisseur. Son schéma exige une propriété portant
 l'ID de chaque affirmation, contenant un résultat et une justification non vide.

--- a/content/it/docs/2-goa-ai/evaluations.md
+++ b/content/it/docs/2-goa-ai/evaluations.md
@@ -191,6 +191,19 @@ che risponde sempre `entailed` non può far passare l'intera suite. Un errore di
 calibrazione ferma la suite prima della chiamata all'applicazione. Negli scenari
 passa solo `entailed`.
 
+Applica le condizioni di ogni claim così come sono scritte. «Riporta il prezzo»
+richiede un prezzo. «Ogni prezzo citato deve corrispondere al riferimento;
+non citare prezzi soddisfa questo vincolo» consente l'omissione: una risposta
+non vuota che non cita prezzi soddisfa quel vincolo (`entailed`, non
+`not_addressed`) se rispetta gli altri requisiti. L'omissione non fornisce
+contenuti obbligatori, non sostiene un'affermazione inclusa senza prove e non
+risolve una condizione sconosciuta sul mondo.
+
+Il modello interpreta queste condizioni; il framework non classifica i claim
+tramite codice e non riscrive etichette o motivazioni. Un `Output` interamente
+vuoto continua ad assegnare `not_addressed` a ogni claim e fa fallire lo scenario
+senza chiamare il giudice.
+
 Il prompt chiede di chiamare esattamente una volta lo strumento di valutazione
 fornito, senza indicare un nome specifico del provider. Lo schema richiede una
 proprietà con l'ID di ogni claim, contenente un'etichetta e una motivazione non

--- a/content/ja/docs/2-goa-ai/evaluations.md
+++ b/content/ja/docs/2-goa-ai/evaluations.md
@@ -334,6 +334,17 @@ Judge(ctx context.Context, output string, claims []eval.Claim, reference string)
 
 成功とみなすのは `entailed` だけです。
 
+各 claim の条件を記載どおりに適用します。「価格を示す」には価格が必要です。
+「記載する価格は参照情報と一致しなければならず、価格を記載しなくてもこの制約を満たす」
+という条件なら省略できます。空ではない回答が価格を記載せず、他の要件も満たしていれば、
+その制約の判定は `not_addressed` ではなく `entailed` です。省略によって必須の内容を
+補ったり、回答に含まれる根拠のない記述を裏付けたり、現実についての不明な条件を
+解決したりすることはできません。
+
+これらの条件はモデルが解釈します。フレームワークはコードで claim を分類したり、
+判定ラベルや理由を書き換えたりしません。`Output` 全体が空なら、引き続き judge を
+呼ばずにすべての claim を `not_addressed` とし、scenario を失敗させます。
+
 scenario を開始する前に、runner は label ごとに 1 つ、固定の 4 example で judge を検査します。この手順を calibration と呼びます。たとえば常に `entailed` を返して全 evaluation を成功させるような、label を区別できない judge は calibration に失敗し、application へ触れる前に suite を停止します。calibration は runner 所有の 2 分 deadline 内で行うため、接続不能または停止した model endpoint は suite を永久に block せず、明確な error になります。
 
 プロンプトは、プロバイダー固有の名前を書かず、提示された評価ツールを正確に 1 回呼び出すよう求めます。


### PR DESCRIPTION
Evaluation authors need to distinguish a claim requiring information from a constraint that permits the answer to omit it. The public evaluation guide lists the grading labels but does not explain this distinction, so a reader could treat every omitted optional detail as missing required content.

This adds the same compact price example beside the existing grading labels in the English, Spanish, French, Italian, and Japanese evaluation guides. “Report the price” still requires a price. A constraint explicitly permitting no quoted price can be satisfied by a nonempty answer that quotes none, provided its other requirements hold. Omission cannot supply required content, support an included statement without evidence, or settle an unknown condition about the world.

The model still interprets claim meaning. The framework does not classify claims in code or rewrite returned labels and rationales. An entirely empty answer still receives `not_addressed` for every claim and fails without a scenario grading call. Existing warnings about malformed responses and model compliance remain unchanged.

This is the documentation companion to [framework PR #347](https://github.com/goadesign/goa-ai/pull/347), which has now merged. Clearer instructions do not guarantee correct model judgments.

## Verification

- Independent review confirmed semantic agreement across all five translations.
- `hugo --minify` passed, with existing theme deprecation warnings.
- Rendered-page checks passed in every language: the two added paragraphs are distinct, grading labels and the empty-answer rule render correctly, and the existing framework-contract link is present.
- `git diff --check` passed. The diff contains only five `evaluations.md` files, with 61 added lines.
- `npm test`: 69 passed, 1 failed in the existing randomized `copy-page` test. Its generated code block contains literal `# `; the assertion incorrectly treats preserved code text as a Markdown heading. Seed `64484983`, shrink path `95:0:0:0:0:0:0:0:0:0:2:0:8:6:3:3:3`. That test loads unchanged JavaScript and synthetic data, not documentation pages. No test or copy behavior is changed in this PR, and the failed run was not retried to obtain a pass.

Review the new paragraphs beside the label definitions. No API, report format, runtime code, retries, model configuration, routing, or deployment behavior changes. No migration or coordinated rollout is needed; reverting the documentation commit restores the previous text.

