### PR TITLE
Document historical instructions in summary context

### DIFF
--- a/content/en/docs/2-goa-ai/memory-sessions.md
+++ b/content/en/docs/2-goa-ai/memory-sessions.md
@@ -79,6 +79,13 @@ bounded exact tail. `CompressAt...` values decide when summarization starts;
 `KeepMax...` values decide which newest whole turns remain unchanged. The
 runtime never truncates a turn.
 
+Historical instructions are quoted for the summary model while remaining exact
+instructions in the destination request. The runtime can reuse a summary within
+one workflow when its evidence and historical instructions are unchanged. See
+[summary evidence](../runtime/#evidence-supplied-to-the-summary-model) and
+[summary reuse](../runtime/#reusing-a-summary-within-one-workflow) for the
+authoritative input and saved-state rules.
+
 Compression requires a configured `HistoryModel`. Token-based triggers and
 retention also require exact token counting from that model client. Bedrock
 Runtime cannot count structured-output requests, and some current Claude

--- a/content/en/docs/2-goa-ai/runtime.md
+++ b/content/en/docs/2-goa-ai/runtime.md
@@ -1891,6 +1891,20 @@ message/part positions, and order remain explicit. Values are not selected,
 rounded, deduplicated, or replaced with tool-result placeholders. The model
 decides which supplied facts matter; the runtime does not predict relevance.
 
+System messages within the selected historical prefix are quoted through the
+same codec. This includes goals or constraints supplied only in instructions:
+for example, "inspect both units, then compare their readings with the service
+limits." The summary model receives those goals as evidence, not as commands to
+execute. The prefix ends at the last selected non-System message; reminders
+after that point do not enter this summary request. Original message and
+attachment positions are unchanged.
+
+Every original System message also remains an exact instruction in the
+destination request, in its original order relative to retained messages. A
+summary never replaces or drops those instructions. They count toward the
+request limit even when the surrounding conversation is summarized; if the
+mandatory instructions and newest turn cannot fit, preparation fails explicitly.
+
 `WithSummaryPrompt` still inserts the complete quoted textual transcript at its
 `%s` placeholder. Images and documents remain native attachments, supplied once
 after that prompt in the same completion. Each original user message containing
@@ -1931,6 +1945,30 @@ request fails explicitly, without dropping evidence, a text-only fallback, or
 another summary call. Media adds no separate counting step. Complete input does
 **not** guarantee that the model preserves every important fact in its prose,
 or that every history fits the summary model.
+
+#### Reusing a summary within one workflow
+
+The runtime can retain the selected model invocation's summary for later planner
+activities in the same workflow. It still counts each destination request with
+its actual model settings and tools; reuse does not cache a token count or change
+the original conversation and suspension records.
+
+Reuse requires unchanged source evidence and summary policy. The built-in
+policy fingerprint, the identifier used to check whether a saved summary still
+applies, also binds the exact historical System messages and their positions
+through the `SourceMessages`-th non-System message. Changing a goal or
+inserting an instruction within that prefix invalidates reuse. Adding a reminder
+after its last source message does not. A replacement summary receives original
+evidence, not an earlier generated summary. The model still decides which facts
+to retain; supplying the original goals does not guarantee better summary prose
+or a completed answer.
+
+Saved summaries with older policy fingerprints remain readable. If a later
+activity needs compression, the current policy generates a replacement once;
+subsequent activities may reuse that replacement. No stored-history conversion,
+new configuration, model change, or threshold change is required. Including the
+historical instructions can enlarge the summary request, and existing request
+limits still apply.
 
 ### Coordinated Generated-System Releases
 


### PR DESCRIPTION
## Explain which instructions reach a history summary

This documents [goa-ai #352](https://github.com/goadesign/goa-ai/pull/352). Hold this website change until that framework correction is merged and adopted; the documentation describes the new behavior, not an already-released guarantee.

The framework previously omitted System messages from the model request that summarizes older conversation. An application's goal could therefore be missing from the summary's input even though the answering model still retained the original instructions. The correction supplies those historical instructions as quoted evidence, without replacing or changing the instructions used for the answer.

The English Runtime guide remains the authoritative website contract. It now explains:

- System messages are quoted only through the selected last non-System message. Later reminders are outside that historical prefix, and original message/attachment positions stay unchanged.
- Every original System message remains exact in the destination request. Quoting it for a summary does not make it an instruction to execute there.
- A saved summary can be reused within one workflow only while its source evidence and policy still match. Changing an instruction inside the prefix invalidates reuse; adding a later reminder does not.
- Older saved summaries remain readable, but a later activity that needs compression can generate one replacement under the updated policy. That successful replacement can then be reused. This is not a blanket promise of zero extra model invocations during upgrade.

The Memory guide adds a short explanation and links to those Runtime sections rather than duplicating the contract. No token-counter documentation, translated pages, configuration, runtime code, or site layout changes are included.

## Scope and verification

The framework change adds no answer-rewriting pass, different model, new summary-call architecture, or threshold adjustment. Historical instructions can enlarge summary input; existing limits still apply. Supplying complete goals is a verified input correction, not proof that generated summary prose improves or that an entire workflow now finishes.

- `npm ci` completed; `npm test` passed all 70 tests in five files.
- The production Hugo build (`hugo --minify`) passed. Existing theme/Sass deprecation warnings remain; no build errors occurred.
- Both rendered Runtime section anchors and both Memory links were verified in the generated HTML.
- `git diff --check` and independent reasoning review passed. The reviewer checked this wording against the exact framework implementation, its retained test evidence, and the observed distinction between summary input and original answering instructions.

No data conversion or application deployment is performed by this PR. Its only rollout dependency is publishing it after the framework adoption described above. Reverting the documentation changes no runtime behavior. Review the additions under **Evidence supplied to the summary model** and **Reusing a summary within one workflow** first.
